### PR TITLE
Fix bypassSubscriptionCheck not working

### DIFF
--- a/app/hooks/useSubscription.ts
+++ b/app/hooks/useSubscription.ts
@@ -5,12 +5,12 @@ export function useSubscription() {
 
   const loading = !isLoaded;
 
-  // Clerk stores subscription status in user public metadata
-  const subscriptionStatus = user?.publicMetadata?.subscriptionStatus as string | undefined;
-  const isActive = subscriptionStatus === 'active';
-
   // Check for bypass flag (for testing/admin purposes)
   const bypassEnabled = user?.publicMetadata?.bypassSubscriptionCheck === true;
+
+  // Clerk stores subscription status in user public metadata
+  const subscriptionStatus = user?.publicMetadata?.subscriptionStatus as string | undefined;
+  const isActive = subscriptionStatus === 'active' || bypassEnabled;
 
   return { isActive, loading, bypassEnabled };
 }


### PR DESCRIPTION
## Summary

Fixes the `bypassSubscriptionCheck` flag so it actually grants premium feature access when set in Clerk user metadata.

## Problem

The bypass flag was being read from user metadata and returned by `useSubscription`, but wasn't actually used in the `isActive` check. This meant premium features remained blocked even when the bypass flag was enabled.

## Solution

Updated the `isActive` logic to include the bypass flag:

```typescript
// Before
const isActive = subscriptionStatus === 'active';

// After  
const isActive = subscriptionStatus === 'active' || bypassEnabled;
```

## Testing

To test, set this in Clerk Dashboard → Users → [User] → Public metadata:
```json
{
  "bypassSubscriptionCheck": true
}
```

Premium features should now be accessible without a subscription.

## Changes

- Updated `app/hooks/useSubscription.ts` to include bypass flag in active check

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved subscription activation logic to support additional subscription scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->