### PR TITLE
Hide Live Typing share button for unauthenticated users

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { ChatBubbleLeftIcon, XMarkIcon, ChevronUpIcon, ChevronDownIcon, ArrowPathIcon, SparklesIcon, ArrowsPointingOutIcon, ArrowsPointingInIcon, ShareIcon } from '@heroicons/react/24/outline';
 import { Tooltip } from 'react-tooltip';
 import { useSettings } from '../contexts/SettingsContext';
+import { useAuth } from '../contexts/AuthContext';
 import FleshOutPopup from './flesh-out/FleshOutPopup';
 import SubscriptionWrapper from './SubscriptionWrapper';
 import { useTypingShare } from '@/lib/hooks/useTypingShare';
@@ -27,6 +28,7 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
   const [showShareModal, setShowShareModal] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { settings } = useSettings();
+  const { user } = useAuth();
   const { speak, isSpeaking, isAvailable } = tts;
   const typingShare = useTypingShare();
   const [isVisible, setIsVisible] = useState(() => {
@@ -294,31 +296,33 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
                   <span>Clear</span>
                 </div>
               </button>
-              <button
-                onClick={handleShare}
-                className={`h-14 col-span-2 transition-colors duration-200 ${
-                  typingShare.isSharing
-                    ? 'bg-green-500 hover:bg-green-600 text-white'
-                    : 'bg-surface hover:bg-surface-hover text-text-secondary'
-                }`}
-                data-tooltip-id="share-tooltip"
-                data-tooltip-content={typingShare.isSharing ? 'View share link' : 'Share your typing'}
-                disabled={typingShare.isCreating}
-              >
-                <div className="flex items-center justify-center gap-2">
-                  {typingShare.isCreating ? (
-                    <>
-                      <ArrowPathIcon className="w-5 h-5 animate-spin" />
-                      <span>Creating...</span>
-                    </>
-                  ) : (
-                    <>
-                      <ShareIcon className="w-5 h-5" />
-                      <span>{typingShare.isSharing ? 'Sharing Active' : 'Share'}</span>
-                    </>
-                  )}
-                </div>
-              </button>
+              {user && (
+                <button
+                  onClick={handleShare}
+                  className={`h-14 col-span-2 transition-colors duration-200 ${
+                    typingShare.isSharing
+                      ? 'bg-green-500 hover:bg-green-600 text-white'
+                      : 'bg-surface hover:bg-surface-hover text-text-secondary'
+                  }`}
+                  data-tooltip-id="share-tooltip"
+                  data-tooltip-content={typingShare.isSharing ? 'View share link' : 'Share your typing'}
+                  disabled={typingShare.isCreating}
+                >
+                  <div className="flex items-center justify-center gap-2">
+                    {typingShare.isCreating ? (
+                      <>
+                        <ArrowPathIcon className="w-5 h-5 animate-spin" />
+                        <span>Creating...</span>
+                      </>
+                    ) : (
+                      <>
+                        <ShareIcon className="w-5 h-5" />
+                        <span>{typingShare.isSharing ? 'Sharing Active' : 'Share'}</span>
+                      </>
+                    )}
+                  </div>
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Live Typing share button was visible to unauthenticated users, even though the feature requires authentication to work.

## Changes

### 🐛 Fix: Hide share button for unauthenticated users (#55)
- **Problem**: The share button was visible to all users, regardless of authentication status
- **Issue**: Since sharing requires authentication (sessions are tied to `user_id`), unauthenticated users who clicked the button would encounter errors
- **Solution**: 
  - Import and use `useAuth` hook from `AuthContext`
  - Conditionally render the share button only when `user` is authenticated
  - Prevents confusion and improves user experience

## Technical Details

**File Modified**: `app/components/TypingArea.tsx`

Changes:
1. Added `useAuth` import from `AuthContext`
2. Destructured `user` from `useAuth()` hook
3. Wrapped share button in conditional check: `{user && (<button>...</button>)}`

## Test Plan

- [x] Tested with authenticated user - share button visible and functional
- [x] Tested with unauthenticated user - share button hidden (verified in logs)
- [x] Code compiles successfully
- [x] No TypeScript errors

### Manual Testing Steps:
1. Log out or visit the site without authentication
2. Verify the share button is not visible in the typing area
3. Log in with valid credentials
4. Verify the share button appears and works correctly

## Related Issues

Closes #55

## Milestone

v1.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Share button is now exclusively available to authenticated users. Previously visible to all users, the button is now hidden for those not logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->