### PR TITLE
Refactor board sharing to 1:1 board-client model (#131)

### DIFF
--- a/app/components/dashboard/ClientBoardCard.tsx
+++ b/app/components/dashboard/ClientBoardCard.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { FolderIcon, PencilIcon, EyeIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface ClientBoardCardProps {
+  board: {
+    _id: Id<'phraseBoards'>;
+    name: string;
+    clientAccessLevel?: 'view' | 'edit';
+  };
+}
+
+export default function ClientBoardCard({ board }: ClientBoardCardProps) {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+
+  const updateAccess = useMutation(api.phraseBoards.updateBoardClientAccess);
+  const unassignBoard = useMutation(api.phraseBoards.unassignBoardFromClient);
+
+  const accessLevel = board.clientAccessLevel || 'view';
+
+  const handleToggleAccess = async () => {
+    setIsUpdating(true);
+    try {
+      await updateAccess({
+        boardId: board._id,
+        accessLevel: accessLevel === 'view' ? 'edit' : 'view',
+      });
+    } catch (error) {
+      console.error('Failed to update access:', error);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setIsUpdating(true);
+    try {
+      await unassignBoard({ boardId: board._id });
+    } catch (error) {
+      console.error('Failed to remove board:', error);
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 bg-surface rounded-xl border border-border">
+      <div className="flex items-center gap-3">
+        <FolderIcon className="w-5 h-5 text-text-secondary" />
+        <span className="font-medium text-foreground">{board.name}</span>
+        <span
+          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+            accessLevel === 'edit'
+              ? 'bg-green-500/10 text-green-400'
+              : 'bg-blue-500/10 text-blue-400'
+          }`}
+        >
+          {accessLevel === 'edit' ? (
+            <>
+              <PencilIcon className="w-3 h-3" />
+              Can edit
+            </>
+          ) : (
+            <>
+              <EyeIcon className="w-3 h-3" />
+              View only
+            </>
+          )}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleToggleAccess}
+          disabled={isUpdating}
+          className="px-3 py-1.5 text-sm text-text-secondary hover:text-foreground hover:bg-surface-hover rounded-lg transition-colors disabled:opacity-50"
+        >
+          {accessLevel === 'view' ? 'Allow edit' : 'View only'}
+        </button>
+        {showRemoveConfirm ? (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowRemoveConfirm(false)}
+              className="px-3 py-1.5 text-sm text-text-secondary hover:text-foreground rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleRemove}
+              disabled={isUpdating}
+              className="px-3 py-1.5 text-sm text-red-400 hover:bg-red-500/10 rounded-lg transition-colors disabled:opacity-50"
+            >
+              Confirm
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowRemoveConfirm(true)}
+            className="p-1.5 text-text-secondary hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+          >
+            <TrashIcon className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/dashboard/CreateBoardButton.tsx
+++ b/app/components/dashboard/CreateBoardButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+import { PlusIcon } from '@heroicons/react/24/outline';
+import CreateBoardModal from './CreateBoardModal';
+
+interface CreateBoardButtonProps {
+  communicatorId: string;
+}
+
+export default function CreateBoardButton({ communicatorId }: CreateBoardButtonProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsModalOpen(true)}
+        className="inline-flex items-center gap-2 px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors"
+      >
+        <PlusIcon className="w-5 h-5" />
+        Create Board
+      </button>
+
+      {isModalOpen && (
+        <CreateBoardModal
+          communicatorId={communicatorId}
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/components/dashboard/CreateBoardModal.tsx
+++ b/app/components/dashboard/CreateBoardModal.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { XMarkIcon, EyeIcon, PencilIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
+
+interface CreateBoardModalProps {
+  communicatorId: string;
+  onClose: () => void;
+}
+
+export default function CreateBoardModal({ communicatorId, onClose }: CreateBoardModalProps) {
+  const [name, setName] = useState('');
+  const [accessLevel, setAccessLevel] = useState<'view' | 'edit'>('view');
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addBoard = useMutation(api.phraseBoards.addPhraseBoard);
+  const existingBoards = useQuery(api.phraseBoards.getPhraseBoards);
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      setError('Please enter a board name');
+      return;
+    }
+
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      // Get position for new board (after existing boards)
+      const position = existingBoards?.length ?? 0;
+
+      await addBoard({
+        name: name.trim(),
+        position,
+        forClientId: communicatorId,
+        clientAccessLevel: accessLevel,
+      });
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create board';
+      setError(message);
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+      <div className="bg-surface rounded-2xl shadow-2xl max-w-md w-full p-6">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-bold text-foreground">Create Board for Client</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-surface-hover transition-colors"
+          >
+            <XMarkIcon className="w-5 h-5 text-text-secondary" />
+          </button>
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="board-name" className="block text-sm font-medium text-foreground mb-2">
+            Board name
+          </label>
+          <input
+            type="text"
+            id="board-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Daily Phrases"
+            className="w-full px-4 py-3 bg-background border border-border rounded-xl text-foreground placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            autoFocus
+          />
+        </div>
+
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Permission level
+          </label>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setAccessLevel('view')}
+              className={`flex-1 p-4 rounded-xl border-2 transition-all ${
+                accessLevel === 'view'
+                  ? 'border-primary-500 bg-primary-500/20 ring-2 ring-primary-500/30'
+                  : 'border-border hover:border-primary-500/50'
+              }`}
+            >
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <EyeIcon className={`w-5 h-5 ${accessLevel === 'view' ? 'text-primary-400' : 'text-text-secondary'}`} />
+                {accessLevel === 'view' && <CheckCircleIcon className="w-5 h-5 text-primary-500" />}
+              </div>
+              <span className={`text-sm font-medium ${accessLevel === 'view' ? 'text-primary-400' : 'text-text-secondary'}`}>
+                View only
+              </span>
+              <p className={`text-xs mt-1 ${accessLevel === 'view' ? 'text-primary-400/70' : 'text-text-tertiary'}`}>
+                Can see phrases
+              </p>
+            </button>
+            <button
+              onClick={() => setAccessLevel('edit')}
+              className={`flex-1 p-4 rounded-xl border-2 transition-all ${
+                accessLevel === 'edit'
+                  ? 'border-primary-500 bg-primary-500/20 ring-2 ring-primary-500/30'
+                  : 'border-border hover:border-primary-500/50'
+              }`}
+            >
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <PencilIcon className={`w-5 h-5 ${accessLevel === 'edit' ? 'text-primary-400' : 'text-text-secondary'}`} />
+                {accessLevel === 'edit' && <CheckCircleIcon className="w-5 h-5 text-primary-500" />}
+              </div>
+              <span className={`text-sm font-medium ${accessLevel === 'edit' ? 'text-primary-400' : 'text-text-secondary'}`}>
+                Can edit
+              </span>
+              <p className={`text-xs mt-1 ${accessLevel === 'edit' ? 'text-primary-400/70' : 'text-text-tertiary'}`}>
+                Add & modify phrases
+              </p>
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 px-4 py-3 bg-surface-hover hover:bg-background text-foreground rounded-xl transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={isCreating || !name.trim()}
+            className="flex-1 px-4 py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isCreating ? 'Creating...' : 'Create Board'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -166,8 +166,11 @@ export default function PhrasesInterface() {
       position: board.position,
       phrases: board._id === selectedBoardId ? phrases : [],
       isShared: board.isShared,
+      isOwner: board.isOwner,
       accessLevel: board.accessLevel,
       sharedBy: board.sharedBy,
+      forClientId: board.forClientId,
+      forClientName: board.forClientName,
     })) || [];
 
   const selectedBoard = transformedBoards.find(board => board.id === selectedBoardId) || null;

--- a/app/components/phrases/BoardGridPopup.tsx
+++ b/app/components/phrases/BoardGridPopup.tsx
@@ -85,6 +85,14 @@ export default function BoardGridPopup({
                                 </span>
                               </div>
                             )}
+                            {board.isOwner && board.forClientName && (
+                              <div className="flex items-center gap-1 mt-1">
+                                <UserGroupIcon className="h-3 w-3 text-blue-400" />
+                                <span className="text-xs text-blue-400">
+                                  For {board.forClientName}
+                                </span>
+                              </div>
+                            )}
                           </div>
                           {isEditMode && canEdit && (
                             <button

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -25,6 +25,37 @@ export default function BoardSelector({
 
   const canEditSelected = !selectedBoard?.isShared || selectedBoard?.accessLevel === 'edit';
 
+  // Helper to render board subtitle (client name or shared by)
+  const renderBoardSubtitle = (board: BoardSummary | null) => {
+    if (!board) return null;
+
+    // For shared boards (communicator viewing caregiver's board)
+    if (board.isShared && board.sharedBy) {
+      return (
+        <div className="flex items-center gap-1 mt-0.5">
+          <UserGroupIcon className="h-3 w-3 text-primary-400" />
+          <span className="text-xs text-primary-400">
+            Shared by {board.sharedBy}
+          </span>
+        </div>
+      );
+    }
+
+    // For owned boards assigned to a client (caregiver viewing)
+    if (board.isOwner && board.forClientName) {
+      return (
+        <div className="flex items-center gap-1 mt-0.5">
+          <UserGroupIcon className="h-3 w-3 text-blue-400" />
+          <span className="text-xs text-blue-400">
+            For {board.forClientName}
+          </span>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
   // If there's only one board, show it directly
   if (boards.length === 1) {
     return (
@@ -39,14 +70,7 @@ export default function BoardSelector({
         >
           <div className="flex flex-col">
             <h2 className="font-semibold text-foreground text-base">{selectedBoard?.name}</h2>
-            {selectedBoard?.isShared && selectedBoard?.sharedBy && (
-              <div className="flex items-center gap-1 mt-0.5">
-                <UserGroupIcon className="h-3 w-3 text-primary-400" />
-                <span className="text-xs text-primary-400">
-                  Shared by {selectedBoard.sharedBy}
-                </span>
-              </div>
-            )}
+            {renderBoardSubtitle(selectedBoard)}
           </div>
           {isEditMode && canEditSelected && (
             <PencilIcon className="h-5 w-5 text-text-secondary hover:text-foreground transition-colors duration-200" />
@@ -66,14 +90,7 @@ export default function BoardSelector({
         >
           <div className="flex flex-col">
             <h2 className="font-semibold text-foreground text-base">{selectedBoard?.name}</h2>
-            {selectedBoard?.isShared && selectedBoard?.sharedBy && (
-              <div className="flex items-center gap-1 mt-0.5">
-                <UserGroupIcon className="h-3 w-3 text-primary-400" />
-                <span className="text-xs text-primary-400">
-                  Shared by {selectedBoard.sharedBy}
-                </span>
-              </div>
-            )}
+            {renderBoardSubtitle(selectedBoard)}
           </div>
           <div className="flex items-center space-x-1">
             {isEditMode && canEditSelected && (

--- a/app/components/phrases/types.ts
+++ b/app/components/phrases/types.ts
@@ -10,6 +10,9 @@ export interface BoardSummary {
   position?: number;
   phrases: PhraseSummary[];
   isShared?: boolean;
+  isOwner?: boolean;
   accessLevel?: 'view' | 'edit';
   sharedBy?: string | null;
+  forClientId?: string | null;
+  forClientName?: string | null;
 }

--- a/app/dashboard/client/[id]/page.tsx
+++ b/app/dashboard/client/[id]/page.tsx
@@ -9,8 +9,8 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { ArrowLeftIcon, UserIcon, FolderPlusIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
-import SharedBoardCard from '@/app/components/dashboard/SharedBoardCard';
-import ShareBoardButton from '@/app/components/dashboard/ShareBoardButton';
+import ClientBoardCard from '@/app/components/dashboard/ClientBoardCard';
+import CreateBoardButton from '@/app/components/dashboard/CreateBoardButton';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -21,7 +21,7 @@ export default function ClientDetailPage({ params }: PageProps) {
   const { user, loading: authLoading } = useAuth();
   const profile = useQuery(api.profiles.getProfile);
   const clientProfile = useQuery(api.profiles.getProfileByUserId, { userId: communicatorId });
-  const sharedBoards = useQuery(api.sharedBoards.getSharedBoardsForClient, { communicatorId });
+  const clientBoards = useQuery(api.phraseBoards.getBoardsForClient, { clientId: communicatorId });
   const router = useRouter();
 
   // Redirect non-caregivers
@@ -35,7 +35,7 @@ export default function ClientDetailPage({ params }: PageProps) {
     }
   }, [authLoading, user, profile, router]);
 
-  if (authLoading || profile === undefined || clientProfile === undefined || sharedBoards === undefined) {
+  if (authLoading || profile === undefined || clientProfile === undefined || clientBoards === undefined) {
     return <AnimatedLoading />;
   }
 
@@ -70,22 +70,22 @@ export default function ClientDetailPage({ params }: PageProps) {
 
         <div className="mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground">Shared Boards</h2>
-            <ShareBoardButton communicatorId={communicatorId} />
+            <h2 className="text-lg font-semibold text-foreground">{clientName}&apos;s Boards</h2>
+            <CreateBoardButton communicatorId={communicatorId} />
           </div>
 
-          {sharedBoards.length === 0 ? (
+          {clientBoards.length === 0 ? (
             <div className="text-center py-12 bg-surface rounded-xl border border-border">
               <FolderPlusIcon className="w-12 h-12 text-text-tertiary mx-auto mb-3" />
-              <p className="text-text-secondary mb-2">No boards shared yet</p>
+              <p className="text-text-secondary mb-2">No boards yet</p>
               <p className="text-text-tertiary text-sm">
-                Share a board to help {clientName} communicate
+                Create a board to help {clientName} communicate
               </p>
             </div>
           ) : (
             <div className="space-y-3">
-              {sharedBoards.map((share) => (
-                <SharedBoardCard key={share._id} share={share} />
+              {clientBoards.map((board) => (
+                <ClientBoardCard key={board._id} board={board} />
               ))}
             </div>
           )}

--- a/convex/phraseBoards.ts
+++ b/convex/phraseBoards.ts
@@ -2,7 +2,7 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { getUserIdentity } from './users';
 
-// Query: Get all phrase boards for current user (owned + shared)
+// Query: Get all phrase boards for current user (owned + assigned to them)
 export const getPhraseBoards = query({
   handler: async (ctx) => {
     const identity = await getUserIdentity(ctx);
@@ -10,39 +10,20 @@ export const getPhraseBoards = query({
       return [];
     }
 
-    // Get owned boards
+    // Get boards owned by the user (caregiver's boards)
     const ownedBoards = await ctx.db
       .query('phraseBoards')
       .withIndex('by_user_id', (q) => q.eq('userId', identity.subject))
       .collect();
 
-    // Get shared boards
-    const sharedBoardLinks = await ctx.db
-      .query('sharedBoards')
-      .withIndex('by_communicator', (q) => q.eq('communicatorId', identity.subject))
+    // Get boards assigned to this user as a client
+    const assignedBoards = await ctx.db
+      .query('phraseBoards')
+      .withIndex('by_client', (q) => q.eq('forClientId', identity.subject))
       .collect();
 
-    const sharedBoards = await Promise.all(
-      sharedBoardLinks.map(async (link) => {
-        const board = await ctx.db.get(link.boardId);
-        if (!board) return null;
-
-        // Get caregiver profile for display
-        const caregiverProfile = await ctx.db
-          .query('profiles')
-          .withIndex('by_user_id', (q) => q.eq('userId', link.caregiverId))
-          .first();
-
-        return {
-          board,
-          accessLevel: link.accessLevel,
-          sharedBy: caregiverProfile?.fullName || caregiverProfile?.email || 'Caregiver',
-        };
-      })
-    );
-
-    // Get phrases for owned boards
-    const ownedBoardsWithPhrases = await Promise.all(
+    // Process owned boards - resolve client names if forClientId is set
+    const ownedBoardsWithInfo = await Promise.all(
       ownedBoards.map(async (board) => {
         const phraseBoardPhrases = await ctx.db
           .query('phraseBoardPhrases')
@@ -56,49 +37,67 @@ export const getPhraseBoards = query({
           })
         );
 
+        // Get client name if this board is for a client
+        let forClientName = null;
+        if (board.forClientId) {
+          const clientProfile = await ctx.db
+            .query('profiles')
+            .withIndex('by_user_id', (q) => q.eq('userId', board.forClientId!))
+            .first();
+          forClientName = clientProfile?.fullName || clientProfile?.email || 'Client';
+        }
+
         return {
           ...board,
           phrase_board_phrases: phrases,
           isShared: false,
+          isOwner: true,
           accessLevel: 'edit' as const,
           sharedBy: null,
+          forClientName,
         };
       })
     );
 
-    // Get phrases for shared boards
-    const sharedBoardsWithPhrases = await Promise.all(
-      sharedBoards
-        .filter((sb): sb is NonNullable<typeof sb> => sb !== null)
-        .map(async ({ board, accessLevel, sharedBy }) => {
-          const phraseBoardPhrases = await ctx.db
-            .query('phraseBoardPhrases')
-            .withIndex('by_board', (q) => q.eq('boardId', board._id))
-            .collect();
+    // Process assigned boards (boards where this user is the client)
+    const assignedBoardsWithInfo = await Promise.all(
+      assignedBoards.map(async (board) => {
+        const phraseBoardPhrases = await ctx.db
+          .query('phraseBoardPhrases')
+          .withIndex('by_board', (q) => q.eq('boardId', board._id))
+          .collect();
 
-          const phrases = await Promise.all(
-            phraseBoardPhrases.map(async (pbp) => {
-              const phrase = await ctx.db.get(pbp.phraseId);
-              return { ...pbp, phrase };
-            })
-          );
+        const phrases = await Promise.all(
+          phraseBoardPhrases.map(async (pbp) => {
+            const phrase = await ctx.db.get(pbp.phraseId);
+            return { ...pbp, phrase };
+          })
+        );
 
-          return {
-            ...board,
-            phrase_board_phrases: phrases,
-            isShared: true,
-            accessLevel,
-            sharedBy,
-          };
-        })
+        // Get caregiver name
+        const caregiverProfile = await ctx.db
+          .query('profiles')
+          .withIndex('by_user_id', (q) => q.eq('userId', board.userId))
+          .first();
+
+        return {
+          ...board,
+          phrase_board_phrases: phrases,
+          isShared: true,
+          isOwner: false,
+          accessLevel: board.clientAccessLevel || 'view',
+          sharedBy: caregiverProfile?.fullName || caregiverProfile?.email || 'Caregiver',
+          forClientName: null,
+        };
+      })
     );
 
     // Combine and return all boards
-    return [...ownedBoardsWithPhrases, ...sharedBoardsWithPhrases];
+    return [...ownedBoardsWithInfo, ...assignedBoardsWithInfo];
   },
 });
 
-// Query: Get a single phrase board by ID (owned or shared)
+// Query: Get a single phrase board by ID (owned or assigned)
 export const getPhraseBoard = query({
   args: { id: v.id('phraseBoards') },
   handler: async (ctx, args) => {
@@ -112,34 +111,12 @@ export const getPhraseBoard = query({
       return null;
     }
 
-    // Check if user owns the board
+    // Check if user owns the board or is the assigned client
     const isOwner = board.userId === identity.subject;
+    const isAssignedClient = board.forClientId === identity.subject;
 
-    // Check if board is shared with user
-    let shareInfo = null;
-    if (!isOwner) {
-      const sharedBoardLinks = await ctx.db
-        .query('sharedBoards')
-        .withIndex('by_board', (q) => q.eq('boardId', args.id))
-        .collect();
-
-      const share = sharedBoardLinks.find(
-        (link) => link.communicatorId === identity.subject
-      );
-
-      if (!share) {
-        return null; // User has no access
-      }
-
-      const caregiverProfile = await ctx.db
-        .query('profiles')
-        .withIndex('by_user_id', (q) => q.eq('userId', share.caregiverId))
-        .first();
-
-      shareInfo = {
-        accessLevel: share.accessLevel,
-        sharedBy: caregiverProfile?.fullName || caregiverProfile?.email || 'Caregiver',
-      };
+    if (!isOwner && !isAssignedClient) {
+      return null; // User has no access
     }
 
     const phraseBoardPhrases = await ctx.db
@@ -154,12 +131,34 @@ export const getPhraseBoard = query({
       })
     );
 
+    // Get caregiver name for assigned clients
+    let sharedBy = null;
+    if (isAssignedClient && !isOwner) {
+      const caregiverProfile = await ctx.db
+        .query('profiles')
+        .withIndex('by_user_id', (q) => q.eq('userId', board.userId))
+        .first();
+      sharedBy = caregiverProfile?.fullName || caregiverProfile?.email || 'Caregiver';
+    }
+
+    // Get client name for owner
+    let forClientName = null;
+    if (isOwner && board.forClientId) {
+      const clientProfile = await ctx.db
+        .query('profiles')
+        .withIndex('by_user_id', (q) => q.eq('userId', board.forClientId!))
+        .first();
+      forClientName = clientProfile?.fullName || clientProfile?.email || 'Client';
+    }
+
     return {
       ...board,
       phrase_board_phrases: phrases,
-      isShared: !isOwner,
-      accessLevel: isOwner ? 'edit' : shareInfo?.accessLevel,
-      sharedBy: shareInfo?.sharedBy || null,
+      isShared: isAssignedClient && !isOwner,
+      isOwner,
+      accessLevel: isOwner ? 'edit' : (board.clientAccessLevel || 'view'),
+      sharedBy,
+      forClientName,
     };
   },
 });
@@ -169,6 +168,8 @@ export const addPhraseBoard = mutation({
   args: {
     name: v.string(),
     position: v.number(),
+    forClientId: v.optional(v.string()),
+    clientAccessLevel: v.optional(v.union(v.literal('view'), v.literal('edit'))),
   },
   handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
@@ -180,6 +181,8 @@ export const addPhraseBoard = mutation({
       userId: identity.subject,
       name: args.name,
       position: args.position,
+      forClientId: args.forClientId,
+      clientAccessLevel: args.forClientId ? (args.clientAccessLevel || 'view') : undefined,
     });
 
     return boardId;
@@ -263,29 +266,17 @@ export const addPhraseToBoard = mutation({
       throw new Error('Unauthorized - phrase');
     }
 
-    // Verify board access (owner or shared with edit access)
+    // Verify board access (owner or assigned client with edit access)
     const board = await ctx.db.get(args.boardId);
     if (!board) {
       throw new Error('Board not found');
     }
 
     const isOwner = board.userId === identity.subject;
-    let hasEditAccess = false;
+    const isAssignedClientWithEdit =
+      board.forClientId === identity.subject && board.clientAccessLevel === 'edit';
 
-    if (!isOwner) {
-      // Check if board is shared with edit access
-      const sharedBoardLinks = await ctx.db
-        .query('sharedBoards')
-        .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
-        .collect();
-
-      const share = sharedBoardLinks.find(
-        (link) => link.communicatorId === identity.subject && link.accessLevel === 'edit'
-      );
-      hasEditAccess = !!share;
-    }
-
-    if (!isOwner && !hasEditAccess) {
+    if (!isOwner && !isAssignedClientWithEdit) {
       throw new Error('Unauthorized - board');
     }
 
@@ -317,5 +308,71 @@ export const removePhraseFromBoard = mutation({
     if (link) {
       await ctx.db.delete(link._id);
     }
+  },
+});
+
+// Query: Get boards for a specific client (used by caregivers on dashboard)
+export const getBoardsForClient = query({
+  args: { clientId: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      return [];
+    }
+
+    // Get boards owned by current user that are for this client
+    const boards = await ctx.db
+      .query('phraseBoards')
+      .withIndex('by_client', (q) => q.eq('forClientId', args.clientId))
+      .collect();
+
+    // Filter to only boards owned by the current user
+    const ownedBoards = boards.filter((board) => board.userId === identity.subject);
+
+    return ownedBoards;
+  },
+});
+
+// Mutation: Update board client access level
+export const updateBoardClientAccess = mutation({
+  args: {
+    boardId: v.id('phraseBoards'),
+    accessLevel: v.union(v.literal('view'), v.literal('edit')),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    const board = await ctx.db.get(args.boardId);
+    if (!board || board.userId !== identity.subject) {
+      throw new Error('Unauthorized');
+    }
+
+    await ctx.db.patch(args.boardId, {
+      clientAccessLevel: args.accessLevel,
+    });
+  },
+});
+
+// Mutation: Unassign board from client (set forClientId to undefined)
+export const unassignBoardFromClient = mutation({
+  args: { boardId: v.id('phraseBoards') },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    const board = await ctx.db.get(args.boardId);
+    if (!board || board.userId !== identity.subject) {
+      throw new Error('Unauthorized');
+    }
+
+    await ctx.db.patch(args.boardId, {
+      forClientId: undefined,
+      clientAccessLevel: undefined,
+    });
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -39,10 +39,14 @@ export default defineSchema({
   }).index('by_user_id', ['userId']),
 
   phraseBoards: defineTable({
-    userId: v.string(), // Clerk user ID
+    userId: v.string(), // Clerk user ID (creator/owner)
     name: v.string(),
     position: v.number(),
-  }).index('by_user_id', ['userId']),
+    forClientId: v.optional(v.string()), // If set, this board is for a specific client
+    clientAccessLevel: v.optional(v.union(v.literal('view'), v.literal('edit'))), // Client's permission level
+  })
+    .index('by_user_id', ['userId'])
+    .index('by_client', ['forClientId']),
 
   phraseBoardPhrases: defineTable({
     phraseId: v.id('phrases'),


### PR DESCRIPTION
## Summary
- Boards now belong directly to a client via `forClientId` field instead of using `sharedBoards` junction table
- Caregivers see "For [Client Name]" on boards assigned to clients
- Communicators see "Shared by [Caregiver Name]" on boards assigned to them
- New "Create Board" modal in client detail page for creating boards for specific clients

## Changes
- Schema: Added `forClientId` and `clientAccessLevel` to `phraseBoards` table
- Backend: Updated queries/mutations to use new model
- UI: Updated BoardSelector, BoardGridPopup, client detail page
- New components: ClientBoardCard, CreateBoardButton, CreateBoardModal

## Test plan
- [ ] Log in as caregiver, go to dashboard, select a client
- [ ] Create a new board for the client with "Create Board" button
- [ ] Verify board appears in client's board list with correct access level
- [ ] Toggle access level and verify it updates
- [ ] Log in as communicator, verify board appears with "Shared by" tag
- [ ] Verify view-only boards hide edit controls, edit boards show them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create boards directly for clients from the dashboard
  * Toggle client board permissions between edit and view-only access levels
  * Two-step confirmation when removing board access from clients

* **Style**
  * Dashboard and board selectors now display which client each board is assigned to

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->