### PR TITLE
Add mobile list view for phrase grid

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -187,28 +187,28 @@ export default function PhrasesInterface() {
             {!loading && (
               <div className="flex flex-col h-full">
                 <div className="flex-1 p-1 overflow-auto">
-                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-1 h-full">
+                  <div className="flex flex-col gap-2 sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 sm:gap-1 h-full">
                     {phrases.map((phrase) => (
                       <PhraseTile
                         key={phrase.id}
                         phrase={phrase}
                         onPress={() => handlePhrasePress(phrase)}
                         onEdit={isEditMode ? () => handleEditPhrase(phrase) : undefined}
-                        className="aspect-square"
+                        className="sm:aspect-square"
                       />
                     ))}
                     {typingText.trim() && (
                       <ActionTile
                         text="+ Add as Phrase"
                         onClick={handleAddTypingAsPhrase}
-                        className="aspect-square"
+                        className="sm:aspect-square"
                       />
                     )}
                     {isEditMode && (
                       <ActionTile
                         text="+ Add Phrase"
                         onClick={handleAddPhrase}
-                        className="aspect-square"
+                        className="sm:aspect-square"
                       />
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- Replace 2-column grid with vertical list layout on mobile devices
- Maintain grid layout on larger screens (sm and above)
- Improve touch interaction and usability on mobile

## Changes
- Modified PhrasesInterface.tsx to use flex column on mobile
- Updated PhraseTile and ActionTile className for responsive behavior
- Grid switches to list automatically based on screen size

## Test plan
- [x] Test mobile view shows vertical list layout
- [x] Test desktop view maintains grid layout
- [x] Verify all phrase functionality works in both layouts
- [x] Check responsive breakpoints work correctly

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)