### PR TITLE
Add caregiver dashboard with client management

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -4,11 +4,14 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '../contexts/AuthContext';
 import { usePathname } from 'next/navigation';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
 import {
   QuestionMarkCircleIcon,
   HomeIcon,
   Cog6ToothIcon,
-  ArrowRightStartOnRectangleIcon
+  ArrowRightStartOnRectangleIcon,
+  UsersIcon
 } from '@heroicons/react/24/outline';
 import { Tooltip } from 'react-tooltip';
 import { UserButton } from '@clerk/nextjs';
@@ -16,6 +19,9 @@ import { UserButton } from '@clerk/nextjs';
 export default function Sidebar() {
   const { user } = useAuth();
   const pathname = usePathname();
+  const profile = useQuery(api.profiles.getProfile);
+
+  const isCaregiver = profile?.role === 'caregiver';
 
   return (
     <aside className="fixed left-0 top-0 h-full w-16 bg-surface z-50 shadow-2xl flex flex-col">
@@ -37,6 +43,15 @@ export default function Sidebar() {
           title="Home"
           isActive={pathname === '/'}
         />
+
+        {user && isCaregiver && (
+          <SidebarItem
+            href="/dashboard"
+            icon={<UsersIcon className="w-6 h-6" />}
+            title="Clients"
+            isActive={pathname?.startsWith('/dashboard') ?? false}
+          />
+        )}
 
         {user && (
           <SidebarItem

--- a/app/components/dashboard/AddClientButton.tsx
+++ b/app/components/dashboard/AddClientButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import { PlusIcon } from '@heroicons/react/24/outline';
+import AddClientModal from './AddClientModal';
+
+export default function AddClientButton() {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setShowModal(true)}
+        className="w-full p-4 rounded-xl border-2 border-dashed border-border hover:border-primary-500/50 bg-surface hover:bg-surface-hover transition-all flex items-center justify-center gap-2 text-text-secondary hover:text-primary-500"
+      >
+        <PlusIcon className="w-5 h-5" />
+        <span className="font-medium">Add Client</span>
+      </button>
+
+      {showModal && <AddClientModal onClose={() => setShowModal(false)} />}
+    </>
+  );
+}

--- a/app/components/dashboard/AddClientModal.tsx
+++ b/app/components/dashboard/AddClientModal.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { XMarkIcon, UserPlusIcon } from '@heroicons/react/24/outline';
+
+interface AddClientModalProps {
+  onClose: () => void;
+}
+
+export default function AddClientModal({ onClose }: AddClientModalProps) {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const addClient = useMutation(api.caregiverClients.addClient);
+
+  // Query to find user by email
+  const foundProfile = useQuery(
+    api.profiles.getProfileByEmail,
+    email.trim() ? { email: email.trim().toLowerCase() } : 'skip'
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!email.trim()) {
+      setError('Please enter an email address');
+      return;
+    }
+
+    if (!foundProfile) {
+      setError('No user found with this email. They need to create an account first.');
+      return;
+    }
+
+    if (foundProfile.role === 'caregiver') {
+      setError('This user is registered as a caregiver, not a communicator.');
+      return;
+    }
+
+    setIsAdding(true);
+    try {
+      await addClient({ communicatorId: foundProfile.userId });
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to add client';
+      setError(message);
+      setIsAdding(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+      <div className="bg-surface rounded-2xl shadow-2xl max-w-md w-full p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-full bg-primary-500/10">
+              <UserPlusIcon className="w-6 h-6 text-primary-500" />
+            </div>
+            <h2 className="text-xl font-bold text-foreground">Add Client</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-surface-hover transition-colors"
+          >
+            <XMarkIcon className="w-5 h-5 text-text-secondary" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-foreground mb-2">
+              Client's Email
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setError(null);
+              }}
+              placeholder="client@example.com"
+              className="w-full px-4 py-3 bg-background border border-border rounded-xl text-foreground placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500/50 focus:border-primary-500"
+              autoFocus
+            />
+            <p className="mt-2 text-text-tertiary text-sm">
+              The client must have an existing SayIt account
+            </p>
+          </div>
+
+          {error && (
+            <div className="mb-4 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          {foundProfile && !error && (
+            <div className="mb-4 p-3 rounded-xl bg-green-500/10 border border-green-500/20 text-green-400 text-sm">
+              Found: {foundProfile.fullName || foundProfile.email}
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-3 bg-surface-hover hover:bg-background text-foreground rounded-xl transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isAdding || !email.trim()}
+              className="flex-1 px-4 py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isAdding ? 'Adding...' : 'Add Client'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/components/dashboard/ClientCard.tsx
+++ b/app/components/dashboard/ClientCard.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { UserIcon, FolderIcon, TrashIcon, EyeIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface ClientCardProps {
+  client: {
+    _id: Id<'caregiverClients'>;
+    communicatorId: string;
+    createdAt: number;
+    profile: {
+      email: string;
+      fullName?: string;
+    } | null;
+  };
+}
+
+export default function ClientCard({ client }: ClientCardProps) {
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const removeClient = useMutation(api.caregiverClients.removeClient);
+  const sharedBoards = useQuery(api.sharedBoards.getSharedBoardsForClient, {
+    communicatorId: client.communicatorId,
+  });
+
+  const handleRemove = async () => {
+    setIsRemoving(true);
+    try {
+      await removeClient({ communicatorId: client.communicatorId });
+    } catch (err) {
+      console.error('Failed to remove client:', err);
+      setIsRemoving(false);
+      setShowConfirm(false);
+    }
+  };
+
+  const displayName = client.profile?.fullName || client.profile?.email || 'Unknown';
+  const boardCount = sharedBoards?.length ?? 0;
+
+  return (
+    <div className="bg-surface rounded-xl border border-border p-4 hover:border-primary-500/30 transition-colors">
+      <div className="flex items-center gap-4">
+        <div className="p-3 rounded-full bg-surface-hover">
+          <UserIcon className="w-6 h-6 text-text-secondary" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-foreground truncate">{displayName}</h3>
+          {client.profile?.fullName && client.profile?.email && (
+            <p className="text-text-tertiary text-sm truncate">{client.profile.email}</p>
+          )}
+          <div className="flex items-center gap-1 mt-1 text-text-secondary text-sm">
+            <FolderIcon className="w-4 h-4" />
+            <span>{boardCount} shared board{boardCount !== 1 ? 's' : ''}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/dashboard/client/${client.communicatorId}`}
+            className="p-2 rounded-lg bg-primary-500/10 text-primary-500 hover:bg-primary-500/20 transition-colors"
+            title="View boards"
+          >
+            <EyeIcon className="w-5 h-5" />
+          </Link>
+
+          {showConfirm ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-3 py-1 text-sm rounded-lg bg-surface-hover text-text-secondary hover:bg-background transition-colors"
+                disabled={isRemoving}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleRemove}
+                disabled={isRemoving}
+                className="px-3 py-1 text-sm rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors disabled:opacity-50"
+              >
+                {isRemoving ? 'Removing...' : 'Remove'}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowConfirm(true)}
+              className="p-2 rounded-lg text-text-tertiary hover:text-red-500 hover:bg-red-500/10 transition-colors"
+              title="Remove client"
+            >
+              <TrashIcon className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/dashboard/ClientList.tsx
+++ b/app/components/dashboard/ClientList.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import ClientCard from './ClientCard';
+import AddClientButton from './AddClientButton';
+
+export default function ClientList() {
+  const clients = useQuery(api.caregiverClients.getClients);
+
+  if (clients === undefined) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-24 bg-surface rounded-xl animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <AddClientButton />
+
+      {clients.length === 0 ? (
+        <div className="text-center py-12 bg-surface rounded-xl border border-border">
+          <p className="text-text-secondary mb-2">No clients yet</p>
+          <p className="text-text-tertiary text-sm">
+            Add your first client to start creating boards for them
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {clients.map((client) => (
+            <ClientCard key={client._id} client={client} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/dashboard/ShareBoardButton.tsx
+++ b/app/components/dashboard/ShareBoardButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+import { PlusIcon } from '@heroicons/react/24/outline';
+import ShareBoardModal from './ShareBoardModal';
+
+interface ShareBoardButtonProps {
+  communicatorId: string;
+}
+
+export default function ShareBoardButton({ communicatorId }: ShareBoardButtonProps) {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setShowModal(true)}
+        className="inline-flex items-center gap-2 px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors"
+      >
+        <PlusIcon className="w-5 h-5" />
+        <span>Share Board</span>
+      </button>
+
+      {showModal && (
+        <ShareBoardModal
+          communicatorId={communicatorId}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/components/dashboard/ShareBoardModal.tsx
+++ b/app/components/dashboard/ShareBoardModal.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { XMarkIcon, FolderIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface ShareBoardModalProps {
+  communicatorId: string;
+  onClose: () => void;
+}
+
+export default function ShareBoardModal({ communicatorId, onClose }: ShareBoardModalProps) {
+  const [selectedBoardId, setSelectedBoardId] = useState<Id<'phraseBoards'> | null>(null);
+  const [accessLevel, setAccessLevel] = useState<'view' | 'edit'>('view');
+  const [isSharing, setIsSharing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const myBoards = useQuery(api.phraseBoards.getPhraseBoards);
+  const alreadyShared = useQuery(api.sharedBoards.getSharedBoardsForClient, { communicatorId });
+  const shareBoard = useMutation(api.sharedBoards.shareBoard);
+
+  const alreadySharedIds = new Set(alreadyShared?.map((s) => s.boardId) ?? []);
+  const availableBoards = myBoards?.filter((b) => !alreadySharedIds.has(b._id)) ?? [];
+
+  const handleShare = async () => {
+    if (!selectedBoardId) return;
+
+    setIsSharing(true);
+    setError(null);
+    try {
+      await shareBoard({
+        boardId: selectedBoardId,
+        communicatorId,
+        accessLevel,
+      });
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to share board';
+      setError(message);
+      setIsSharing(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+      <div className="bg-surface rounded-2xl shadow-2xl max-w-md w-full p-6">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-bold text-foreground">Share a Board</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-surface-hover transition-colors"
+          >
+            <XMarkIcon className="w-5 h-5 text-text-secondary" />
+          </button>
+        </div>
+
+        {myBoards === undefined ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-16 bg-surface-hover rounded-xl animate-pulse" />
+            ))}
+          </div>
+        ) : availableBoards.length === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-text-secondary mb-2">No boards available to share</p>
+            <p className="text-text-tertiary text-sm">
+              {myBoards.length === 0
+                ? 'Create a board first to share it'
+                : 'All your boards are already shared with this client'}
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Select a board
+              </label>
+              <div className="space-y-2 max-h-48 overflow-y-auto">
+                {availableBoards.map((board) => (
+                  <button
+                    key={board._id}
+                    onClick={() => setSelectedBoardId(board._id)}
+                    className={`w-full p-3 rounded-xl border-2 transition-all text-left flex items-center gap-3 ${
+                      selectedBoardId === board._id
+                        ? 'border-primary-500 bg-primary-500/10'
+                        : 'border-border hover:border-primary-500/50'
+                    }`}
+                  >
+                    <FolderIcon className="w-5 h-5 text-text-secondary flex-shrink-0" />
+                    <span className="flex-1 truncate text-foreground">{board.name}</span>
+                    {selectedBoardId === board._id && (
+                      <CheckIcon className="w-5 h-5 text-primary-500 flex-shrink-0" />
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="mb-6">
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Permission level
+              </label>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setAccessLevel('view')}
+                  className={`flex-1 px-4 py-2 rounded-xl border-2 transition-all text-sm font-medium ${
+                    accessLevel === 'view'
+                      ? 'border-primary-500 bg-primary-500/10 text-primary-400'
+                      : 'border-border text-text-secondary hover:border-primary-500/50'
+                  }`}
+                >
+                  View only
+                </button>
+                <button
+                  onClick={() => setAccessLevel('edit')}
+                  className={`flex-1 px-4 py-2 rounded-xl border-2 transition-all text-sm font-medium ${
+                    accessLevel === 'edit'
+                      ? 'border-primary-500 bg-primary-500/10 text-primary-400'
+                      : 'border-border text-text-secondary hover:border-primary-500/50'
+                  }`}
+                >
+                  Can edit
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <div className="mb-4 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+                {error}
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 px-4 py-3 bg-surface-hover hover:bg-background text-foreground rounded-xl transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleShare}
+                disabled={isSharing || !selectedBoardId}
+                className="flex-1 px-4 py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSharing ? 'Sharing...' : 'Share Board'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/dashboard/SharedBoardCard.tsx
+++ b/app/components/dashboard/SharedBoardCard.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { FolderIcon, TrashIcon, PencilIcon, EyeIcon } from '@heroicons/react/24/outline';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface SharedBoardCardProps {
+  share: {
+    _id: Id<'sharedBoards'>;
+    boardId: Id<'phraseBoards'>;
+    board: {
+      _id: Id<'phraseBoards'>;
+      name: string;
+      position: number;
+    };
+    accessLevel: 'view' | 'edit';
+    sharedAt: number;
+  };
+}
+
+export default function SharedBoardCard({ share }: SharedBoardCardProps) {
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const unshareBoard = useMutation(api.sharedBoards.unshareBoard);
+  const updateAccess = useMutation(api.sharedBoards.updateBoardAccess);
+
+  const handleUnshare = async () => {
+    setIsRemoving(true);
+    try {
+      await unshareBoard({ shareId: share._id });
+    } catch (err) {
+      console.error('Failed to unshare board:', err);
+      setIsRemoving(false);
+      setShowConfirm(false);
+    }
+  };
+
+  const handleToggleAccess = async () => {
+    setIsUpdating(true);
+    try {
+      await updateAccess({
+        shareId: share._id,
+        accessLevel: share.accessLevel === 'view' ? 'edit' : 'view',
+      });
+    } catch (err) {
+      console.error('Failed to update access:', err);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <div className="bg-surface rounded-xl border border-border p-4 hover:border-primary-500/30 transition-colors">
+      <div className="flex items-center gap-4">
+        <div className="p-3 rounded-full bg-surface-hover">
+          <FolderIcon className="w-6 h-6 text-text-secondary" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-foreground truncate">{share.board.name}</h3>
+          <div className="flex items-center gap-2 mt-1">
+            <span
+              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                share.accessLevel === 'edit'
+                  ? 'bg-green-500/10 text-green-400'
+                  : 'bg-blue-500/10 text-blue-400'
+              }`}
+            >
+              {share.accessLevel === 'edit' ? (
+                <>
+                  <PencilIcon className="w-3 h-3" />
+                  Can edit
+                </>
+              ) : (
+                <>
+                  <EyeIcon className="w-3 h-3" />
+                  View only
+                </>
+              )}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleToggleAccess}
+            disabled={isUpdating}
+            className="px-3 py-1.5 text-sm rounded-lg bg-surface-hover text-text-secondary hover:bg-background transition-colors disabled:opacity-50"
+          >
+            {isUpdating ? 'Updating...' : share.accessLevel === 'view' ? 'Allow edit' : 'View only'}
+          </button>
+
+          {showConfirm ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-3 py-1.5 text-sm rounded-lg bg-surface-hover text-text-secondary hover:bg-background transition-colors"
+                disabled={isRemoving}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleUnshare}
+                disabled={isRemoving}
+                className="px-3 py-1.5 text-sm rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors disabled:opacity-50"
+              >
+                {isRemoving ? 'Removing...' : 'Unshare'}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowConfirm(true)}
+              className="p-2 rounded-lg text-text-tertiary hover:text-red-500 hover:bg-red-500/10 transition-colors"
+              title="Unshare board"
+            >
+              <TrashIcon className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/client/[id]/page.tsx
+++ b/app/dashboard/client/[id]/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { use } from 'react';
+import { useAuth } from '@/app/contexts/AuthContext';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { ArrowLeftIcon, UserIcon, FolderPlusIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import SharedBoardCard from '@/app/components/dashboard/SharedBoardCard';
+import ShareBoardButton from '@/app/components/dashboard/ShareBoardButton';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function ClientDetailPage({ params }: PageProps) {
+  const { id: communicatorId } = use(params);
+  const { user, loading: authLoading } = useAuth();
+  const profile = useQuery(api.profiles.getProfile);
+  const clientProfile = useQuery(api.profiles.getProfileByUserId, { userId: communicatorId });
+  const sharedBoards = useQuery(api.sharedBoards.getSharedBoardsForClient, { communicatorId });
+  const router = useRouter();
+
+  // Redirect non-caregivers
+  useEffect(() => {
+    if (!authLoading && profile !== undefined) {
+      if (!user) {
+        router.push('/sign-in');
+      } else if (profile?.role !== 'caregiver') {
+        router.push('/');
+      }
+    }
+  }, [authLoading, user, profile, router]);
+
+  if (authLoading || profile === undefined || clientProfile === undefined || sharedBoards === undefined) {
+    return <AnimatedLoading />;
+  }
+
+  if (!user || profile?.role !== 'caregiver') {
+    return <AnimatedLoading />;
+  }
+
+  const clientName = clientProfile?.fullName || clientProfile?.email || 'Client';
+
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-4xl mx-auto">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 text-text-secondary hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeftIcon className="w-4 h-4" />
+          <span>Back to clients</span>
+        </Link>
+
+        <div className="flex items-center gap-4 mb-8">
+          <div className="p-3 rounded-full bg-primary-500/10">
+            <UserIcon className="w-8 h-8 text-primary-500" />
+          </div>
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold text-foreground">{clientName}</h1>
+            {clientProfile?.fullName && clientProfile?.email && (
+              <p className="text-text-secondary">{clientProfile.email}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-foreground">Shared Boards</h2>
+            <ShareBoardButton communicatorId={communicatorId} />
+          </div>
+
+          {sharedBoards.length === 0 ? (
+            <div className="text-center py-12 bg-surface rounded-xl border border-border">
+              <FolderPlusIcon className="w-12 h-12 text-text-tertiary mx-auto mb-3" />
+              <p className="text-text-secondary mb-2">No boards shared yet</p>
+              <p className="text-text-tertiary text-sm">
+                Share a board to help {clientName} communicate
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {sharedBoards.map((share) => (
+                <SharedBoardCard key={share._id} share={share} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useAuth } from '@/app/contexts/AuthContext';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
+import ClientList from '@/app/components/dashboard/ClientList';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { UsersIcon } from '@heroicons/react/24/outline';
+
+export default function DashboardPage() {
+  const { user, loading: authLoading } = useAuth();
+  const profile = useQuery(api.profiles.getProfile);
+  const router = useRouter();
+
+  // Redirect non-caregivers
+  useEffect(() => {
+    if (!authLoading && profile !== undefined) {
+      if (!user) {
+        router.push('/sign-in');
+      } else if (profile?.role !== 'caregiver') {
+        router.push('/');
+      }
+    }
+  }, [authLoading, user, profile, router]);
+
+  if (authLoading || profile === undefined) {
+    return <AnimatedLoading />;
+  }
+
+  if (!user || profile?.role !== 'caregiver') {
+    return <AnimatedLoading />;
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center gap-3 mb-8">
+          <div className="p-3 rounded-full bg-primary-500/10">
+            <UsersIcon className="w-8 h-8 text-primary-500" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">My Clients</h1>
+            <p className="text-text-secondary">Manage your clients and their boards</p>
+          </div>
+        </div>
+
+        <ClientList />
+      </div>
+    </div>
+  );
+}

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -13,6 +13,17 @@ export const getProfileByUserId = query({
   },
 });
 
+// Query: Get profile by email (used for finding clients)
+export const getProfileByEmail = query({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query('profiles')
+      .withIndex('by_email', (q) => q.eq('email', args.email.toLowerCase()))
+      .first();
+  },
+});
+
 // Query: Get current user's profile
 export const getProfile = query({
   handler: async (ctx) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -8,7 +8,9 @@ export default defineSchema({
     fullName: v.optional(v.string()),
     bypassSubscriptionCheck: v.optional(v.boolean()),
     role: v.optional(v.union(v.literal('caregiver'), v.literal('communicator'))),
-  }).index('by_user_id', ['userId']),
+  })
+    .index('by_user_id', ['userId'])
+    .index('by_email', ['email']),
 
   caregiverClients: defineTable({
     caregiverId: v.string(), // Clerk user ID of caregiver


### PR DESCRIPTION
## Summary
- Creates dashboard for caregivers to manage their clients
- Allows adding existing users as clients by email
- Shows list of clients with shared board counts
- Client detail page for managing shared boards per client
- Share/unshare boards with configurable permissions (view/edit)

## New Pages
- `/dashboard` - Caregiver client list
- `/dashboard/client/[id]` - Client detail with shared boards

## New Components
- `ClientList`, `ClientCard` - Display clients
- `AddClientButton`, `AddClientModal` - Add clients by email
- `ShareBoardButton`, `ShareBoardModal` - Share boards
- `SharedBoardCard` - Display/manage shared boards

## Schema Changes
- Added `by_email` index to profiles table

## Test plan
- [ ] Sign in as caregiver
- [ ] Verify "Clients" link appears in sidebar
- [ ] Add a client by their email
- [ ] View client's page
- [ ] Share a board with view/edit permissions
- [ ] Toggle permission level
- [ ] Unshare a board
- [ ] Remove a client

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added caregiver dashboard to manage and share boards with clients
  * Caregivers can add clients by email and view them in a client list
  * Caregivers can share individual boards with clients and control access levels (view or edit)
  * Caregivers can manage shared boards with each client

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->