### PR TITLE
Display typing area buttons in 2x2 grid layout

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -172,13 +172,13 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
             )}
           </div>
           {text.trim() && (
-            <div className="flex border-t border-gray-100 dark:border-gray-700 divide-x divide-gray-100 dark:divide-gray-700 transition-colors duration-200">
+            <div className="grid grid-cols-2 gap-[1px] bg-gray-100 dark:bg-gray-700 border-t border-gray-100 dark:border-gray-700 transition-colors duration-200">
               <button
                 onClick={handleSpeak}
-                className={`flex-1 h-14 transition-colors duration-200 ${
+                className={`h-14 transition-colors duration-200 ${
                   isSpeaking
                     ? 'bg-blue-500 hover:bg-blue-600 text-white'
-                    : 'bg-transparent hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300'
+                    : 'bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300'
                 }`}
                 data-tooltip-id="speak-tooltip"
                 data-tooltip-content={isSpeaking ? 'Stop speaking' : 'Speak text'}
@@ -191,7 +191,7 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
               </button>
               <button
                 onClick={handleFleshOut}
-                className="flex-1 h-14 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300 transition-colors duration-200"
+                className="h-14 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300 transition-colors duration-200"
                 data-tooltip-id="flesh-out-tooltip"
                 data-tooltip-content="Flesh out with AI"
                 disabled={!text.trim()}
@@ -205,7 +205,7 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
                 fallback={
                   <button
                     onClick={() => window.location.href = '/pricing'}
-                    className="flex-1 h-14 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300 transition-colors duration-200"
+                    className="h-14 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300 transition-colors duration-200"
                     data-tooltip-id="fix-text-tooltip"
                     data-tooltip-content="Fix Text (Pro feature)"
                   >
@@ -218,10 +218,10 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
               >
                 <button
                   onClick={handleFixText}
-                  className={`flex-1 h-14 transition-colors duration-200 ${
+                  className={`h-14 transition-colors duration-200 ${
                     isFixingText
                       ? 'bg-purple-500 hover:bg-purple-600 text-white'
-                      : 'bg-transparent hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300'
+                      : 'bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300'
                   }`}
                   data-tooltip-id="fix-text-tooltip"
                   data-tooltip-content="Fix grammar and spelling"
@@ -244,7 +244,7 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
               </SubscriptionWrapper>
               <button
                 onClick={handleClear}
-                className="flex-1 h-14 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300 transition-colors duration-200"
+                className="h-14 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 text-gray-600 dark:text-gray-300 transition-colors duration-200"
                 data-tooltip-id="clear-tooltip"
                 data-tooltip-content="Clear"
               >


### PR DESCRIPTION
## Summary
- Reorganized typing area buttons from horizontal row to 2x2 grid for better usability
- Closes #26

## Changes
- ✅ Changed button container from `flex` to `grid grid-cols-2`
- ✅ Added 1px gap between buttons with gray background for visual separation
- ✅ Updated button backgrounds to white/gray-800 instead of transparent
- ✅ Removed `flex-1` and used consistent `h-14` height for all buttons
- ✅ Maintained all existing functionality, colors, and hover states

## Visual Layout
Before (horizontal):
```
[Speak] [Flesh Out] [Fix Text] [Clear]
```

After (2x2 grid):
```
[Speak    ] [Flesh Out]
[Fix Text ] [Clear    ]
```

## Benefits
- 🎯 Larger touch targets on mobile devices
- 📱 Better use of vertical space
- 🎨 More balanced visual layout
- 👆 Easier to tap buttons on touchscreens
- ✨ Cleaner appearance with visual separation

## Test plan
- [x] Verify 2x2 grid displays correctly
- [x] Test all button functionality remains intact
- [x] Check responsive behavior on mobile screens
- [x] Verify hover and active states work properly
- [x] Test in both light and dark modes
- [x] Ensure tooltips display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)