### PR TITLE
Add communicator shared boards view (#126)

### DIFF
--- a/app/components/dashboard/ShareBoardModal.tsx
+++ b/app/components/dashboard/ShareBoardModal.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
-import { XMarkIcon, FolderIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, FolderIcon, CheckIcon, EyeIcon, PencilIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { Id } from '@/convex/_generated/dataModel';
 
 interface ShareBoardModalProps {
@@ -102,26 +103,44 @@ export default function ShareBoardModal({ communicatorId, onClose }: ShareBoardM
               <label className="block text-sm font-medium text-foreground mb-2">
                 Permission level
               </label>
-              <div className="flex gap-2">
+              <div className="flex gap-3">
                 <button
                   onClick={() => setAccessLevel('view')}
-                  className={`flex-1 px-4 py-2 rounded-xl border-2 transition-all text-sm font-medium ${
+                  className={`flex-1 p-4 rounded-xl border-2 transition-all ${
                     accessLevel === 'view'
-                      ? 'border-primary-500 bg-primary-500/10 text-primary-400'
-                      : 'border-border text-text-secondary hover:border-primary-500/50'
+                      ? 'border-primary-500 bg-primary-500/20 ring-2 ring-primary-500/30'
+                      : 'border-border hover:border-primary-500/50'
                   }`}
                 >
-                  View only
+                  <div className="flex items-center justify-center gap-2 mb-1">
+                    <EyeIcon className={`w-5 h-5 ${accessLevel === 'view' ? 'text-primary-400' : 'text-text-secondary'}`} />
+                    {accessLevel === 'view' && <CheckCircleIcon className="w-5 h-5 text-primary-500" />}
+                  </div>
+                  <span className={`text-sm font-medium ${accessLevel === 'view' ? 'text-primary-400' : 'text-text-secondary'}`}>
+                    View only
+                  </span>
+                  <p className={`text-xs mt-1 ${accessLevel === 'view' ? 'text-primary-400/70' : 'text-text-tertiary'}`}>
+                    Can see phrases
+                  </p>
                 </button>
                 <button
                   onClick={() => setAccessLevel('edit')}
-                  className={`flex-1 px-4 py-2 rounded-xl border-2 transition-all text-sm font-medium ${
+                  className={`flex-1 p-4 rounded-xl border-2 transition-all ${
                     accessLevel === 'edit'
-                      ? 'border-primary-500 bg-primary-500/10 text-primary-400'
-                      : 'border-border text-text-secondary hover:border-primary-500/50'
+                      ? 'border-primary-500 bg-primary-500/20 ring-2 ring-primary-500/30'
+                      : 'border-border hover:border-primary-500/50'
                   }`}
                 >
-                  Can edit
+                  <div className="flex items-center justify-center gap-2 mb-1">
+                    <PencilIcon className={`w-5 h-5 ${accessLevel === 'edit' ? 'text-primary-400' : 'text-text-secondary'}`} />
+                    {accessLevel === 'edit' && <CheckCircleIcon className="w-5 h-5 text-primary-500" />}
+                  </div>
+                  <span className={`text-sm font-medium ${accessLevel === 'edit' ? 'text-primary-400' : 'text-text-secondary'}`}>
+                    Can edit
+                  </span>
+                  <p className={`text-xs mt-1 ${accessLevel === 'edit' ? 'text-primary-400/70' : 'text-text-tertiary'}`}>
+                    Add & modify phrases
+                  </p>
                 </button>
               </div>
             </div>

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -165,9 +165,15 @@ export default function PhrasesInterface() {
       name: board.name,
       position: board.position,
       phrases: board._id === selectedBoardId ? phrases : [],
+      isShared: board.isShared,
+      accessLevel: board.accessLevel,
+      sharedBy: board.sharedBy,
     })) || [];
 
   const selectedBoard = transformedBoards.find(board => board.id === selectedBoardId) || null;
+
+  // Check if current board allows editing
+  const canEditCurrentBoard = !selectedBoard?.isShared || selectedBoard?.accessLevel === 'edit';
 
   return (
     <>
@@ -218,18 +224,18 @@ export default function PhrasesInterface() {
                         key={phrase.id}
                         phrase={phrase}
                         onPress={() => handlePhrasePress(phrase)}
-                        onEdit={isEditMode ? () => handleEditPhrase(phrase) : undefined}
+                        onEdit={isEditMode && canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
                         className="sm:aspect-square"
                       />
                     ))}
-                    {typingText.trim() && (
+                    {typingText.trim() && canEditCurrentBoard && (
                       <ActionTile
                         text="+ Add as Phrase"
                         onClick={handleAddTypingAsPhrase}
                         className="sm:aspect-square"
                       />
                     )}
-                    {isEditMode && (
+                    {isEditMode && canEditCurrentBoard && (
                       <ActionTile
                         text="+ Add Phrase"
                         onClick={handleAddPhrase}
@@ -250,6 +256,7 @@ export default function PhrasesInterface() {
         onReader={handleReader}
         boardPresent={transformedBoards.length > 0}
         isEditMode={isEditMode}
+        canEditBoard={canEditCurrentBoard}
       />
       <ReaderPopup
         phrases={phrases}

--- a/app/components/phrases/BoardGridPopup.tsx
+++ b/app/components/phrases/BoardGridPopup.tsx
@@ -1,6 +1,6 @@
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment } from 'react';
-import { PencilIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, UserGroupIcon } from '@heroicons/react/24/outline';
 import type { BoardSummary } from './types';
 
 interface BoardGridPopupProps {
@@ -59,37 +59,48 @@ export default function BoardGridPopup({
                 </Dialog.Title>
 
                 <div className="grid grid-cols-2 gap-4">
-                  {boards.map((board) => (
-                    <div
-                      key={board.id}
-                      className={`relative p-5 rounded-2xl border-2 cursor-pointer transition-all duration-300 ${
-                        selectedBoard?.id === board.id
-                          ? 'border-primary-500 bg-primary-500/10 shadow-lg'
-                          : 'border-border hover:border-primary-300 hover:shadow-md'
-                      }`}
-                      onClick={() => {
-                        onSelectBoard(board);
-                        onClose();
-                      }}
-                    >
-                      <div className="flex items-start justify-between">
-                        <div className="flex-1">
-                          <h4 className="font-semibold text-foreground text-base">{board.name}</h4>
+                  {boards.map((board) => {
+                    const canEdit = !board.isShared || board.accessLevel === 'edit';
+                    return (
+                      <div
+                        key={board.id}
+                        className={`relative p-5 rounded-2xl border-2 cursor-pointer transition-all duration-300 ${
+                          selectedBoard?.id === board.id
+                            ? 'border-primary-500 bg-primary-500/10 shadow-lg'
+                            : 'border-border hover:border-primary-300 hover:shadow-md'
+                        }`}
+                        onClick={() => {
+                          onSelectBoard(board);
+                          onClose();
+                        }}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <h4 className="font-semibold text-foreground text-base">{board.name}</h4>
+                            {board.isShared && board.sharedBy && (
+                              <div className="flex items-center gap-1 mt-1">
+                                <UserGroupIcon className="h-3 w-3 text-primary-400" />
+                                <span className="text-xs text-primary-400">
+                                  Shared by {board.sharedBy}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                          {isEditMode && canEdit && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onEditBoard(board.id);
+                              }}
+                              className="p-2 hover:bg-surface-hover rounded-xl transition-all duration-200"
+                            >
+                              <PencilIcon className="h-4 w-4 text-text-secondary hover:text-foreground transition-colors duration-200" />
+                            </button>
+                          )}
                         </div>
-                        {isEditMode && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onEditBoard(board.id);
-                            }}
-                            className="p-2 hover:bg-surface-hover rounded-xl transition-all duration-200"
-                          >
-                            <PencilIcon className="h-4 w-4 text-text-secondary hover:text-foreground transition-colors duration-200" />
-                          </button>
-                        )}
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </Dialog.Panel>
             </Transition.Child>

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { PencilIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, UserGroupIcon } from '@heroicons/react/24/outline';
 import BoardGridPopup from './BoardGridPopup';
 import { Button } from '@/app/components/ui/Button';
 import type { BoardSummary } from './types';
@@ -23,6 +23,8 @@ export default function BoardSelector({
 
   if (boards.length === 0) return null;
 
+  const canEditSelected = !selectedBoard?.isShared || selectedBoard?.accessLevel === 'edit';
+
   // If there's only one board, show it directly
   if (boards.length === 1) {
     return (
@@ -30,15 +32,23 @@ export default function BoardSelector({
         <div
           className="flex-1 flex items-center justify-between px-6 py-4 cursor-pointer"
           onClick={() => {
-            if (isEditMode && selectedBoard) {
+            if (isEditMode && selectedBoard && canEditSelected) {
               onEditBoard(selectedBoard.id);
             }
           }}
         >
-          <div className="flex items-center space-x-2">
+          <div className="flex flex-col">
             <h2 className="font-semibold text-foreground text-base">{selectedBoard?.name}</h2>
+            {selectedBoard?.isShared && selectedBoard?.sharedBy && (
+              <div className="flex items-center gap-1 mt-0.5">
+                <UserGroupIcon className="h-3 w-3 text-primary-400" />
+                <span className="text-xs text-primary-400">
+                  Shared by {selectedBoard.sharedBy}
+                </span>
+              </div>
+            )}
           </div>
-          {isEditMode && (
+          {isEditMode && canEditSelected && (
             <PencilIcon className="h-5 w-5 text-text-secondary hover:text-foreground transition-colors duration-200" />
           )}
         </div>
@@ -54,11 +64,19 @@ export default function BoardSelector({
           className="flex-1 flex items-center justify-between px-6 py-4 cursor-pointer"
           onClick={() => setIsPopupOpen(true)}
         >
-          <div className="flex items-center space-x-2">
+          <div className="flex flex-col">
             <h2 className="font-semibold text-foreground text-base">{selectedBoard?.name}</h2>
+            {selectedBoard?.isShared && selectedBoard?.sharedBy && (
+              <div className="flex items-center gap-1 mt-0.5">
+                <UserGroupIcon className="h-3 w-3 text-primary-400" />
+                <span className="text-xs text-primary-400">
+                  Shared by {selectedBoard.sharedBy}
+                </span>
+              </div>
+            )}
           </div>
           <div className="flex items-center space-x-1">
-            {isEditMode && (
+            {isEditMode && canEditSelected && (
               <Button
                 variant="ghost"
                 size="icon"

--- a/app/components/phrases/PhrasesActionMenu.tsx
+++ b/app/components/phrases/PhrasesActionMenu.tsx
@@ -11,6 +11,7 @@ interface PhrasesActionMenuProps {
   onReader: () => void
   boardPresent: boolean
   isEditMode: boolean
+  canEditBoard?: boolean
 }
 
 export default function PhrasesActionMenu({
@@ -20,6 +21,7 @@ export default function PhrasesActionMenu({
   onReader,
   boardPresent,
   isEditMode,
+  canEditBoard = true,
 }: PhrasesActionMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -74,8 +76,8 @@ export default function PhrasesActionMenu({
             <span className="text-sm font-medium text-text-primary whitespace-nowrap">New Board</span>
           </div>
 
-          {/* Add to Board Action - Only show when board is present */}
-          {boardPresent && (
+          {/* Add to Board Action - Only show when board is present and can be edited */}
+          {boardPresent && canEditBoard && (
             <div
               onClick={() => handleAction(onAddPhrase)}
               className="flex items-center gap-3 bg-surface shadow-lg rounded-full px-4 py-3 cursor-pointer hover:bg-surface-hover transition-colors duration-200 border border-border"
@@ -100,26 +102,28 @@ export default function PhrasesActionMenu({
             </div>
           )}
 
-          {/* Edit/Done Action */}
-          <div
-            onClick={() => handleAction(onEdit)}
-            className={`flex items-center gap-3 shadow-lg rounded-full px-4 py-3 cursor-pointer transition-all duration-200 border ${
-              isEditMode
-                ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500'
-                : 'bg-surface hover:bg-surface-hover border-border'
-            }`}
-            data-tooltip-id="edit-tooltip"
-            data-tooltip-content={isEditMode ? 'Finish editing the board' : 'Edit the current board'}
-          >
-            {isEditMode ? (
-              <Check className="w-5 h-5" />
-            ) : (
-              <Pencil className={`w-5 h-5 ${isEditMode ? 'text-white' : 'text-text-secondary'}`} />
-            )}
-            <span className={`text-sm font-medium whitespace-nowrap ${isEditMode ? 'text-white' : 'text-text-primary'}`}>
-              {isEditMode ? 'Done' : 'Edit'}
-            </span>
-          </div>
+          {/* Edit/Done Action - Only show when board can be edited */}
+          {canEditBoard && (
+            <div
+              onClick={() => handleAction(onEdit)}
+              className={`flex items-center gap-3 shadow-lg rounded-full px-4 py-3 cursor-pointer transition-all duration-200 border ${
+                isEditMode
+                  ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500'
+                  : 'bg-surface hover:bg-surface-hover border-border'
+              }`}
+              data-tooltip-id="edit-tooltip"
+              data-tooltip-content={isEditMode ? 'Finish editing the board' : 'Edit the current board'}
+            >
+              {isEditMode ? (
+                <Check className="w-5 h-5" />
+              ) : (
+                <Pencil className={`w-5 h-5 ${isEditMode ? 'text-white' : 'text-text-secondary'}`} />
+              )}
+              <span className={`text-sm font-medium whitespace-nowrap ${isEditMode ? 'text-white' : 'text-text-primary'}`}>
+                {isEditMode ? 'Done' : 'Edit'}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Main Action Button */}

--- a/app/components/phrases/types.ts
+++ b/app/components/phrases/types.ts
@@ -9,4 +9,7 @@ export interface BoardSummary {
   name: string;
   position?: number;
   phrases: PhraseSummary[];
+  isShared?: boolean;
+  accessLevel?: 'view' | 'edit';
+  sharedBy?: string | null;
 }

--- a/convex/phraseBoards.ts
+++ b/convex/phraseBoards.ts
@@ -2,7 +2,7 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { getUserIdentity } from './users';
 
-// Query: Get all phrase boards for current user
+// Query: Get all phrase boards for current user (owned + shared)
 export const getPhraseBoards = query({
   handler: async (ctx) => {
     const identity = await getUserIdentity(ctx);
@@ -10,14 +10,40 @@ export const getPhraseBoards = query({
       return [];
     }
 
-    const boards = await ctx.db
+    // Get owned boards
+    const ownedBoards = await ctx.db
       .query('phraseBoards')
       .withIndex('by_user_id', (q) => q.eq('userId', identity.subject))
       .collect();
 
-    // Get phrases for each board
-    const boardsWithPhrases = await Promise.all(
-      boards.map(async (board) => {
+    // Get shared boards
+    const sharedBoardLinks = await ctx.db
+      .query('sharedBoards')
+      .withIndex('by_communicator', (q) => q.eq('communicatorId', identity.subject))
+      .collect();
+
+    const sharedBoards = await Promise.all(
+      sharedBoardLinks.map(async (link) => {
+        const board = await ctx.db.get(link.boardId);
+        if (!board) return null;
+
+        // Get caregiver profile for display
+        const caregiverProfile = await ctx.db
+          .query('profiles')
+          .withIndex('by_user_id', (q) => q.eq('userId', link.caregiverId))
+          .first();
+
+        return {
+          board,
+          accessLevel: link.accessLevel,
+          sharedBy: caregiverProfile?.fullName || caregiverProfile?.email || 'Caregiver',
+        };
+      })
+    );
+
+    // Get phrases for owned boards
+    const ownedBoardsWithPhrases = await Promise.all(
+      ownedBoards.map(async (board) => {
         const phraseBoardPhrases = await ctx.db
           .query('phraseBoardPhrases')
           .withIndex('by_board', (q) => q.eq('boardId', board._id))
@@ -30,15 +56,49 @@ export const getPhraseBoards = query({
           })
         );
 
-        return { ...board, phrase_board_phrases: phrases };
+        return {
+          ...board,
+          phrase_board_phrases: phrases,
+          isShared: false,
+          accessLevel: 'edit' as const,
+          sharedBy: null,
+        };
       })
     );
 
-    return boardsWithPhrases;
+    // Get phrases for shared boards
+    const sharedBoardsWithPhrases = await Promise.all(
+      sharedBoards
+        .filter((sb): sb is NonNullable<typeof sb> => sb !== null)
+        .map(async ({ board, accessLevel, sharedBy }) => {
+          const phraseBoardPhrases = await ctx.db
+            .query('phraseBoardPhrases')
+            .withIndex('by_board', (q) => q.eq('boardId', board._id))
+            .collect();
+
+          const phrases = await Promise.all(
+            phraseBoardPhrases.map(async (pbp) => {
+              const phrase = await ctx.db.get(pbp.phraseId);
+              return { ...pbp, phrase };
+            })
+          );
+
+          return {
+            ...board,
+            phrase_board_phrases: phrases,
+            isShared: true,
+            accessLevel,
+            sharedBy,
+          };
+        })
+    );
+
+    // Combine and return all boards
+    return [...ownedBoardsWithPhrases, ...sharedBoardsWithPhrases];
   },
 });
 
-// Query: Get a single phrase board by ID
+// Query: Get a single phrase board by ID (owned or shared)
 export const getPhraseBoard = query({
   args: { id: v.id('phraseBoards') },
   handler: async (ctx, args) => {
@@ -48,8 +108,38 @@ export const getPhraseBoard = query({
     }
 
     const board = await ctx.db.get(args.id);
-    if (!board || board.userId !== identity.subject) {
+    if (!board) {
       return null;
+    }
+
+    // Check if user owns the board
+    const isOwner = board.userId === identity.subject;
+
+    // Check if board is shared with user
+    let shareInfo = null;
+    if (!isOwner) {
+      const sharedBoardLinks = await ctx.db
+        .query('sharedBoards')
+        .withIndex('by_board', (q) => q.eq('boardId', args.id))
+        .collect();
+
+      const share = sharedBoardLinks.find(
+        (link) => link.communicatorId === identity.subject
+      );
+
+      if (!share) {
+        return null; // User has no access
+      }
+
+      const caregiverProfile = await ctx.db
+        .query('profiles')
+        .withIndex('by_user_id', (q) => q.eq('userId', share.caregiverId))
+        .first();
+
+      shareInfo = {
+        accessLevel: share.accessLevel,
+        sharedBy: caregiverProfile?.fullName || caregiverProfile?.email || 'Caregiver',
+      };
     }
 
     const phraseBoardPhrases = await ctx.db
@@ -64,7 +154,13 @@ export const getPhraseBoard = query({
       })
     );
 
-    return { ...board, phrase_board_phrases: phrases };
+    return {
+      ...board,
+      phrase_board_phrases: phrases,
+      isShared: !isOwner,
+      accessLevel: isOwner ? 'edit' : shareInfo?.accessLevel,
+      sharedBy: shareInfo?.sharedBy || null,
+    };
   },
 });
 
@@ -161,14 +257,35 @@ export const addPhraseToBoard = mutation({
       throw new Error('Unauthenticated');
     }
 
-    // Verify phrase and board ownership
+    // Verify phrase ownership
     const phrase = await ctx.db.get(args.phraseId);
-    const board = await ctx.db.get(args.boardId);
-
     if (!phrase || phrase.userId !== identity.subject) {
       throw new Error('Unauthorized - phrase');
     }
-    if (!board || board.userId !== identity.subject) {
+
+    // Verify board access (owner or shared with edit access)
+    const board = await ctx.db.get(args.boardId);
+    if (!board) {
+      throw new Error('Board not found');
+    }
+
+    const isOwner = board.userId === identity.subject;
+    let hasEditAccess = false;
+
+    if (!isOwner) {
+      // Check if board is shared with edit access
+      const sharedBoardLinks = await ctx.db
+        .query('sharedBoards')
+        .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
+        .collect();
+
+      const share = sharedBoardLinks.find(
+        (link) => link.communicatorId === identity.subject && link.accessLevel === 'edit'
+      );
+      hasEditAccess = !!share;
+    }
+
+    if (!isOwner && !hasEditAccess) {
       throw new Error('Unauthorized - board');
     }
 


### PR DESCRIPTION
## Summary
- Communicators can now see boards shared with them by caregivers
- "Shared by [name]" indicator shows on shared boards
- View-only boards hide edit/add phrase controls
- Caregivers get improved access level selection UI when sharing boards

## Test plan
- [ ] Log in as caregiver, share a board with a communicator
- [ ] Log in as communicator, verify shared board appears with "Shared by" tag
- [ ] Verify view-only shared boards hide edit controls
- [ ] Verify edit-access shared boards allow adding phrases
- [ ] Test access level selection UI in ShareBoardModal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Board sharing now enforces view and edit permissions—users with "View only" access cannot modify phrases; only users with "Edit" access can add or modify content.
  * Shared boards now display "Shared by" information to indicate the source.
  * Enhanced permission selection UI with icons and descriptive subtitles ("View only" → "Can see phrases"; "Can edit" → "Add & modify phrases").

* **Bug Fixes**
  * Fixed unauthorized phrase editing on restricted shared boards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->