### PR TITLE
Add reader mode with popup navigation and auto-speak

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/navigation';
 import { Phrase } from '@/lib/models/Phrase';
 import { PhraseBoard } from '@/lib/models/PhraseBoard';
 import PhrasesActionMenu from '../phrases/PhrasesActionMenu';
+import ReaderPopup from '../phrases/ReaderPopup';
 import BoardSelector from '../phrases/BoardSelector';
 import TypingArea from '../TypingArea';
 import { useTTS } from '@/lib/hooks/useTTS';
@@ -24,6 +25,7 @@ export default function PhrasesInterface() {
   const [loading, setLoading] = useState(true);
   const [loadingPhrases, setLoadingPhrases] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isReaderOpen, setIsReaderOpen] = useState(false);
 
   useEffect(() => {
     if (!user) return;
@@ -142,6 +144,18 @@ export default function PhrasesInterface() {
     router.push('/phrases/boards/add');
   };
 
+  const handleReader = () => {
+    setIsReaderOpen(true);
+  };
+
+  const handleCloseReader = () => {
+    setIsReaderOpen(false);
+  };
+
+  const handleSpeakInReader = (text: string) => {
+    tts.speak(text);
+  };
+
   const handleSelectBoard = (board: PhraseBoard) => {
     setSelectedBoard(board);
     // Save the selected board ID to localStorage
@@ -222,8 +236,15 @@ export default function PhrasesInterface() {
         onAddPhrase={handleAddPhrase}
         onAddBoard={handleAddBoard}
         onEdit={handleEdit}
+        onReader={handleReader}
         boardPresent={boards.length > 0}
         isEditMode={isEditMode}
+      />
+      <ReaderPopup
+        phrases={phrases}
+        isOpen={isReaderOpen}
+        onClose={handleCloseReader}
+        onSpeak={handleSpeakInReader}
       />
     </>
   );

--- a/app/components/phrases/PhrasesActionMenu.tsx
+++ b/app/components/phrases/PhrasesActionMenu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plus, Pencil, MessageSquare, Check, Menu, X } from 'lucide-react';
+import { Plus, Pencil, MessageSquare, Check, Menu, X, Book } from 'lucide-react';
 import { Tooltip } from 'react-tooltip';
 import { useState, useRef, useEffect } from 'react';
 
@@ -8,6 +8,7 @@ interface PhrasesActionMenuProps {
   onAddPhrase: () => void
   onAddBoard: () => void
   onEdit: () => void
+  onReader: () => void
   boardPresent: boolean
   isEditMode: boolean
 }
@@ -16,6 +17,7 @@ export default function PhrasesActionMenu({
   onAddPhrase,
   onAddBoard,
   onEdit,
+  onReader,
   boardPresent,
   isEditMode,
 }: PhrasesActionMenuProps) {
@@ -76,6 +78,19 @@ export default function PhrasesActionMenu({
           </div>
         )}
 
+        {/* Reader Action - Only show when board has phrases */}
+        {boardPresent && (
+          <div
+            onClick={() => handleAction(onReader)}
+            className="flex items-center gap-3 bg-white dark:bg-gray-800 shadow-lg rounded-full px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200 border border-gray-200 dark:border-gray-600"
+            data-tooltip-id="reader-tooltip"
+            data-tooltip-content="Open reader mode to navigate through phrases"
+          >
+            <Book className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+            <span className="text-sm font-medium text-gray-800 dark:text-gray-200 whitespace-nowrap">Reader</span>
+          </div>
+        )}
+
         {/* Edit/Done Action */}
         <div
           onClick={() => handleAction(onEdit)}
@@ -119,6 +134,7 @@ export default function PhrasesActionMenu({
       {/* Tooltips */}
       <Tooltip id="new-board-tooltip" place="left" />
       <Tooltip id="add-phrase-tooltip" place="left" />
+      <Tooltip id="reader-tooltip" place="left" />
       <Tooltip id="edit-tooltip" place="left" />
       <Tooltip id="main-action-tooltip" place="left" />
     </div>

--- a/app/components/phrases/ReaderPopup.tsx
+++ b/app/components/phrases/ReaderPopup.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { ChevronLeft, ChevronRight, Volume2, X } from 'lucide-react';
+import { Tooltip } from 'react-tooltip';
+import { useState, useEffect, useRef } from 'react';
+import { Phrase } from '@/lib/models/Phrase';
+
+interface ReaderPopupProps {
+  phrases: Phrase[]
+  isOpen: boolean
+  onClose: () => void
+  onSpeak: (text: string) => void
+}
+
+export default function ReaderPopup({
+  phrases,
+  isOpen,
+  onClose,
+  onSpeak,
+}: ReaderPopupProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  const currentPhrase = phrases[currentIndex];
+
+  const goToPrevious = () => {
+    const newIndex = currentIndex > 0 ? currentIndex - 1 : phrases.length - 1;
+    setCurrentIndex(newIndex);
+    if (phrases[newIndex]) {
+      onSpeak(phrases[newIndex].text);
+    }
+  };
+
+  const goToNext = () => {
+    const newIndex = currentIndex < phrases.length - 1 ? currentIndex + 1 : 0;
+    setCurrentIndex(newIndex);
+    if (phrases[newIndex]) {
+      onSpeak(phrases[newIndex].text);
+    }
+  };
+
+  const handleSpeak = () => {
+    if (currentPhrase) {
+      onSpeak(currentPhrase.text);
+    }
+  };
+
+  // Handle keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isOpen) return;
+
+      switch (event.key) {
+      case 'Escape':
+        onClose();
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        goToPrevious();
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        goToNext();
+        break;
+      case ' ':
+        event.preventDefault();
+        handleSpeak();
+        break;
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, currentPhrase]);
+
+  // Click outside to close
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (popupRef.current && !popupRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  // Reset index when phrases change
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [phrases]);
+
+  if (!isOpen || !phrases.length) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div
+        ref={popupRef}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-600">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Reader Mode
+          </h2>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {currentIndex + 1} of {phrases.length}
+            </span>
+            <button
+              onClick={onClose}
+              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
+              data-tooltip-id="close-reader-tooltip"
+              data-tooltip-content="Close reader mode (ESC)"
+            >
+              <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+            </button>
+          </div>
+        </div>
+
+        {/* Phrase Display */}
+        <div className="flex-1 flex flex-col min-h-0">
+          <div className="flex-1 p-8 overflow-y-auto" style={{ scrollbarWidth: 'thin', scrollbarColor: '#9CA3AF #F3F4F6' }}>
+            <p className="text-xl md:text-2xl lg:text-3xl text-gray-900 dark:text-gray-100 leading-relaxed break-words hyphens-auto text-center">
+              {currentPhrase?.text}
+            </p>
+          </div>
+        </div>
+
+        {/* Navigation Controls */}
+        <div className="flex items-center justify-center gap-4 p-4 border-t border-gray-200 dark:border-gray-600">
+          <button
+            onClick={goToPrevious}
+            disabled={phrases.length <= 1}
+            className="flex items-center justify-center w-12 h-12 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-full transition-colors"
+            data-tooltip-id="previous-tooltip"
+            data-tooltip-content="Previous phrase (←)"
+          >
+            <ChevronLeft className="w-6 h-6 text-gray-700 dark:text-gray-300" />
+          </button>
+
+          <button
+            onClick={handleSpeak}
+            className="flex items-center justify-center w-14 h-14 bg-blue-500 hover:bg-blue-600 text-white rounded-full transition-colors"
+            data-tooltip-id="speak-tooltip"
+            data-tooltip-content="Speak phrase (Spacebar)"
+          >
+            <Volume2 className="w-6 h-6" />
+          </button>
+
+          <button
+            onClick={goToNext}
+            disabled={phrases.length <= 1}
+            className="flex items-center justify-center w-12 h-12 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-full transition-colors"
+            data-tooltip-id="next-tooltip"
+            data-tooltip-content="Next phrase (→)"
+          >
+            <ChevronRight className="w-6 h-6 text-gray-700 dark:text-gray-300" />
+          </button>
+        </div>
+
+        {/* Keyboard Shortcuts Info */}
+        <div className="px-4 pb-4">
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+            Use arrow keys to navigate • Spacebar to speak • ESC to close
+          </p>
+        </div>
+
+        {/* Tooltips */}
+        <Tooltip id="close-reader-tooltip" place="bottom" />
+        <Tooltip id="previous-tooltip" place="top" />
+        <Tooltip id="speak-tooltip" place="top" />
+        <Tooltip id="next-tooltip" place="top" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add reader mode feature that displays phrases in a popup with navigation controls
- Implement automatic speech when moving between phrases
- Provide keyboard shortcuts and accessibility features

## Features Added
- **Reader Button**: Book icon in action menu to open reader mode
- **Modal Popup**: Large, readable phrase display with proper text overflow handling
- **Navigation Controls**: Previous, Speak, and Next buttons
- **Auto-Speak**: Automatically speaks phrases when navigating with buttons or arrow keys
- **Keyboard Shortcuts**: Arrow keys for navigation, spacebar to speak, ESC to close
- **Accessibility**: Click-outside to dismiss, tooltips, progress indicator
- **Responsive Design**: Works on mobile with dark mode support

## Technical Implementation
- **New Component**: `ReaderPopup` with full keyboard navigation
- **TTS Integration**: Uses existing TTS system for speech functionality
- **Proper Scrolling**: Text scrolls correctly for long phrases with visible scrollbar
- **Cross-browser**: Inline CSS for scrollbar styling compatibility
- **State Management**: Reader state integrated into PhrasesInterface

## User Experience
- Click "Reader" from action menu to open popup
- Navigate through phrases with Previous/Next buttons or arrow keys
- Each phrase is automatically spoken when navigated to
- Large, centered text for easy reading
- Progress indicator shows current position (e.g., "3 of 10")
- Easy dismissal with close button, click outside, or ESC key

## Test Plan
- [ ] Reader button appears in action menu when board has phrases
- [ ] Popup opens and displays current phrase with proper formatting
- [ ] Previous/Next navigation works correctly and speaks phrases
- [ ] Keyboard navigation functions (arrow keys, spacebar, ESC)
- [ ] Text scrolling works for long phrases
- [ ] Auto-speak triggers on navigation
- [ ] Popup dismisses correctly with all methods
- [ ] Mobile responsive design works properly
- [ ] Dark mode styling is correct

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)