### PR TITLE
Fix dark theme support and add orange accent for interactions

### DIFF
--- a/app/components/phrases/ActionTile.tsx
+++ b/app/components/phrases/ActionTile.tsx
@@ -10,10 +10,10 @@ export default function ActionTile({ text, onClick, className = '' }: ActionTile
   return (
     <button
       onClick={onClick}
-      className={`aspect-square flex items-center justify-center bg-gray-100 bg-surface hover:bg-gray-200 hover:bg-surface-hover rounded-lg border-2 border-dashed border-gray-300 border-border transition-colors duration-200 ${className}`}
+      className={`aspect-square flex items-center justify-center bg-surface hover:bg-surface-hover active:ring-2 active:ring-orange active:scale-[0.98] rounded-lg border-2 border-dashed border-border transition-all duration-200 ${className}`}
       aria-label={text}
     >
-      <span className="text-gray-500 text-text-secondary text-lg">{text}</span>
+      <span className="text-text-secondary text-lg">{text}</span>
     </button>
   );
 } 

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -28,9 +28,9 @@ export default function BoardSelector({
   // If there's only one board, show it directly
   if (boards.length === 1) {
     return (
-      <div className="flex items-center bg-white bg-surface mb-2">
+      <div className="flex items-center bg-surface mb-2">
         <div
-          className="flex-1 flex items-center justify-between p-3 min-h-[40px] cursor-pointer hover:bg-gray-50 hover:bg-surface-hover/50 transition-colors duration-200"
+          className="flex-1 flex items-center justify-between p-3 min-h-[40px] cursor-pointer hover:bg-surface-hover/50 transition-colors duration-200"
           onClick={() => {
             if (isEditMode && selectedBoard) {
               onEditBoard(selectedBoard.id ?? '');
@@ -39,12 +39,12 @@ export default function BoardSelector({
         >
           <div className="flex items-center space-x-2">
             <div>
-              <h2 className="font-medium text-black text-foreground text-sm">{selectedBoard?.name}</h2>
-              <p className="text-xs text-black text-text-secondary">
+              <h2 className="font-medium text-foreground text-sm">{selectedBoard?.name}</h2>
+              <p className="text-xs text-text-secondary">
                 {isLoadingPhrases ? (
-                  <span className="inline-block w-16 h-3 bg-gray-200 bg-surface-hover rounded animate-pulse" />
+                  <span className="inline-block w-16 h-3 bg-surface-hover rounded animate-pulse" />
                 ) : selectedBoard?.phrases.length === 0 ? (
-                  <span className="text-gray-500 text-text-secondary">Empty board</span>
+                  <span className="text-text-secondary">Empty board</span>
                 ) : (
                   `${selectedBoard?.phrases.length} ${selectedBoard?.phrases.length === 1 ? 'phrase' : 'phrases'}`
                 )}
@@ -52,7 +52,7 @@ export default function BoardSelector({
             </div>
           </div>
           {isEditMode && (
-            <PencilIcon className="h-4 w-4 text-gray-500 text-text-secondary" />
+            <PencilIcon className="h-4 w-4 text-text-secondary" />
           )}
         </div>
       </div>
@@ -62,19 +62,19 @@ export default function BoardSelector({
   // If there are multiple boards, show a button to open the popup
   return (
     <>
-      <div className="flex items-center bg-white bg-surface mb-2">
+      <div className="flex items-center bg-surface mb-2">
         <div
-          className="flex-1 flex items-center justify-between p-3 min-h-[40px] cursor-pointer hover:bg-gray-50 hover:bg-surface-hover/50 transition-colors duration-200"
+          className="flex-1 flex items-center justify-between p-3 min-h-[40px] cursor-pointer hover:bg-surface-hover/50 transition-colors duration-200"
           onClick={() => setIsPopupOpen(true)}
         >
           <div className="flex items-center space-x-2">
             <div>
-              <h2 className="font-medium text-black text-foreground text-sm">{selectedBoard?.name}</h2>
-              <p className="text-xs text-black text-text-secondary">
+              <h2 className="font-medium text-foreground text-sm">{selectedBoard?.name}</h2>
+              <p className="text-xs text-text-secondary">
                 {isLoadingPhrases ? (
-                  <span className="inline-block w-16 h-3 bg-gray-200 bg-surface-hover rounded animate-pulse" />
+                  <span className="inline-block w-16 h-3 bg-surface-hover rounded animate-pulse" />
                 ) : selectedBoard?.phrases.length === 0 ? (
-                  <span className="text-gray-500 text-text-secondary">Empty board</span>
+                  <span className="text-text-secondary">Empty board</span>
                 ) : (
                   `${selectedBoard?.phrases.length} ${selectedBoard?.phrases.length === 1 ? 'phrase' : 'phrases'}`
                 )}
@@ -93,7 +93,7 @@ export default function BoardSelector({
                   }
                 }}
               >
-                <PencilIcon className="h-4 w-4 text-gray-500 text-text-secondary" />
+                <PencilIcon className="h-4 w-4 text-text-secondary" />
               </Button>
             )}
             <Button
@@ -104,7 +104,7 @@ export default function BoardSelector({
                 setIsPopupOpen(true);
               }}
             >
-              <span className="text-gray-500 text-text-secondary">▼</span>
+              <span className="text-text-secondary">▼</span>
             </Button>
           </div>
         </div>

--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -46,10 +46,10 @@ export default function PhraseTile({ phrase, onPress, onEdit, className = '' }: 
 
   return (
     <div
-      className={`relative bg-surface rounded-lg shadow-sm p-4 cursor-pointer hover:shadow-md hover:bg-surface-hover transition-all duration-300 flex flex-col items-center justify-center h-full ${
+      className={`relative bg-surface rounded-lg shadow-sm p-4 cursor-pointer hover:shadow-md hover:bg-surface-hover active:ring-2 active:ring-orange active:scale-[0.98] transition-all duration-300 flex flex-col items-center justify-center h-full ${
         onEdit ? 'ring-2 ring-blue-400' : ''
       } ${
-        isSpeaking ? 'ring-2 ring-green-400 scale-[0.98]' : ''
+        isSpeaking ? 'ring-2 ring-orange scale-[0.98]' : ''
       } ${className}`}
       onClick={handleClick}
     >
@@ -62,7 +62,7 @@ export default function PhraseTile({ phrase, onPress, onEdit, className = '' }: 
       )}
       {isSpeaking && !onEdit && (
         <div className="absolute top-2 right-2 z-10">
-          <div className="bg-green-500 rounded-full p-1.5 shadow-sm animate-pulse">
+          <div className="bg-orange rounded-full p-1.5 shadow-sm animate-pulse">
             <SpeakerWaveIcon className="h-4 w-4 text-white" />
           </div>
         </div>

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -5,20 +5,20 @@ import { motion, HTMLMotionProps } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
         default:
-          'bg-black text-white shadow hover:bg-gray-900',
+          'bg-black text-white shadow hover:bg-gray-900 active:bg-gray-800 active:ring-2 active:ring-orange',
         destructive:
-          'bg-red-600 text-white shadow-sm hover:bg-red-700',
+          'bg-red-600 text-white shadow-sm hover:bg-red-700 active:bg-red-800 active:ring-2 active:ring-orange',
         outline:
-          'border border-border bg-surface text-foreground shadow-sm hover:bg-surface-hover',
+          'border border-border bg-surface text-foreground shadow-sm hover:bg-surface-hover active:bg-surface active:ring-2 active:ring-orange',
         secondary:
-          'bg-background text-foreground shadow-sm hover:bg-surface-hover',
-        ghost: 'hover:bg-surface-hover text-foreground',
-        link: 'text-foreground underline-offset-4 hover:underline',
+          'bg-background text-foreground shadow-sm hover:bg-surface-hover active:bg-surface active:ring-2 active:ring-orange',
+        ghost: 'hover:bg-surface-hover text-foreground active:bg-surface active:ring-2 active:ring-orange',
+        link: 'text-foreground underline-offset-4 hover:underline active:text-orange',
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -59,6 +59,12 @@ const config: Config = {
           DEFAULT: '#ef4444', // Red-500 - 5.5:1 contrast
           hover: '#dc2626',
         },
+        orange: {
+          DEFAULT: '#ff9800', // Orange-500 - main accent for interactions
+          hover: '#f57c00', // Orange-700 - darker hover
+          active: '#e65100', // Orange-900 - darkest active/pressed
+          light: '#ffb74d', // Orange-300 - lighter variant
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- Fixed BoardSelector component showing white background instead of respecting dark theme
- Added orange accent color for consistent interactive feedback across components
- Enhanced button accessibility with orange focus/active states

## Changes
- **BoardSelector**: Removed hardcoded `bg-white`, `text-black`, and gray colors, replaced with semantic theme tokens
- **PhraseTile**: Updated speaking indicator from green to orange for brand consistency
- **ActionTile**: Added orange active states and removed hardcoded gray colors
- **Button**: Added orange focus/active ring states to all variants for better accessibility
- **Tailwind config**: Added orange color palette for interactive elements

## Test plan
- [x] Verify BoardSelector no longer shows white in dark theme
- [x] Check all interactive elements (buttons, tiles) show orange accent on focus/active
- [x] Confirm speaking state shows orange indicator
- [x] Test all button variants maintain proper contrast and accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer interactive feedback: buttons and tiles now show active rings and subtle scaling.
  - Board selector includes a dedicated edit button, separating edit actions from opening the menu.

- Style
  - Adopted an orange theme for focus and active states with a more prominent ring across buttons.
  - Phrase speaking indicators now use orange accents instead of green.
  - Improved text colors, hover effects, and transitions for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->