### PR TITLE
Hide expand button when typing area is collapsed

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -275,21 +275,23 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
         </div>
       )}
       <div className="flex">
-        <button
-          onClick={toggleExpanded}
-          className="h-10 flex-1 bg-surface hover:bg-surface-hover text-text-secondary transition-colors duration-200 flex items-center justify-center shadow-sm border border-t-0 border-r-0 border-border"
-          data-tooltip-id="expand-tooltip"
-          data-tooltip-content={isExpanded ? 'Collapse typing area' : 'Expand typing area'}
-        >
-          {isExpanded ? (
-            <ArrowsPointingInIcon className="w-4 h-4" />
-          ) : (
-            <ArrowsPointingOutIcon className="w-4 h-4" />
-          )}
-        </button>
+        {isVisible && (
+          <button
+            onClick={toggleExpanded}
+            className="h-10 flex-1 bg-surface hover:bg-surface-hover text-text-secondary transition-colors duration-200 flex items-center justify-center shadow-sm border border-t-0 border-r-0 border-border"
+            data-tooltip-id="expand-tooltip"
+            data-tooltip-content={isExpanded ? 'Collapse typing area' : 'Expand typing area'}
+          >
+            {isExpanded ? (
+              <ArrowsPointingInIcon className="w-4 h-4" />
+            ) : (
+              <ArrowsPointingOutIcon className="w-4 h-4" />
+            )}
+          </button>
+        )}
         <button
           onClick={toggleVisibility}
-          className="h-10 flex-1 bg-surface hover:bg-surface-hover text-text-secondary transition-colors duration-200 flex items-center justify-center shadow-sm border border-t-0 border-border"
+          className={`h-10 bg-surface hover:bg-surface-hover text-text-secondary transition-colors duration-200 flex items-center justify-center shadow-sm border border-t-0 border-border ${isVisible ? 'flex-1' : 'w-full'}`}
           data-tooltip-id="toggle-tooltip"
           data-tooltip-content={isVisible ? 'Hide typing area' : 'Show typing area'}
         >


### PR DESCRIPTION
## Summary
The expand/collapse button is now only shown when the typing area is visible, improving UX by hiding non-functional controls.

## Changes
- Conditionally render expand button only when `isVisible` is true
- Show/hide button takes full width (`w-full`) when typing area is hidden
- Show/hide button shares width (`flex-1`) when expand button is visible

## Before
- Both buttons always visible
- Expand button has no effect when typing area is hidden
- Confusing UX

## After
- When typing area visible: Both buttons shown (expand + show/hide)
- When typing area hidden: Only show/hide button shown (full width)
- Cleaner, more intuitive UX

## Test Plan
- [x] Hide typing area - expand button disappears, show/hide button full width
- [x] Show typing area - both buttons appear, sharing width equally
- [x] Toggle expand/collapse works correctly when visible

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)