### PR TITLE
Fix subscription checking to use Clerk's native billing (#147)

### DIFF
--- a/app/hooks/useSubscription.ts
+++ b/app/hooks/useSubscription.ts
@@ -1,16 +1,17 @@
-import { useUser } from '@clerk/nextjs';
+import { useAuth, useUser } from '@clerk/nextjs';
 
 export function useSubscription() {
-  const { user, isLoaded } = useUser();
+  const { has, isLoaded: authLoaded } = useAuth();
+  const { user, isLoaded: userLoaded } = useUser();
 
-  const loading = !isLoaded;
+  const loading = !authLoaded || !userLoaded;
 
   // Check for bypass flag (for testing/admin purposes)
   const bypassEnabled = user?.publicMetadata?.bypassSubscriptionCheck === true;
 
-  // Clerk stores subscription status in user public metadata
-  const subscriptionStatus = user?.publicMetadata?.subscriptionStatus as string | undefined;
-  const isActive = subscriptionStatus === 'active' || bypassEnabled;
+  // Use Clerk's native billing has() helper to check subscription plan
+  const hasProPlan = has?.({ plan: 'sayit_pro_monthly' }) ?? false;
+  const isActive = hasProPlan || bypassEnabled;
 
   return { isActive, loading, bypassEnabled };
 }


### PR DESCRIPTION
## Summary
- Fix broken subscription checking by using Clerk's native `has()` helper
- Replace custom `publicMetadata.subscriptionStatus` check with `has({ plan: 'sayit_pro_monthly' })`

## Changes
- `app/hooks/useSubscription.ts`: Use `useAuth().has({ plan: 'sayit_pro_monthly' })` instead of metadata check

## Test plan
- [ ] User without subscription sees paywall on dashboard
- [ ] User with `sayit_pro_monthly` plan can access dashboard
- [ ] User with `bypassSubscriptionCheck` metadata can still bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated subscription status detection mechanism to use Clerk's built-in plan verification, improving reliability of pro plan recognition.
  * Enhanced loading state handling to accurately reflect both authentication and user data loading status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->