### PR TITLE
Fix role selection modal flash on app load (#153)

### DIFF
--- a/app/components/onboarding/RoleGate.tsx
+++ b/app/components/onboarding/RoleGate.tsx
@@ -75,10 +75,13 @@ export default function RoleGate({ children }: RoleGateProps) {
     setShowRoleModal(false);
   };
 
+  // Don't render modal while still loading to prevent flash
+  const shouldRenderModal = showRoleModal && !authLoading && profile !== undefined;
+
   return (
     <>
       {children}
-      {showRoleModal && <RoleSelectionModal onComplete={handleRoleComplete} />}
+      {shouldRenderModal && <RoleSelectionModal onComplete={handleRoleComplete} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Fix brief flash of role selection modal when loading app
- Only render modal after profile is fully loaded

## Test plan
- [ ] Load app as user with role set - no modal flash
- [ ] Load app as new user without role - modal appears after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role selection modal timing to display only when authentication and profile data are fully loaded, preventing display during loading states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->