### PR TITLE
Add role selection onboarding flow

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -8,6 +8,7 @@ import { ConvexReactClient } from 'convex/react';
 import { AuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import Sidebar from './components/Sidebar';
+import RoleGate from './components/onboarding/RoleGate';
 
 export default function ClientLayout({
   children,
@@ -44,14 +45,16 @@ export default function ClientLayout({
       <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
         <AuthProvider>
           <SettingsProvider>
-            <div className="min-h-screen flex">
-              <Sidebar />
-              <div className="flex-1 pl-16">
-                <main>
-                  {children}
-                </main>
+            <RoleGate>
+              <div className="min-h-screen flex">
+                <Sidebar />
+                <div className="flex-1 pl-16">
+                  <main>
+                    {children}
+                  </main>
+                </div>
               </div>
-            </div>
+            </RoleGate>
           </SettingsProvider>
         </AuthProvider>
       </ConvexProviderWithClerk>

--- a/app/components/onboarding/RoleGate.tsx
+++ b/app/components/onboarding/RoleGate.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuery } from 'convex/react';
+import { usePathname } from 'next/navigation';
+import { api } from '@/convex/_generated/api';
+import { useAuth } from '@/app/contexts/AuthContext';
+import RoleSelectionModal from './RoleSelectionModal';
+
+interface RoleGateProps {
+  children: React.ReactNode;
+}
+
+// Pages that should not show the role selection modal
+const EXCLUDED_PATHS = [
+  '/sign-in',
+  '/sign-up',
+  '/privacy',
+  '/support',
+  '/pricing',
+  '/reset-password',
+];
+
+export default function RoleGate({ children }: RoleGateProps) {
+  const { user, loading: authLoading } = useAuth();
+  const profile = useQuery(api.profiles.getProfile);
+  const rawPathname = usePathname();
+  const pathname = rawPathname ?? '';
+  const [showRoleModal, setShowRoleModal] = useState(false);
+  const [roleSelected, setRoleSelected] = useState(false);
+
+  // Check if current path is excluded
+  const isExcludedPath = EXCLUDED_PATHS.some(path => pathname.startsWith(path));
+
+  useEffect(() => {
+    // Don't show modal on excluded paths
+    if (isExcludedPath) {
+      setShowRoleModal(false);
+      return;
+    }
+
+    // Don't show if role was just selected
+    if (roleSelected) {
+      setShowRoleModal(false);
+      return;
+    }
+
+    // Don't show if auth is still loading
+    if (authLoading) {
+      return;
+    }
+
+    // Don't show if user is not logged in
+    if (!user) {
+      setShowRoleModal(false);
+      return;
+    }
+
+    // Profile is still loading (undefined in Convex means loading)
+    if (profile === undefined) {
+      return;
+    }
+
+    // Profile doesn't exist yet (null) or exists but no role set - show modal
+    // setRole mutation will create the profile if needed
+    if (profile === null || !profile.role) {
+      setShowRoleModal(true);
+    } else {
+      setShowRoleModal(false);
+    }
+  }, [authLoading, user, profile, roleSelected, isExcludedPath, pathname]);
+
+  const handleRoleComplete = () => {
+    setRoleSelected(true);
+    setShowRoleModal(false);
+  };
+
+  return (
+    <>
+      {children}
+      {showRoleModal && <RoleSelectionModal onComplete={handleRoleComplete} />}
+    </>
+  );
+}

--- a/app/components/onboarding/RoleSelectionModal.tsx
+++ b/app/components/onboarding/RoleSelectionModal.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { UserIcon, HeartIcon, CheckCircleIcon } from '@heroicons/react/24/solid';
+
+interface RoleSelectionModalProps {
+  onComplete: () => void;
+}
+
+export default function RoleSelectionModal({ onComplete }: RoleSelectionModalProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedRole, setSelectedRole] = useState<'caregiver' | 'communicator' | null>(null);
+  const setRole = useMutation(api.profiles.setRole);
+
+  const handleSubmit = async () => {
+    if (!selectedRole) return;
+
+    setIsSubmitting(true);
+    try {
+      await setRole({ role: selectedRole });
+      onComplete();
+    } catch (err) {
+      console.error('Failed to set role:', err);
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50">
+      <div className="bg-surface rounded-2xl shadow-2xl max-w-lg w-full p-8">
+        <div className="text-center mb-8">
+          <h2 className="text-3xl font-bold text-foreground mb-2">Welcome to SayIt!</h2>
+          <p className="text-text-secondary">
+            How will you be using the app?
+          </p>
+        </div>
+
+        <div className="space-y-4 mb-8">
+          <button
+            onClick={() => setSelectedRole('communicator')}
+            className={`w-full p-6 rounded-xl border-2 transition-all text-left flex items-start gap-4 relative ${
+              selectedRole === 'communicator'
+                ? 'border-primary-500 bg-primary-500/20 ring-2 ring-primary-500/50'
+                : 'border-border hover:border-primary-500/50 hover:bg-surface-hover'
+            }`}
+          >
+            {selectedRole === 'communicator' && (
+              <CheckCircleIcon className="absolute top-4 right-4 w-6 h-6 text-primary-500" />
+            )}
+            <div className={`p-3 rounded-full flex-shrink-0 ${
+              selectedRole === 'communicator' ? 'bg-primary-500' : 'bg-surface-hover'
+            }`}>
+              <UserIcon className={`w-6 h-6 ${
+                selectedRole === 'communicator' ? 'text-white' : 'text-text-secondary'
+              }`} />
+            </div>
+            <div className="pr-8">
+              <h3 className={`text-lg font-semibold mb-1 ${
+                selectedRole === 'communicator' ? 'text-primary-400' : 'text-foreground'
+              }`}>
+                I need help communicating
+              </h3>
+              <p className="text-text-secondary text-sm">
+                Use boards and phrases to express yourself. You can create your own or receive boards from a caregiver.
+              </p>
+            </div>
+          </button>
+
+          <button
+            onClick={() => setSelectedRole('caregiver')}
+            className={`w-full p-6 rounded-xl border-2 transition-all text-left flex items-start gap-4 relative ${
+              selectedRole === 'caregiver'
+                ? 'border-primary-500 bg-primary-500/20 ring-2 ring-primary-500/50'
+                : 'border-border hover:border-primary-500/50 hover:bg-surface-hover'
+            }`}
+          >
+            {selectedRole === 'caregiver' && (
+              <CheckCircleIcon className="absolute top-4 right-4 w-6 h-6 text-primary-500" />
+            )}
+            <div className={`p-3 rounded-full flex-shrink-0 ${
+              selectedRole === 'caregiver' ? 'bg-primary-500' : 'bg-surface-hover'
+            }`}>
+              <HeartIcon className={`w-6 h-6 ${
+                selectedRole === 'caregiver' ? 'text-white' : 'text-text-secondary'
+              }`} />
+            </div>
+            <div className="pr-8">
+              <h3 className={`text-lg font-semibold mb-1 ${
+                selectedRole === 'caregiver' ? 'text-primary-400' : 'text-foreground'
+              }`}>
+                I'm helping someone communicate
+              </h3>
+              <p className="text-text-secondary text-sm">
+                Create and manage boards for your clients. Share boards with configurable permissions.
+              </p>
+            </div>
+          </button>
+        </div>
+
+        <button
+          onClick={handleSubmit}
+          disabled={!selectedRole || isSubmitting}
+          className="w-full px-6 py-4 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSubmitting ? 'Setting up...' : 'Continue'}
+        </button>
+
+        <p className="text-text-tertiary text-xs text-center mt-4">
+          You can change this later in settings
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,9 +8,11 @@
  * @module
  */
 
+import type * as caregiverClients from "../caregiverClients.js";
 import type * as phraseBoards from "../phraseBoards.js";
 import type * as phrases from "../phrases.js";
 import type * as profiles from "../profiles.js";
+import type * as sharedBoards from "../sharedBoards.js";
 import type * as typingSessions from "../typingSessions.js";
 import type * as users from "../users.js";
 
@@ -20,29 +22,39 @@ import type {
   FunctionReference,
 } from "convex/server";
 
+declare const fullApi: ApiFromModules<{
+  caregiverClients: typeof caregiverClients;
+  phraseBoards: typeof phraseBoards;
+  phrases: typeof phrases;
+  profiles: typeof profiles;
+  sharedBoards: typeof sharedBoards;
+  typingSessions: typeof typingSessions;
+  users: typeof users;
+}>;
+
 /**
- * A utility for referencing Convex functions in your app's API.
+ * A utility for referencing Convex functions in your app's public API.
  *
  * Usage:
  * ```js
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-declare const fullApi: ApiFromModules<{
-  phraseBoards: typeof phraseBoards;
-  phrases: typeof phrases;
-  profiles: typeof profiles;
-  typingSessions: typeof typingSessions;
-  users: typeof users;
-}>;
-declare const fullApiWithMounts: typeof fullApi;
-
 export declare const api: FilterApi<
-  typeof fullApiWithMounts,
+  typeof fullApi,
   FunctionReference<any, "public">
 >;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
 export declare const internal: FilterApi<
-  typeof fullApiWithMounts,
+  typeof fullApi,
   FunctionReference<any, "internal">
 >;
 

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -10,7 +10,6 @@
 
 import {
   ActionBuilder,
-  AnyComponents,
   HttpActionBuilder,
   MutationBuilder,
   QueryBuilder,
@@ -19,14 +18,8 @@ import {
   GenericQueryCtx,
   GenericDatabaseReader,
   GenericDatabaseWriter,
-  FunctionReference,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
-
-type GenericCtx =
-  | GenericActionCtx<DataModel>
-  | GenericMutationCtx<DataModel>
-  | GenericQueryCtx<DataModel>;
 
 /**
  * Define a query in this Convex app's public API.
@@ -92,11 +85,12 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
 /**
  * Define an HTTP action.
  *
- * This function will be used to respond to HTTP requests received by a Convex
- * deployment if the requests matches the path and method where this action
- * is routed. Be sure to route your action in `convex/http.js`.
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
  *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -16,7 +16,6 @@ import {
   internalActionGeneric,
   internalMutationGeneric,
   internalQueryGeneric,
-  componentsGeneric,
 } from "convex/server";
 
 /**
@@ -81,10 +80,14 @@ export const action = actionGeneric;
 export const internalAction = internalActionGeneric;
 
 /**
- * Define a Convex HTTP action.
+ * Define an HTTP action.
  *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument, and a `Request` object
- * as its second.
- * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -77,6 +77,7 @@ export const deleteProfile = mutation({
 });
 
 // Mutation: Set user role (caregiver or communicator)
+// Creates profile if it doesn't exist (handles case where webhook hasn't fired yet)
 export const setRole = mutation({
   args: {
     role: v.union(v.literal('caregiver'), v.literal('communicator')),
@@ -93,7 +94,15 @@ export const setRole = mutation({
       .first();
 
     if (!profile) {
-      throw new Error('Profile not found');
+      // Create profile if it doesn't exist
+      const email = identity.email ?? '';
+      const fullName = identity.name ?? undefined;
+      return await ctx.db.insert('profiles', {
+        userId: identity.subject,
+        email,
+        fullName,
+        role: args.role,
+      });
     }
 
     await ctx.db.patch(profile._id, {


### PR DESCRIPTION
## Summary
- Creates role selection modal shown to users without a role set
- Modal appears after sign-in for users who haven't selected Caregiver or Communicator
- Clear visual feedback with checkmark, ring highlight, and color changes on selection
- Handles case where profile doesn't exist yet (creates it during role selection)

## New Components
- `RoleSelectionModal` - Modal with two role options and clear selection states
- `RoleGate` - Wrapper that checks if user needs to select a role

## Changes
- `ClientLayout.tsx` - Integrates RoleGate
- `profiles.ts` - Updated setRole to create profile if needed

## Test plan
- [ ] Sign in with account that has no role set
- [ ] Verify modal appears
- [ ] Select a role and verify visual feedback is clear
- [ ] Click Continue and verify role is saved
- [ ] Refresh page and verify modal doesn't appear again
- [ ] Verify modal doesn't appear on sign-in/sign-up pages

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced role selection during onboarding. Users choose between "I need help communicating" or "I'm helping someone communicate."
  * Role selection displays on first access and can be updated later in settings.
  * Streamlined profile initialization for new users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->