### PR TITLE
Increase board selection popup backdrop opacity

### DIFF
--- a/app/components/phrases/BoardGridPopup.tsx
+++ b/app/components/phrases/BoardGridPopup.tsx
@@ -36,7 +36,7 @@ export default function BoardGridPopup({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black/25" />
+          <div className="fixed inset-0 bg-black/75" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">


### PR DESCRIPTION
## Summary
Increases the backdrop opacity from 25% to 75% to properly obscure content below the board selection modal.

## Problem
With only 25% opacity, light-colored text (using `text-foreground` #f5f5f5) underneath the popup is clearly visible, creating visual distraction and reducing focus on the modal content.

## Before
```tsx
<div className="fixed inset-0 bg-black/25" />
```
- 25% opacity
- Underlying text clearly visible
- Poor visual hierarchy
- Distracting user experience

## After
```tsx
<div className="fixed inset-0 bg-black/75" />
```
- 75% opacity
- Underlying content properly dimmed
- Clear focus on modal
- Standard modal overlay pattern

## Benefits
- **Better UX**: Users can focus entirely on the board selection
- **Visual hierarchy**: Modal stands out clearly from background
- **Standard pattern**: 75% is a common opacity for modal overlays
- **Maintains transitions**: Still uses smooth fade animations

## Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation successful
- ✅ No errors or warnings

## References
- Issue: #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased modal backdrop opacity for enhanced visibility and prominence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->