### PR TITLE
Upgrade @types/node to v24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@eslint/js": "^9.25.1",
         "@next/eslint-plugin-next": "^15.3.1",
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^22.15.29",
+        "@types/node": "^24.10.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript-eslint/eslint-plugin": "^8.31.0",
@@ -4169,12 +4169,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.0.tgz",
-      "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -12744,9 +12744,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@eslint/js": "^9.25.1",
     "@next/eslint-plugin-next": "^15.3.1",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^22.15.29",
+    "@types/node": "^24.10.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.31.0",


### PR DESCRIPTION
## Summary
- Upgraded @types/node from v22.19.0 to v24.10.1

## Changes
- No code changes required
- All types compile successfully
- Build passes without errors

## Test Plan
- [x] Build passes successfully
- [x] No TypeScript compilation errors
- [x] All Node.js APIs properly typed

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->