### PR TITLE
Gate caregiver dashboard behind subscription

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -6,12 +6,14 @@ import { useAuth } from '../contexts/AuthContext';
 import { usePathname } from 'next/navigation';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
+import { useSubscription } from '@/app/hooks/useSubscription';
 import {
   QuestionMarkCircleIcon,
   HomeIcon,
   Cog6ToothIcon,
   ArrowRightStartOnRectangleIcon,
-  UsersIcon
+  UsersIcon,
+  LockClosedIcon
 } from '@heroicons/react/24/outline';
 import { Tooltip } from 'react-tooltip';
 import { UserButton } from '@clerk/nextjs';
@@ -20,6 +22,7 @@ export default function Sidebar() {
   const { user } = useAuth();
   const pathname = usePathname();
   const profile = useQuery(api.profiles.getProfile);
+  const { isActive: hasSubscription } = useSubscription();
 
   const isCaregiver = profile?.role === 'caregiver';
 
@@ -47,8 +50,17 @@ export default function Sidebar() {
         {user && isCaregiver && (
           <SidebarItem
             href="/dashboard"
-            icon={<UsersIcon className="w-6 h-6" />}
-            title="Clients"
+            icon={
+              hasSubscription ? (
+                <UsersIcon className="w-6 h-6" />
+              ) : (
+                <div className="relative">
+                  <UsersIcon className="w-6 h-6" />
+                  <LockClosedIcon className="w-3 h-3 absolute -bottom-1 -right-1 text-text-tertiary" />
+                </div>
+              )
+            }
+            title={hasSubscription ? "Clients" : "Clients (Pro)"}
             isActive={pathname?.startsWith('/dashboard') ?? false}
           />
         )}

--- a/app/dashboard/client/[id]/page.tsx
+++ b/app/dashboard/client/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/app/contexts/AuthContext';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
+import SubscriptionWrapper from '@/app/components/SubscriptionWrapper';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { ArrowLeftIcon, UserIcon, FolderPlusIcon } from '@heroicons/react/24/outline';
@@ -56,40 +57,60 @@ export default function ClientDetailPage({ params }: PageProps) {
           <span>Back to clients</span>
         </Link>
 
-        <div className="flex items-center gap-4 mb-8">
-          <div className="p-3 rounded-full bg-primary-500/10">
-            <UserIcon className="w-8 h-8 text-primary-500" />
+        <SubscriptionWrapper
+          fallback={
+            <div className="text-center py-16">
+              <div className="p-4 rounded-full bg-primary-500/10 w-fit mx-auto mb-6">
+                <UserIcon className="w-12 h-12 text-primary-500" />
+              </div>
+              <h2 className="text-2xl font-bold text-foreground mb-2">Client Management</h2>
+              <p className="text-text-secondary mb-6 max-w-md mx-auto">
+                Manage client boards and create personalized communication tools with a Pro subscription.
+              </p>
+              <a
+                href="/pricing"
+                className="inline-block px-6 py-3 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-xl transition-colors"
+              >
+                Upgrade to Pro
+              </a>
+            </div>
+          }
+        >
+          <div className="flex items-center gap-4 mb-8">
+            <div className="p-3 rounded-full bg-primary-500/10">
+              <UserIcon className="w-8 h-8 text-primary-500" />
+            </div>
+            <div className="flex-1">
+              <h1 className="text-2xl font-bold text-foreground">{clientName}</h1>
+              {clientProfile?.fullName && clientProfile?.email && (
+                <p className="text-text-secondary">{clientProfile.email}</p>
+              )}
+            </div>
           </div>
-          <div className="flex-1">
-            <h1 className="text-2xl font-bold text-foreground">{clientName}</h1>
-            {clientProfile?.fullName && clientProfile?.email && (
-              <p className="text-text-secondary">{clientProfile.email}</p>
+
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-foreground">{clientName}&apos;s Boards</h2>
+              <CreateBoardButton communicatorId={communicatorId} />
+            </div>
+
+            {clientBoards.length === 0 ? (
+              <div className="text-center py-12 bg-surface rounded-xl border border-border">
+                <FolderPlusIcon className="w-12 h-12 text-text-tertiary mx-auto mb-3" />
+                <p className="text-text-secondary mb-2">No boards yet</p>
+                <p className="text-text-tertiary text-sm">
+                  Create a board to help {clientName} communicate
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {clientBoards.map((board) => (
+                  <ClientBoardCard key={board._id} board={board} />
+                ))}
+              </div>
             )}
           </div>
-        </div>
-
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground">{clientName}&apos;s Boards</h2>
-            <CreateBoardButton communicatorId={communicatorId} />
-          </div>
-
-          {clientBoards.length === 0 ? (
-            <div className="text-center py-12 bg-surface rounded-xl border border-border">
-              <FolderPlusIcon className="w-12 h-12 text-text-tertiary mx-auto mb-3" />
-              <p className="text-text-secondary mb-2">No boards yet</p>
-              <p className="text-text-tertiary text-sm">
-                Create a board to help {clientName} communicate
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {clientBoards.map((board) => (
-                <ClientBoardCard key={board._id} board={board} />
-              ))}
-            </div>
-          )}
-        </div>
+        </SubscriptionWrapper>
       </div>
     </div>
   );

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
 import ClientList from '@/app/components/dashboard/ClientList';
+import SubscriptionWrapper from '@/app/components/SubscriptionWrapper';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { UsersIcon } from '@heroicons/react/24/outline';
@@ -36,17 +37,37 @@ export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-background p-6">
       <div className="max-w-4xl mx-auto">
-        <div className="flex items-center gap-3 mb-8">
-          <div className="p-3 rounded-full bg-primary-500/10">
-            <UsersIcon className="w-8 h-8 text-primary-500" />
+        <SubscriptionWrapper
+          fallback={
+            <div className="text-center py-16">
+              <div className="p-4 rounded-full bg-primary-500/10 w-fit mx-auto mb-6">
+                <UsersIcon className="w-12 h-12 text-primary-500" />
+              </div>
+              <h2 className="text-2xl font-bold text-foreground mb-2">Client Management</h2>
+              <p className="text-text-secondary mb-6 max-w-md mx-auto">
+                Manage multiple clients, create personalized boards, and track their communication needs with a Pro subscription.
+              </p>
+              <a
+                href="/pricing"
+                className="inline-block px-6 py-3 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-xl transition-colors"
+              >
+                Upgrade to Pro
+              </a>
+            </div>
+          }
+        >
+          <div className="flex items-center gap-3 mb-8">
+            <div className="p-3 rounded-full bg-primary-500/10">
+              <UsersIcon className="w-8 h-8 text-primary-500" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-foreground">My Clients</h1>
+              <p className="text-text-secondary">Manage your clients and their boards</p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">My Clients</h1>
-            <p className="text-text-secondary">Manage your clients and their boards</p>
-          </div>
-        </div>
 
-        <ClientList />
+          <ClientList />
+        </SubscriptionWrapper>
       </div>
     </div>
   );

--- a/tests/components/dashboard/AddClientModal.test.tsx
+++ b/tests/components/dashboard/AddClientModal.test.tsx
@@ -49,7 +49,7 @@ describe('AddClientModal', () => {
   it('shows helper text about existing account', () => {
     render(<AddClientModal onClose={mockOnClose} />);
 
-    expect(screen.getByText(/must have an existing sayit account/i)).toBeInTheDocument();
+    expect(screen.getByText(/must have an existing sayit! account/i)).toBeInTheDocument();
   });
 
   it('shows found user when profile exists', () => {


### PR DESCRIPTION
## Summary
Require active subscription to access caregiver dashboard and client management features.

## Changes
- `/dashboard` page wrapped with `SubscriptionWrapper` - shows upgrade prompt for non-subscribers
- `/dashboard/client/[id]` page wrapped with `SubscriptionWrapper` - shows upgrade prompt for non-subscribers
- Sidebar shows lock icon + "(Pro)" tooltip on Clients link for non-subscribers
- Fixed test for SayIt! branding change

## User Experience
- Caregiver role selection still works without subscription
- Non-subscribers see the Clients link with a lock indicator
- Clicking shows a friendly upgrade prompt instead of the dashboard
- Subscribers get full access to client management

## Test plan
- [x] Tests pass (122 tests)
- [ ] Verify non-subscriber caregivers see upgrade prompt on /dashboard
- [ ] Verify sidebar shows lock icon for non-subscribers
- [ ] Verify subscribers have full access

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clients feature is now exclusive to Pro subscribers, displaying a lock icon for standard users.
  * Client Management and detail pages are gated behind Pro subscription with upgrade prompts.
  * Subscription status now determines access to client-related features across the dashboard.

* **Tests**
  * Updated test assertion text for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->