### PR TITLE
Add client connection request flow (#145)

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -60,7 +60,7 @@ export default function Sidebar() {
                 </div>
               )
             }
-            title={hasSubscription ? "Clients" : "Clients (Pro)"}
+            title={hasSubscription ? 'Clients' : 'Clients (Pro)'}
             isActive={pathname?.startsWith('/dashboard') ?? false}
           />
         )}

--- a/app/components/connection/ConnectionRequestCard.tsx
+++ b/app/components/connection/ConnectionRequestCard.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { UserIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface ConnectionRequestCardProps {
+  request: {
+    _id: Id<'connectionRequests'>;
+    caregiverId: string;
+    createdAt: number;
+    caregiver: {
+      fullName?: string;
+      email: string;
+    } | null;
+  };
+}
+
+export default function ConnectionRequestCard({ request }: ConnectionRequestCardProps) {
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [isRejecting, setIsRejecting] = useState(false);
+  const acceptRequest = useMutation(api.connectionRequests.acceptConnectionRequest);
+  const rejectRequest = useMutation(api.connectionRequests.rejectConnectionRequest);
+
+  const handleAccept = async () => {
+    setIsAccepting(true);
+    try {
+      await acceptRequest({ requestId: request._id });
+    } catch (err) {
+      console.error('Failed to accept request:', err);
+      setIsAccepting(false);
+    }
+  };
+
+  const handleReject = async () => {
+    setIsRejecting(true);
+    try {
+      await rejectRequest({ requestId: request._id });
+    } catch (err) {
+      console.error('Failed to reject request:', err);
+      setIsRejecting(false);
+    }
+  };
+
+  const displayName = request.caregiver?.fullName || request.caregiver?.email || 'Unknown';
+  const isProcessing = isAccepting || isRejecting;
+
+  return (
+    <div className="bg-surface rounded-xl border border-border p-4">
+      <div className="flex items-center gap-4">
+        <div className="p-3 rounded-full bg-primary-500/10">
+          <UserIcon className="w-6 h-6 text-primary-500" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-foreground truncate">{displayName}</h3>
+          {request.caregiver?.fullName && request.caregiver?.email && (
+            <p className="text-text-tertiary text-sm truncate">{request.caregiver.email}</p>
+          )}
+          <p className="text-text-secondary text-sm mt-1">wants to connect with you</p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleReject}
+            disabled={isProcessing}
+            className="p-2 rounded-lg bg-surface-hover hover:bg-red-500/10 text-text-secondary hover:text-red-500 transition-colors disabled:opacity-50"
+            title="Decline"
+          >
+            <XMarkIcon className="w-5 h-5" />
+          </button>
+          <button
+            onClick={handleAccept}
+            disabled={isProcessing}
+            className="px-4 py-2 rounded-lg bg-primary-500 hover:bg-primary-600 text-white font-medium transition-colors disabled:opacity-50 flex items-center gap-2"
+          >
+            {isAccepting ? (
+              'Accepting...'
+            ) : (
+              <>
+                <CheckIcon className="w-4 h-4" />
+                Accept
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/connection/ConnectionRequestsBanner.tsx
+++ b/app/components/connection/ConnectionRequestsBanner.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { BellAlertIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import ConnectionRequestCard from './ConnectionRequestCard';
+
+export default function ConnectionRequestsBanner() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const pendingRequests = useQuery(api.connectionRequests.getPendingRequestsForCommunicator);
+
+  // Don't render anything while loading or if no requests
+  if (pendingRequests === undefined || pendingRequests.length === 0) {
+    return null;
+  }
+
+  const requestCount = pendingRequests.length;
+
+  return (
+    <div className="mb-4">
+      {/* Collapsed Banner */}
+      {!isExpanded && (
+        <button
+          onClick={() => setIsExpanded(true)}
+          className="w-full bg-primary-500/10 border border-primary-500/30 rounded-xl p-4 flex items-center gap-3 hover:bg-primary-500/20 transition-colors text-left"
+        >
+          <div className="p-2 rounded-full bg-primary-500/20">
+            <BellAlertIcon className="w-5 h-5 text-primary-500" />
+          </div>
+          <div className="flex-1">
+            <p className="font-medium text-foreground">
+              {requestCount} connection {requestCount === 1 ? 'request' : 'requests'}
+            </p>
+            <p className="text-text-secondary text-sm">
+              Tap to view and respond
+            </p>
+          </div>
+          <span className="text-primary-500 font-medium text-sm">View</span>
+        </button>
+      )}
+
+      {/* Expanded View */}
+      {isExpanded && (
+        <div className="bg-surface rounded-xl border border-border p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+              <BellAlertIcon className="w-5 h-5 text-primary-500" />
+              Connection Requests
+            </h2>
+            <button
+              onClick={() => setIsExpanded(false)}
+              className="p-2 rounded-lg hover:bg-surface-hover transition-colors"
+            >
+              <XMarkIcon className="w-5 h-5 text-text-secondary" />
+            </button>
+          </div>
+
+          <p className="text-text-secondary text-sm">
+            Accept to let caregivers create boards for you. You can remove them later from settings.
+          </p>
+
+          <div className="space-y-3">
+            {pendingRequests.map((request) => (
+              <ConnectionRequestCard key={request._id} request={request} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/dashboard/AddClientModal.tsx
+++ b/app/components/dashboard/AddClientModal.tsx
@@ -12,8 +12,9 @@ interface AddClientModalProps {
 export default function AddClientModal({ onClose }: AddClientModalProps) {
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [isAdding, setIsAdding] = useState(false);
-  const addClient = useMutation(api.caregiverClients.addClient);
+  const [isSending, setIsSending] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const createRequest = useMutation(api.connectionRequests.createConnectionRequest);
 
   // Query to find user by email
   const foundProfile = useQuery(
@@ -40,14 +41,15 @@ export default function AddClientModal({ onClose }: AddClientModalProps) {
       return;
     }
 
-    setIsAdding(true);
+    setIsSending(true);
     try {
-      await addClient({ communicatorId: foundProfile.userId });
-      onClose();
+      await createRequest({ communicatorId: foundProfile.userId });
+      setSuccess(true);
+      setTimeout(() => onClose(), 1500);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to add client';
+      const message = err instanceof Error ? err.message : 'Failed to send request';
       setError(message);
-      setIsAdding(false);
+      setIsSending(false);
     }
   };
 
@@ -86,7 +88,7 @@ export default function AddClientModal({ onClose }: AddClientModalProps) {
               autoFocus
             />
             <p className="mt-2 text-text-tertiary text-sm">
-              The client must have an existing SayIt! account
+              They must accept your request before you can create boards for them
             </p>
           </div>
 
@@ -96,7 +98,13 @@ export default function AddClientModal({ onClose }: AddClientModalProps) {
             </div>
           )}
 
-          {foundProfile && !error && (
+          {success && (
+            <div className="mb-4 p-3 rounded-xl bg-green-500/10 border border-green-500/20 text-green-400 text-sm">
+              Request sent! Waiting for {foundProfile?.fullName || foundProfile?.email} to accept.
+            </div>
+          )}
+
+          {foundProfile && !error && !success && (
             <div className="mb-4 p-3 rounded-xl bg-green-500/10 border border-green-500/20 text-green-400 text-sm">
               Found: {foundProfile.fullName || foundProfile.email}
             </div>
@@ -108,15 +116,17 @@ export default function AddClientModal({ onClose }: AddClientModalProps) {
               onClick={onClose}
               className="flex-1 px-4 py-3 bg-surface-hover hover:bg-background text-foreground rounded-xl transition-colors"
             >
-              Cancel
+              {success ? 'Close' : 'Cancel'}
             </button>
-            <button
-              type="submit"
-              disabled={isAdding || !email.trim()}
-              className="flex-1 px-4 py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isAdding ? 'Adding...' : 'Add Client'}
-            </button>
+            {!success && (
+              <button
+                type="submit"
+                disabled={isSending || !email.trim()}
+                className="flex-1 px-4 py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSending ? 'Sending...' : 'Send Request'}
+              </button>
+            )}
           </div>
         </form>
       </div>

--- a/app/components/dashboard/ClientList.tsx
+++ b/app/components/dashboard/ClientList.tsx
@@ -3,12 +3,14 @@
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import ClientCard from './ClientCard';
+import PendingRequestCard from './PendingRequestCard';
 import AddClientButton from './AddClientButton';
 
 export default function ClientList() {
   const clients = useQuery(api.caregiverClients.getClients);
+  const pendingRequests = useQuery(api.connectionRequests.getSentRequestsForCaregiver);
 
-  if (clients === undefined) {
+  if (clients === undefined || pendingRequests === undefined) {
     return (
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
@@ -18,22 +20,44 @@ export default function ClientList() {
     );
   }
 
+  const hasNoClientsOrRequests = clients.length === 0 && pendingRequests.length === 0;
+
   return (
     <div className="space-y-4">
       <AddClientButton />
 
-      {clients.length === 0 ? (
+      {hasNoClientsOrRequests ? (
         <div className="text-center py-12 bg-surface rounded-xl border border-border">
           <p className="text-text-secondary mb-2">No clients yet</p>
           <p className="text-text-tertiary text-sm">
-            Add your first client to start creating boards for them
+            Send a request to add your first client
           </p>
         </div>
       ) : (
         <div className="space-y-3">
-          {clients.map((client) => (
-            <ClientCard key={client._id} client={client} />
-          ))}
+          {pendingRequests.length > 0 && (
+            <>
+              <h3 className="text-sm font-medium text-text-secondary uppercase tracking-wide">
+                Pending Requests
+              </h3>
+              {pendingRequests.map((request) => (
+                <PendingRequestCard key={request._id} request={request} />
+              ))}
+            </>
+          )}
+
+          {clients.length > 0 && (
+            <>
+              {pendingRequests.length > 0 && (
+                <h3 className="text-sm font-medium text-text-secondary uppercase tracking-wide mt-6">
+                  Connected Clients
+                </h3>
+              )}
+              {clients.map((client) => (
+                <ClientCard key={client._id} client={client} />
+              ))}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/app/components/dashboard/PendingRequestCard.tsx
+++ b/app/components/dashboard/PendingRequestCard.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { UserIcon, ClockIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface PendingRequestCardProps {
+  request: {
+    _id: Id<'connectionRequests'>;
+    communicatorId: string;
+    createdAt: number;
+    communicator: {
+      fullName?: string;
+      email: string;
+    } | null;
+  };
+}
+
+export default function PendingRequestCard({ request }: PendingRequestCardProps) {
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const cancelRequest = useMutation(api.connectionRequests.cancelConnectionRequest);
+
+  const handleCancel = async () => {
+    setIsCancelling(true);
+    try {
+      await cancelRequest({ requestId: request._id });
+    } catch (err) {
+      console.error('Failed to cancel request:', err);
+      setIsCancelling(false);
+      setShowConfirm(false);
+    }
+  };
+
+  const displayName = request.communicator?.fullName || request.communicator?.email || 'Unknown';
+
+  return (
+    <div className="bg-surface rounded-xl border border-yellow-500/30 p-4">
+      <div className="flex items-center gap-4">
+        <div className="p-3 rounded-full bg-yellow-500/10">
+          <UserIcon className="w-6 h-6 text-yellow-500" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-foreground truncate">{displayName}</h3>
+          {request.communicator?.fullName && request.communicator?.email && (
+            <p className="text-text-tertiary text-sm truncate">{request.communicator.email}</p>
+          )}
+          <div className="flex items-center gap-1 mt-1 text-yellow-500 text-sm">
+            <ClockIcon className="w-4 h-4" />
+            <span>Pending acceptance</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {showConfirm ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-3 py-1 text-sm rounded-lg bg-surface-hover text-text-secondary hover:bg-background transition-colors"
+                disabled={isCancelling}
+              >
+                Keep
+              </button>
+              <button
+                onClick={handleCancel}
+                disabled={isCancelling}
+                className="px-3 py-1 text-sm rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors disabled:opacity-50"
+              >
+                {isCancelling ? 'Cancelling...' : 'Cancel'}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowConfirm(true)}
+              className="p-2 rounded-lg text-text-tertiary hover:text-red-500 hover:bg-red-500/10 transition-colors"
+              title="Cancel request"
+            >
+              <XMarkIcon className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/app/contexts/AuthContext';
 import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
 import HomeFeatures from '@/app/components/home/HomeFeatures';
 import PhrasesInterface from '@/app/components/home/PhrasesInterface';
+import ConnectionRequestsBanner from '@/app/components/connection/ConnectionRequestsBanner';
 
 export default function Home() {
   const { user, loading: authLoading } = useAuth();
@@ -17,7 +18,10 @@ export default function Home() {
       {!user ? (
         <HomeFeatures />
       ) : (
-        <PhrasesInterface />
+        <>
+          <ConnectionRequestsBanner />
+          <PhrasesInterface />
+        </>
       )}
     </div>
   );

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as caregiverClients from "../caregiverClients.js";
+import type * as connectionRequests from "../connectionRequests.js";
 import type * as phraseBoards from "../phraseBoards.js";
 import type * as phrases from "../phrases.js";
 import type * as profiles from "../profiles.js";
@@ -23,6 +24,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   caregiverClients: typeof caregiverClients;
+  connectionRequests: typeof connectionRequests;
   phraseBoards: typeof phraseBoards;
   phrases: typeof phrases;
   profiles: typeof profiles;

--- a/convex/connectionRequests.ts
+++ b/convex/connectionRequests.ts
@@ -1,0 +1,263 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+import { getUserIdentity } from './users';
+
+// Query: Get pending requests FOR the current communicator
+export const getPendingRequestsForCommunicator = query({
+  handler: async (ctx) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      return [];
+    }
+
+    const requests = await ctx.db
+      .query('connectionRequests')
+      .withIndex('by_communicator', (q) => q.eq('communicatorId', identity.subject))
+      .collect();
+
+    // Filter to only pending and get caregiver profiles
+    const pendingRequests = await Promise.all(
+      requests
+        .filter((req) => req.status === 'pending')
+        .map(async (req) => {
+          const caregiverProfile = await ctx.db
+            .query('profiles')
+            .withIndex('by_user_id', (q) => q.eq('userId', req.caregiverId))
+            .first();
+
+          return {
+            _id: req._id,
+            caregiverId: req.caregiverId,
+            createdAt: req.createdAt,
+            caregiver: caregiverProfile
+              ? {
+                fullName: caregiverProfile.fullName,
+                email: caregiverProfile.email,
+              }
+              : null,
+          };
+        })
+    );
+
+    return pendingRequests;
+  },
+});
+
+// Query: Get sent requests BY the current caregiver
+export const getSentRequestsForCaregiver = query({
+  handler: async (ctx) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      return [];
+    }
+
+    const requests = await ctx.db
+      .query('connectionRequests')
+      .withIndex('by_caregiver', (q) => q.eq('caregiverId', identity.subject))
+      .collect();
+
+    // Filter to only pending and get communicator profiles
+    const pendingRequests = await Promise.all(
+      requests
+        .filter((req) => req.status === 'pending')
+        .map(async (req) => {
+          const communicatorProfile = await ctx.db
+            .query('profiles')
+            .withIndex('by_user_id', (q) => q.eq('userId', req.communicatorId))
+            .first();
+
+          return {
+            _id: req._id,
+            communicatorId: req.communicatorId,
+            createdAt: req.createdAt,
+            communicator: communicatorProfile
+              ? {
+                fullName: communicatorProfile.fullName,
+                email: communicatorProfile.email,
+              }
+              : null,
+          };
+        })
+    );
+
+    return pendingRequests;
+  },
+});
+
+// Mutation: Create a connection request (caregiver requests to add communicator)
+export const createConnectionRequest = mutation({
+  args: {
+    communicatorId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const caregiverId = identity.subject;
+
+    // Verify the caregiver has the correct role
+    const caregiverProfile = await ctx.db
+      .query('profiles')
+      .withIndex('by_user_id', (q) => q.eq('userId', caregiverId))
+      .first();
+
+    if (!caregiverProfile || caregiverProfile.role !== 'caregiver') {
+      throw new Error('Only caregivers can send connection requests');
+    }
+
+    // Verify the communicator exists and has communicator role
+    const communicatorProfile = await ctx.db
+      .query('profiles')
+      .withIndex('by_user_id', (q) => q.eq('userId', args.communicatorId))
+      .first();
+
+    if (!communicatorProfile) {
+      throw new Error('User not found');
+    }
+
+    if (communicatorProfile.role !== 'communicator') {
+      throw new Error('Can only send requests to communicators');
+    }
+
+    // Check if already connected
+    const existingClient = await ctx.db
+      .query('caregiverClients')
+      .withIndex('by_caregiver', (q) => q.eq('caregiverId', caregiverId))
+      .collect();
+
+    const alreadyConnected = existingClient.find(
+      (rel) => rel.communicatorId === args.communicatorId
+    );
+
+    if (alreadyConnected) {
+      throw new Error('Already connected to this client');
+    }
+
+    // Check if pending request already exists
+    const existingRequests = await ctx.db
+      .query('connectionRequests')
+      .withIndex('by_caregiver', (q) => q.eq('caregiverId', caregiverId))
+      .collect();
+
+    const pendingRequest = existingRequests.find(
+      (req) => req.communicatorId === args.communicatorId && req.status === 'pending'
+    );
+
+    if (pendingRequest) {
+      throw new Error('Connection request already pending');
+    }
+
+    // Create the request
+    return await ctx.db.insert('connectionRequests', {
+      caregiverId,
+      communicatorId: args.communicatorId,
+      status: 'pending',
+      createdAt: Date.now(),
+    });
+  },
+});
+
+// Mutation: Accept a connection request (communicator accepts)
+export const acceptConnectionRequest = mutation({
+  args: {
+    requestId: v.id('connectionRequests'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const request = await ctx.db.get(args.requestId);
+    if (!request) {
+      throw new Error('Request not found');
+    }
+
+    // Verify the current user is the communicator
+    if (request.communicatorId !== identity.subject) {
+      throw new Error('Not authorized to accept this request');
+    }
+
+    if (request.status !== 'pending') {
+      throw new Error('Request is no longer pending');
+    }
+
+    // Create the caregiverClients relationship
+    await ctx.db.insert('caregiverClients', {
+      caregiverId: request.caregiverId,
+      communicatorId: request.communicatorId,
+      createdAt: Date.now(),
+    });
+
+    // Delete the request (or update status to accepted)
+    await ctx.db.delete(args.requestId);
+
+    return { success: true };
+  },
+});
+
+// Mutation: Reject a connection request (communicator rejects)
+export const rejectConnectionRequest = mutation({
+  args: {
+    requestId: v.id('connectionRequests'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const request = await ctx.db.get(args.requestId);
+    if (!request) {
+      throw new Error('Request not found');
+    }
+
+    // Verify the current user is the communicator
+    if (request.communicatorId !== identity.subject) {
+      throw new Error('Not authorized to reject this request');
+    }
+
+    if (request.status !== 'pending') {
+      throw new Error('Request is no longer pending');
+    }
+
+    // Delete the request
+    await ctx.db.delete(args.requestId);
+
+    return { success: true };
+  },
+});
+
+// Mutation: Cancel a connection request (caregiver cancels their own request)
+export const cancelConnectionRequest = mutation({
+  args: {
+    requestId: v.id('connectionRequests'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const request = await ctx.db.get(args.requestId);
+    if (!request) {
+      throw new Error('Request not found');
+    }
+
+    // Verify the current user is the caregiver who sent it
+    if (request.caregiverId !== identity.subject) {
+      throw new Error('Not authorized to cancel this request');
+    }
+
+    if (request.status !== 'pending') {
+      throw new Error('Request is no longer pending');
+    }
+
+    // Delete the request
+    await ctx.db.delete(args.requestId);
+
+    return { success: true };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -20,6 +20,15 @@ export default defineSchema({
     .index('by_caregiver', ['caregiverId'])
     .index('by_communicator', ['communicatorId']),
 
+  connectionRequests: defineTable({
+    caregiverId: v.string(), // Clerk user ID of caregiver requesting connection
+    communicatorId: v.string(), // Clerk user ID of communicator being requested
+    status: v.union(v.literal('pending'), v.literal('accepted'), v.literal('rejected')),
+    createdAt: v.number(),
+  })
+    .index('by_caregiver', ['caregiverId'])
+    .index('by_communicator', ['communicatorId']),
+
   phrases: defineTable({
     userId: v.string(), // Clerk user ID
     text: v.string(),

--- a/tests/components/dashboard/AddClientModal.test.tsx
+++ b/tests/components/dashboard/AddClientModal.test.tsx
@@ -25,7 +25,7 @@ describe('AddClientModal', () => {
 
     expect(screen.getByRole('heading', { name: 'Add Client' })).toBeInTheDocument();
     expect(screen.getByPlaceholderText('client@example.com')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add client/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send request/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
   });
 
@@ -46,10 +46,10 @@ describe('AddClientModal', () => {
     expect(emailInput).toHaveValue('test@example.com');
   });
 
-  it('shows helper text about existing account', () => {
+  it('shows helper text about request process', () => {
     render(<AddClientModal onClose={mockOnClose} />);
 
-    expect(screen.getByText(/must have an existing sayit! account/i)).toBeInTheDocument();
+    expect(screen.getByText(/must accept your request/i)).toBeInTheDocument();
   });
 
   it('shows found user when profile exists', () => {


### PR DESCRIPTION
## Summary
- Adds accept/reject flow for caregiver-communicator connections
- Caregivers send requests instead of directly adding clients
- Communicators can accept or reject pending requests
- Connection created only after acceptance

## Changes
- **Schema:** `connectionRequests` table with pending/accepted/rejected status
- **Backend:** New `convex/connectionRequests.ts` with all mutations/queries
- **Caregiver UI:** AddClientModal sends request, ClientList shows pending requests
- **Communicator UI:** ConnectionRequestsBanner on home page with accept/reject

## Test plan
- [ ] Caregiver sends connection request
- [ ] Request shows as pending in caregiver dashboard
- [ ] Caregiver can cancel pending request
- [ ] Communicator sees banner with pending requests
- [ ] Communicator accepts → relationship created
- [ ] Communicator rejects → request deleted
- [ ] Duplicate requests prevented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Connection request system enabling caregivers to send invitations with accept/decline workflow
  * New request management interface displaying pending requests and action options
  * Dashboard now organizes pending requests and connected clients into separate sections
  * Pending request cards display requester information and status indicators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->