### PR TITLE
Use correct app color tokens for board selector

### DIFF
--- a/app/components/phrases/BoardGridPopup.tsx
+++ b/app/components/phrases/BoardGridPopup.tsx
@@ -50,10 +50,10 @@ export default function BoardGridPopup({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-3xl bg-black p-8 text-left align-middle shadow-2xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-3xl bg-surface p-8 text-left align-middle shadow-2xl transition-all">
                 <Dialog.Title
                   as="h3"
-                  className="text-2xl font-bold leading-6 text-white mb-6"
+                  className="text-2xl font-bold leading-6 text-foreground mb-6"
                 >
                   Select a Board
                 </Dialog.Title>
@@ -64,8 +64,8 @@ export default function BoardGridPopup({
                       key={board.id}
                       className={`relative p-5 rounded-2xl border-2 cursor-pointer transition-all duration-300 ${
                         selectedBoard?.id === board.id
-                          ? 'border-primary-500 bg-primary-500/20 shadow-lg'
-                          : 'border-gray-700 hover:border-primary-300 hover:shadow-md'
+                          ? 'border-primary-500 bg-primary-500/10 shadow-lg'
+                          : 'border-border hover:border-primary-300 hover:shadow-md'
                       }`}
                       onClick={() => {
                         onSelectBoard(board);
@@ -74,7 +74,7 @@ export default function BoardGridPopup({
                     >
                       <div className="flex items-start justify-between">
                         <div className="flex-1">
-                          <h4 className="font-semibold text-white text-base">{board.name}</h4>
+                          <h4 className="font-semibold text-foreground text-base">{board.name}</h4>
                         </div>
                         {isEditMode && (
                           <button
@@ -82,9 +82,9 @@ export default function BoardGridPopup({
                               e.stopPropagation();
                               onEditBoard(board.id);
                             }}
-                            className="p-2 hover:bg-gray-800 rounded-xl transition-all duration-200"
+                            className="p-2 hover:bg-surface-hover rounded-xl transition-all duration-200"
                           >
-                            <PencilIcon className="h-4 w-4 text-gray-400 hover:text-white transition-colors duration-200" />
+                            <PencilIcon className="h-4 w-4 text-text-secondary hover:text-foreground transition-colors duration-200" />
                           </button>
                         )}
                       </div>

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -26,7 +26,7 @@ export default function BoardSelector({
   // If there's only one board, show it directly
   if (boards.length === 1) {
     return (
-      <div className="flex items-center bg-black rounded-3xl shadow-2xl hover:shadow-3xl mb-4 transition-all duration-300">
+      <div className="flex items-center bg-surface rounded-3xl shadow-2xl hover:shadow-3xl mb-4 transition-all duration-300">
         <div
           className="flex-1 flex items-center justify-between px-6 py-4 cursor-pointer"
           onClick={() => {
@@ -36,7 +36,7 @@ export default function BoardSelector({
           }}
         >
           <div className="flex items-center space-x-2">
-            <h2 className="font-semibold text-white text-base">{selectedBoard?.name}</h2>
+            <h2 className="font-semibold text-foreground text-base">{selectedBoard?.name}</h2>
           </div>
           {isEditMode && (
             <PencilIcon className="h-5 w-5 text-text-secondary hover:text-foreground transition-colors duration-200" />
@@ -49,13 +49,13 @@ export default function BoardSelector({
   // If there are multiple boards, show a button to open the popup
   return (
     <>
-      <div className="flex items-center bg-black rounded-3xl shadow-2xl hover:shadow-3xl mb-4 transition-all duration-300">
+      <div className="flex items-center bg-surface rounded-3xl shadow-2xl hover:shadow-3xl mb-4 transition-all duration-300">
         <div
           className="flex-1 flex items-center justify-between px-6 py-4 cursor-pointer"
           onClick={() => setIsPopupOpen(true)}
         >
           <div className="flex items-center space-x-2">
-            <h2 className="font-semibold text-white text-base">{selectedBoard?.name}</h2>
+            <h2 className="font-semibold text-foreground text-base">{selectedBoard?.name}</h2>
           </div>
           <div className="flex items-center space-x-1">
             {isEditMode && (
@@ -69,7 +69,7 @@ export default function BoardSelector({
                   }
                 }}
               >
-                <PencilIcon className="h-5 w-5 text-gray-400 hover:text-white transition-colors duration-200" />
+                <PencilIcon className="h-5 w-5 text-text-secondary hover:text-foreground transition-colors duration-200" />
               </Button>
             )}
             <Button
@@ -80,7 +80,7 @@ export default function BoardSelector({
                 setIsPopupOpen(true);
               }}
             >
-              <span className="text-gray-400 hover:text-white transition-colors duration-200 text-lg">▼</span>
+              <span className="text-text-secondary hover:text-foreground transition-colors duration-200 text-lg">▼</span>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Replaces hardcoded black/white colors with semantic design tokens from the app's color system to ensure consistency across the UI.

## Problem
The board selector was using pure black (`bg-black` #000000) and white (`text-white`) instead of the app's design system colors defined in `app/globals.css`.

## App Color System
```css
--surface: #242424        /* Card/component background */
--foreground: #f5f5f5     /* Primary text */
--text-secondary: #b8b8b8 /* Secondary text */
--border: #3a3a3a         /* Borders */
--surface-hover: #2e2e2e  /* Hover states */
```

## Changes Made

### BoardSelector.tsx
- ✅ `bg-black` → `bg-surface` (#242424)
- ✅ `text-white` → `text-foreground` (#f5f5f5)
- ✅ `text-gray-400` → `text-text-secondary` (#b8b8b8)
- ✅ Icons now use semantic hover states

### BoardGridPopup.tsx
- ✅ `bg-black` → `bg-surface`
- ✅ `text-white` → `text-foreground`
- ✅ `border-gray-700` → `border-border` (#3a3a3a)
- ✅ `hover:bg-gray-800` → `hover:bg-surface-hover` (#2e2e2e)
- ✅ Selected state: `bg-primary-500/20` → `bg-primary-500/10`

## Benefits
- **Consistent design**: Matches SettingsCard and other UI components
- **Theme-aware**: Uses CSS variables that can adapt to theme changes
- **Maintainable**: Single source of truth for colors
- **Better contrast**: #242424 is softer than pure black #000000

## Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation successful
- ✅ No errors or warnings

## References
- Issue: #97
- Design system: `app/globals.css`
- Reference component: `app/components/ui/SettingsCard.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined color scheme across board management UI with updated backgrounds, text colors, and interactive element styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->