### PR TITLE
feat: add Clerk account management link to account page

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -64,10 +64,17 @@ export default function AccountPage() {
             <div className="p-8">
               <div className="space-y-8">
                 <div>
-                  <h2 className="text-xl font-semibold text-foreground mb-2">Email</h2>
-                  <p className="text-text-secondary">{user?.email}</p>
+                  <h2 className="text-xl font-semibold text-foreground mb-3">Profile</h2>
+                  <p className="text-text-secondary mb-4">{user?.email}</p>
+                  <Button
+                    onClick={() => window.location.href = 'https://accounts.sayitaac.com/user'}
+                    variant="outline"
+                    size="lg"
+                  >
+                    Manage Account Settings
+                  </Button>
                   <p className="text-text-tertiary text-sm mt-2">
-                    To update your email or password, please use the Clerk account settings.
+                    Update your email, password, and security settings
                   </p>
                 </div>
 


### PR DESCRIPTION
## Summary

Adds a prominent "Manage Account Settings" button to the account page that links to the Clerk account management portal at `https://accounts.sayitaac.com/user`.

## Changes

- ✅ Added "Manage Account Settings" button with outline variant
- ✅ Button links to `https://accounts.sayitaac.com/user`
- ✅ Removed text mentioning "Clerk account settings"
- ✅ Updated section title from "Email" to "Profile" for clarity
- ✅ Added descriptive helper text about account management features

## UI Changes

**Before:**
- Section titled "Email"
- Text: "To update your email or password, please use the Clerk account settings."

**After:**
- Section titled "Profile"
- "Manage Account Settings" button (outline style)
- Helper text: "Update your email, password, and security settings"

## Screenshots

The button maintains consistent styling with the rest of the account page and follows the existing design system.

## Test Plan

- [ ] Verify button appears on account page
- [ ] Click button and confirm it navigates to `https://accounts.sayitaac.com/user`
- [ ] Verify responsive layout on mobile and desktop
- [ ] Confirm no Clerk-specific text remains

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)