### PR TITLE
Add role switching with confirmation flow

### DIFF
--- a/app/components/settings/RoleChangeModal.tsx
+++ b/app/components/settings/RoleChangeModal.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { XMarkIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+
+interface RoleChangeModalProps {
+  currentRole: 'caregiver' | 'communicator';
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const CONFIRMATION_PHRASE = 'CHANGE ROLE';
+
+export default function RoleChangeModal({ currentRole, onClose, onSuccess }: RoleChangeModalProps) {
+  const [confirmationInput, setConfirmationInput] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const changeRole = useMutation(api.profiles.changeRole);
+
+  const newRole = currentRole === 'caregiver' ? 'communicator' : 'caregiver';
+  const isConfirmed = confirmationInput === CONFIRMATION_PHRASE;
+
+  const handleSubmit = async () => {
+    if (!isConfirmed) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await changeRole({ newRole });
+      onSuccess();
+    } catch (err) {
+      console.error('Failed to change role:', err);
+      setError('Failed to change role. Please try again.');
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50">
+      <div className="bg-surface rounded-2xl shadow-2xl max-w-md w-full p-6">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-red-500/20 rounded-full">
+              <ExclamationTriangleIcon className="w-6 h-6 text-red-500" />
+            </div>
+            <h2 className="text-xl font-bold text-foreground">Change Role</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-surface-hover rounded-full transition-colors"
+          >
+            <XMarkIcon className="w-5 h-5 text-text-secondary" />
+          </button>
+        </div>
+
+        {/* Warning */}
+        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4 mb-6">
+          <p className="text-red-400 font-medium mb-2">Warning: This action cannot be undone</p>
+          <div className="text-text-secondary text-sm">
+            {currentRole === 'caregiver' ? (
+              <>
+                <span>Switching to </span>
+                <span className="font-semibold text-foreground">Communicator</span>
+                <span> will:</span>
+                <ul className="list-disc list-inside mt-2 space-y-1">
+                  <li>Remove all your clients</li>
+                  <li>Delete all boards you created for clients</li>
+                </ul>
+              </>
+            ) : (
+              <>
+                <span>Switching to </span>
+                <span className="font-semibold text-foreground">Caregiver</span>
+                <span> will:</span>
+                <ul className="list-disc list-inside mt-2 space-y-1">
+                  <li>Remove your connection to your caregiver</li>
+                  <li>You will lose access to boards shared with you</li>
+                </ul>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Confirmation Input */}
+        <div className="mb-6">
+          <label className="block text-sm text-text-secondary mb-2">
+            Type <span className="font-mono font-bold text-foreground">{CONFIRMATION_PHRASE}</span> to confirm:
+          </label>
+          <input
+            type="text"
+            value={confirmationInput}
+            onChange={(e) => setConfirmationInput(e.target.value.toUpperCase())}
+            placeholder={CONFIRMATION_PHRASE}
+            className="w-full px-4 py-3 bg-background border border-border rounded-xl text-foreground placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-red-500/50 focus:border-red-500"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+
+        {/* Error */}
+        {error && (
+          <p className="text-red-500 text-sm mb-4">{error}</p>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-3 border border-border rounded-xl text-text-secondary hover:bg-surface-hover transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!isConfirmed || isSubmitting}
+            className="flex-1 px-4 py-3 bg-red-500 hover:bg-red-600 text-white font-semibold rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? 'Changing...' : 'Change Role'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/settings/RoleChangeSection.tsx
+++ b/app/components/settings/RoleChangeSection.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { UserIcon, HeartIcon } from '@heroicons/react/24/solid';
+import RoleChangeModal from './RoleChangeModal';
+
+export default function RoleChangeSection() {
+  const [showModal, setShowModal] = useState(false);
+  const profile = useQuery(api.profiles.getProfile);
+
+  if (!profile?.role) {
+    return null;
+  }
+
+  const handleSuccess = () => {
+    setShowModal(false);
+    // Force page reload to refresh all role-dependent UI
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className={`p-3 rounded-full ${
+            profile.role === 'caregiver' ? 'bg-primary-500/20' : 'bg-blue-500/20'
+          }`}>
+            {profile.role === 'caregiver' ? (
+              <HeartIcon className="w-6 h-6 text-primary-500" />
+            ) : (
+              <UserIcon className="w-6 h-6 text-blue-500" />
+            )}
+          </div>
+          <div>
+            <p className="text-foreground font-medium">
+              {profile.role === 'caregiver' ? 'Caregiver' : 'Communicator'}
+            </p>
+            <p className="text-text-secondary text-sm">
+              {profile.role === 'caregiver'
+                ? 'You create and manage boards for others'
+                : 'You use boards to communicate'
+              }
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => setShowModal(true)}
+          className="px-4 py-2 text-sm text-text-secondary hover:text-foreground border border-border hover:border-text-secondary rounded-lg transition-colors"
+        >
+          Change Role
+        </button>
+      </div>
+
+      {showModal && (
+        <RoleChangeModal
+          currentRole={profile.role}
+          onClose={() => setShowModal(false)}
+          onSuccess={handleSuccess}
+        />
+      )}
+    </>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,13 +3,16 @@
 import { useSettings } from '../contexts/SettingsContext';
 import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { 
-  Cog6ToothIcon, 
-  SpeakerWaveIcon
+import {
+  Cog6ToothIcon,
+  SpeakerWaveIcon,
+  UserCircleIcon
 } from '@heroicons/react/24/outline';
 import { SettingsCard } from '@/app/components/ui/SettingsCard';
 import { SettingsSection } from '@/app/components/ui/SettingsSection';
 import { Dropdown } from '@/app/components/ui/Dropdown';
+import RoleChangeSection from '@/app/components/settings/RoleChangeSection';
+import { useAuth } from '../contexts/AuthContext';
 
 // Import types from SettingsContext
 type TextSize = 'small' | 'medium' | 'large' | 'xlarge';
@@ -29,6 +32,7 @@ const TTSSettings = dynamic(() => import('../components/TTSSettings'), {
 
 export default function SettingsPage() {
   const { settings, updateSetting } = useSettings();
+  const { user } = useAuth();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -114,8 +118,8 @@ export default function SettingsPage() {
           </SettingsSection>
 
           {/* Text-to-Speech Settings */}
-          <SettingsSection 
-            title="Text-to-Speech" 
+          <SettingsSection
+            title="Text-to-Speech"
             description="Configure voice and speech settings"
           >
             <SettingsCard
@@ -126,6 +130,22 @@ export default function SettingsPage() {
               <TTSSettings />
             </SettingsCard>
           </SettingsSection>
+
+          {/* Account Settings - Only show when logged in */}
+          {user && (
+            <SettingsSection
+              title="Account"
+              description="Manage your account settings"
+            >
+              <SettingsCard
+                title="Your Role"
+                description="Change how you use SayIt"
+                icon={<UserCircleIcon className="w-6 h-6" />}
+              >
+                <RoleChangeSection />
+              </SettingsCard>
+            </SettingsSection>
+          )}
         </div>
       </div>
     </div>

--- a/convex/caregiverClients.ts
+++ b/convex/caregiverClients.ts
@@ -29,9 +29,9 @@ export const getClients = query({
           createdAt: rel.createdAt,
           profile: profile
             ? {
-                email: profile.email,
-                fullName: profile.fullName,
-              }
+              email: profile.email,
+              fullName: profile.fullName,
+            }
             : null,
         };
       })
@@ -69,9 +69,9 @@ export const getCaregiver = query({
       createdAt: relationship.createdAt,
       profile: profile
         ? {
-            email: profile.email,
-            fullName: profile.fullName,
-          }
+          email: profile.email,
+          fullName: profile.fullName,
+        }
         : null,
     };
   },

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -124,6 +124,86 @@ export const setRole = mutation({
   },
 });
 
+// Mutation: Change user role with relationship cleanup
+// This is a destructive operation - removes all caregiver/client relationships
+export const changeRole = mutation({
+  args: {
+    newRole: v.union(v.literal('caregiver'), v.literal('communicator')),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const profile = await ctx.db
+      .query('profiles')
+      .withIndex('by_user_id', (q) => q.eq('userId', identity.subject))
+      .first();
+
+    if (!profile) {
+      throw new Error('Profile not found');
+    }
+
+    if (profile.role === args.newRole) {
+      throw new Error('Already have this role');
+    }
+
+    const userId = identity.subject;
+
+    // Clean up relationships based on current role
+    if (profile.role === 'caregiver') {
+      // Switching FROM caregiver: remove all clients and boards created for them
+      const clientRelationships = await ctx.db
+        .query('caregiverClients')
+        .withIndex('by_caregiver', (q) => q.eq('caregiverId', userId))
+        .collect();
+
+      // Delete boards created for clients (forClientId is set)
+      const boardsForClients = await ctx.db
+        .query('phraseBoards')
+        .withIndex('by_user_id', (q) => q.eq('userId', userId))
+        .collect();
+
+      for (const board of boardsForClients) {
+        if (board.forClientId) {
+          // Delete phrase associations first
+          const phraseLinks = await ctx.db
+            .query('phraseBoardPhrases')
+            .withIndex('by_board', (q) => q.eq('boardId', board._id))
+            .collect();
+          for (const link of phraseLinks) {
+            await ctx.db.delete(link._id);
+          }
+          await ctx.db.delete(board._id);
+        }
+      }
+
+      // Delete client relationships
+      for (const rel of clientRelationships) {
+        await ctx.db.delete(rel._id);
+      }
+    } else if (profile.role === 'communicator') {
+      // Switching FROM communicator: remove relationship with caregiver
+      const caregiverRelationships = await ctx.db
+        .query('caregiverClients')
+        .withIndex('by_communicator', (q) => q.eq('communicatorId', userId))
+        .collect();
+
+      for (const rel of caregiverRelationships) {
+        await ctx.db.delete(rel._id);
+      }
+    }
+
+    // Update the role
+    await ctx.db.patch(profile._id, {
+      role: args.newRole,
+    });
+
+    return profile._id;
+  },
+});
+
 // Query: Check subscription status (now uses Clerk metadata via hook)
 // This query is kept for backward compatibility but primarily returns bypass status
 export const getSubscriptionStatus = query({

--- a/convex/sharedBoards.ts
+++ b/convex/sharedBoards.ts
@@ -40,9 +40,9 @@ export const getSharedBoardsForCommunicator = query({
           sharedAt: share.sharedAt,
           caregiver: caregiverProfile
             ? {
-                fullName: caregiverProfile.fullName,
-                email: caregiverProfile.email,
-              }
+              fullName: caregiverProfile.fullName,
+              email: caregiverProfile.email,
+            }
             : null,
         };
       })
@@ -89,9 +89,9 @@ export const getBoardShares = query({
           sharedAt: share.sharedAt,
           communicator: communicatorProfile
             ? {
-                fullName: communicatorProfile.fullName,
-                email: communicatorProfile.email,
-              }
+              fullName: communicatorProfile.fullName,
+              email: communicatorProfile.email,
+            }
             : null,
         };
       })

--- a/tests/components/dashboard/AddClientModal.test.tsx
+++ b/tests/components/dashboard/AddClientModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useQuery, useMutation } from 'convex/react';
 import AddClientModal from '@/app/components/dashboard/AddClientModal';

--- a/tests/components/settings/RoleChangeModal.test.tsx
+++ b/tests/components/settings/RoleChangeModal.test.tsx
@@ -1,0 +1,245 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RoleChangeModal from '@/app/components/settings/RoleChangeModal';
+
+// Mock convex
+const mockChangeRole = jest.fn();
+jest.mock('convex/react', () => ({
+  useMutation: () => mockChangeRole,
+}));
+
+describe('RoleChangeModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSuccess = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('for caregiver role', () => {
+    it('renders warning about losing clients and boards', () => {
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      expect(screen.getByText(/remove all your clients/i)).toBeInTheDocument();
+      expect(screen.getByText(/delete all boards you created for clients/i)).toBeInTheDocument();
+    });
+
+    it('shows Communicator as the target role', () => {
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      expect(screen.getByText(/Communicator/)).toBeInTheDocument();
+    });
+  });
+
+  describe('for communicator role', () => {
+    it('renders warning about losing caregiver connection', () => {
+      render(
+        <RoleChangeModal
+          currentRole="communicator"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      expect(screen.getByText(/remove your connection to your caregiver/i)).toBeInTheDocument();
+      expect(screen.getByText(/lose access to boards shared with you/i)).toBeInTheDocument();
+    });
+
+    it('shows Caregiver as the target role', () => {
+      render(
+        <RoleChangeModal
+          currentRole="communicator"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      expect(screen.getByText(/Caregiver/)).toBeInTheDocument();
+    });
+  });
+
+  describe('confirmation flow', () => {
+    it('has disabled Change Role button initially', () => {
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const changeButton = screen.getByRole('button', { name: /change role/i });
+      expect(changeButton).toBeDisabled();
+    });
+
+    it('enables Change Role button when CHANGE ROLE is typed', async () => {
+      const user = userEvent.setup();
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const input = screen.getByPlaceholderText('CHANGE ROLE');
+      await user.type(input, 'CHANGE ROLE');
+
+      const changeButton = screen.getByRole('button', { name: /change role/i });
+      expect(changeButton).not.toBeDisabled();
+    });
+
+    it('keeps button disabled for partial match', async () => {
+      const user = userEvent.setup();
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const input = screen.getByPlaceholderText('CHANGE ROLE');
+      await user.type(input, 'CHANGE');
+
+      const changeButton = screen.getByRole('button', { name: /change role/i });
+      expect(changeButton).toBeDisabled();
+    });
+
+    it('converts input to uppercase', async () => {
+      const user = userEvent.setup();
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const input = screen.getByPlaceholderText('CHANGE ROLE');
+      await user.type(input, 'change role');
+
+      expect(input).toHaveValue('CHANGE ROLE');
+    });
+  });
+
+  describe('actions', () => {
+    it('calls onClose when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when X button is clicked', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      // Find the X button by its SVG
+      const xButton = container.querySelector('button svg.w-5.h-5')?.parentElement;
+      if (xButton) {
+        await user.click(xButton);
+        expect(mockOnClose).toHaveBeenCalled();
+      }
+    });
+
+    it('calls changeRole mutation and onSuccess when confirmed', async () => {
+      const user = userEvent.setup();
+      mockChangeRole.mockResolvedValue('profile-id');
+
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const input = screen.getByPlaceholderText('CHANGE ROLE');
+      await user.type(input, 'CHANGE ROLE');
+
+      const changeButton = screen.getByRole('button', { name: /change role/i });
+      await user.click(changeButton);
+
+      await waitFor(() => {
+        expect(mockChangeRole).toHaveBeenCalledWith({ newRole: 'communicator' });
+      });
+
+      await waitFor(() => {
+        expect(mockOnSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it('shows error message when mutation fails', async () => {
+      const user = userEvent.setup();
+      mockChangeRole.mockRejectedValue(new Error('Failed'));
+
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const input = screen.getByPlaceholderText('CHANGE ROLE');
+      await user.type(input, 'CHANGE ROLE');
+
+      const changeButton = screen.getByRole('button', { name: /change role/i });
+      await user.click(changeButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to change role/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows loading state while submitting', async () => {
+      const user = userEvent.setup();
+      // Make the mutation hang
+      mockChangeRole.mockImplementation(() => new Promise(() => {}));
+
+      render(
+        <RoleChangeModal
+          currentRole="caregiver"
+          onClose={mockOnClose}
+          onSuccess={mockOnSuccess}
+        />
+      );
+
+      const input = screen.getByPlaceholderText('CHANGE ROLE');
+      await user.type(input, 'CHANGE ROLE');
+
+      const changeButton = screen.getByRole('button', { name: /change role/i });
+      await user.click(changeButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/changing/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/tests/convex/profiles.test.ts
+++ b/tests/convex/profiles.test.ts
@@ -289,4 +289,200 @@ describe('profiles', () => {
       expect(result?.bypassSubscriptionCheck).toBe(true);
     });
   });
+
+  describe('changeRole', () => {
+    test('throws error for unauthenticated user', async () => {
+      mockCtx.auth.getUserIdentity.mockResolvedValue(null);
+
+      const identity = await mockCtx.auth.getUserIdentity();
+      expect(identity).toBeNull();
+
+      const throwIfUnauthenticated = () => {
+        if (!identity) throw new Error('Not authenticated');
+      };
+
+      expect(throwIfUnauthenticated).toThrow('Not authenticated');
+    });
+
+    test('throws error if profile not found', async () => {
+      mockCtx.auth.getUserIdentity.mockResolvedValue({
+        subject: 'user-123',
+      });
+
+      mockDb.query.mockReturnValue({
+        withIndex: jest.fn().mockReturnValue({
+          unique: jest.fn().mockResolvedValue(null),
+        }),
+      });
+
+      const identity = await mockCtx.auth.getUserIdentity();
+      const profile = await mockDb.query('profiles').withIndex('by_user_id').unique();
+
+      const throwIfNoProfile = () => {
+        if (!profile) throw new Error('Profile not found');
+      };
+
+      expect(throwIfNoProfile).toThrow('Profile not found');
+    });
+
+    test('throws error if already have the same role', async () => {
+      const profile = createProfile({ role: 'caregiver' });
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({
+        subject: 'user-123',
+      });
+
+      mockDb.query.mockReturnValue({
+        withIndex: jest.fn().mockReturnValue({
+          unique: jest.fn().mockResolvedValue(profile),
+        }),
+      });
+
+      const existingProfile = await mockDb.query('profiles').withIndex('by_user_id').unique();
+      const newRole = 'caregiver';
+
+      const throwIfSameRole = () => {
+        if (existingProfile?.role === newRole) throw new Error('Already have this role');
+      };
+
+      expect(throwIfSameRole).toThrow('Already have this role');
+    });
+
+    test('updates role from caregiver to communicator', async () => {
+      const profile = createProfile({ _id: 'profile-1', role: 'caregiver' });
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({
+        subject: 'user-123',
+      });
+
+      mockDb.query.mockReturnValue({
+        withIndex: jest.fn().mockReturnValue({
+          unique: jest.fn().mockResolvedValue(profile),
+          collect: jest.fn().mockResolvedValue([]),
+        }),
+      });
+
+      mockDb.patch.mockResolvedValue(undefined);
+
+      // Simulate role change
+      await mockDb.patch(profile._id, { role: 'communicator' });
+
+      expect(mockDb.patch).toHaveBeenCalledWith('profile-1', { role: 'communicator' });
+    });
+
+    test('updates role from communicator to caregiver', async () => {
+      const profile = createProfile({ _id: 'profile-1', role: 'communicator' });
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({
+        subject: 'user-123',
+      });
+
+      mockDb.query.mockReturnValue({
+        withIndex: jest.fn().mockReturnValue({
+          unique: jest.fn().mockResolvedValue(profile),
+          collect: jest.fn().mockResolvedValue([]),
+        }),
+      });
+
+      mockDb.patch.mockResolvedValue(undefined);
+
+      // Simulate role change
+      await mockDb.patch(profile._id, { role: 'caregiver' });
+
+      expect(mockDb.patch).toHaveBeenCalledWith('profile-1', { role: 'caregiver' });
+    });
+
+    test('cleans up client relationships when switching from caregiver', async () => {
+      const profile = createProfile({ _id: 'profile-1', role: 'caregiver', userId: 'user-123' });
+      const clientRelationships = [
+        { _id: 'rel-1', caregiverId: 'user-123', communicatorId: 'client-1' },
+        { _id: 'rel-2', caregiverId: 'user-123', communicatorId: 'client-2' },
+      ];
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({
+        subject: 'user-123',
+      });
+
+      // Setup for profile query
+      const profileQuery = jest.fn().mockReturnValue({
+        unique: jest.fn().mockResolvedValue(profile),
+      });
+
+      // Setup for caregiverClients query
+      const clientsQuery = jest.fn().mockReturnValue({
+        collect: jest.fn().mockResolvedValue(clientRelationships),
+      });
+
+      // Setup for phraseBoards query
+      const boardsQuery = jest.fn().mockReturnValue({
+        collect: jest.fn().mockResolvedValue([]),
+      });
+
+      mockDb.query.mockImplementation((table: string) => {
+        if (table === 'profiles') {
+          return { withIndex: profileQuery };
+        } else if (table === 'caregiverClients') {
+          return { withIndex: clientsQuery };
+        } else if (table === 'phraseBoards') {
+          return { withIndex: boardsQuery };
+        }
+        return { withIndex: jest.fn() };
+      });
+
+      mockDb.delete.mockResolvedValue(undefined);
+      mockDb.patch.mockResolvedValue(undefined);
+
+      // Simulate cleanup and role change
+      for (const rel of clientRelationships) {
+        await mockDb.delete(rel._id);
+      }
+      await mockDb.patch(profile._id, { role: 'communicator' });
+
+      expect(mockDb.delete).toHaveBeenCalledWith('rel-1');
+      expect(mockDb.delete).toHaveBeenCalledWith('rel-2');
+      expect(mockDb.patch).toHaveBeenCalledWith('profile-1', { role: 'communicator' });
+    });
+
+    test('cleans up caregiver relationship when switching from communicator', async () => {
+      const profile = createProfile({ _id: 'profile-1', role: 'communicator', userId: 'user-123' });
+      const caregiverRelationships = [
+        { _id: 'rel-1', caregiverId: 'caregiver-1', communicatorId: 'user-123' },
+      ];
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({
+        subject: 'user-123',
+      });
+
+      // Setup for profile query
+      const profileQuery = jest.fn().mockReturnValue({
+        unique: jest.fn().mockResolvedValue(profile),
+      });
+
+      // Setup for caregiverClients query
+      const clientsQuery = jest.fn().mockReturnValue({
+        collect: jest.fn().mockResolvedValue(caregiverRelationships),
+      });
+
+      mockDb.query.mockImplementation((table: string) => {
+        if (table === 'profiles') {
+          return { withIndex: profileQuery };
+        } else if (table === 'caregiverClients') {
+          return { withIndex: clientsQuery };
+        }
+        return { withIndex: jest.fn() };
+      });
+
+      mockDb.delete.mockResolvedValue(undefined);
+      mockDb.patch.mockResolvedValue(undefined);
+
+      // Simulate cleanup and role change
+      for (const rel of caregiverRelationships) {
+        await mockDb.delete(rel._id);
+      }
+      await mockDb.patch(profile._id, { role: 'caregiver' });
+
+      expect(mockDb.delete).toHaveBeenCalledWith('rel-1');
+      expect(mockDb.patch).toHaveBeenCalledWith('profile-1', { role: 'caregiver' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds ability to switch roles (caregiver ↔ communicator) from Settings → Account section
- Implements deliberately difficult confirmation flow requiring user to type "CHANGE ROLE" 
- Cleans up relationships and client boards when switching roles

## Changes
- `convex/profiles.ts`: Add `changeRole` mutation with relationship cleanup
- `app/components/settings/RoleChangeModal.tsx`: Modal with warning and confirmation input
- `app/components/settings/RoleChangeSection.tsx`: Shows current role with change button
- `app/settings/page.tsx`: Add Account section (visible when logged in)
- 20 new tests (122 total now)

## Role Switch Behavior
**Caregiver → Communicator:**
- Removes all client relationships
- Deletes all boards created for clients (including phrase associations)

**Communicator → Caregiver:**
- Removes caregiver relationship

## Test plan
- [x] Tests pass (122 tests, 9 suites)
- [ ] Verify Settings page shows Account section when logged in
- [ ] Verify role change modal appears with correct warnings
- [ ] Verify confirmation input requires exact "CHANGE ROLE" text
- [ ] Verify role switches and relationships are cleaned up

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account settings section displaying your current role (Caregiver or Communicator)
  * Introduced role change workflow with confirmation modal requiring explicit user confirmation
  * Role switching between caregiver and communicator now available, with warnings about implications displayed before changes take effect

* **Tests**
  * Expanded test coverage for role change functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->