### PR TITLE
Move role selection to home page to prevent flash (#155)

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -8,7 +8,6 @@ import { ConvexReactClient } from 'convex/react';
 import { AuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import Sidebar from './components/Sidebar';
-import RoleGate from './components/onboarding/RoleGate';
 
 export default function ClientLayout({
   children,
@@ -45,16 +44,14 @@ export default function ClientLayout({
       <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
         <AuthProvider>
           <SettingsProvider>
-            <RoleGate>
-              <div className="min-h-screen flex">
-                <Sidebar />
-                <div className="flex-1 pl-16">
-                  <main>
-                    {children}
-                  </main>
-                </div>
+            <div className="min-h-screen flex">
+              <Sidebar />
+              <div className="flex-1 pl-16">
+                <main>
+                  {children}
+                </main>
               </div>
-            </RoleGate>
+            </div>
           </SettingsProvider>
         </AuthProvider>
       </ConvexProviderWithClerk>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,38 @@
 'use client';
 
+import { useState } from 'react';
 import { useAuth } from '@/app/contexts/AuthContext';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
 import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
 import HomeFeatures from '@/app/components/home/HomeFeatures';
 import PhrasesInterface from '@/app/components/home/PhrasesInterface';
 import ConnectionRequestsBanner from '@/app/components/connection/ConnectionRequestsBanner';
+import RoleSelectionModal from '@/app/components/onboarding/RoleSelectionModal';
 
 export default function Home() {
   const { user, loading: authLoading } = useAuth();
+  const profile = useQuery(api.profiles.getProfile);
+  const [roleJustSelected, setRoleJustSelected] = useState(false);
 
   if (authLoading) {
     return <AnimatedLoading />;
+  }
+
+  // Show loading while profile is being fetched for logged-in users
+  if (user && profile === undefined) {
+    return <AnimatedLoading />;
+  }
+
+  // Show role selection if user is logged in but has no role
+  const needsRoleSelection = user && !roleJustSelected && (profile === null || !profile?.role);
+
+  if (needsRoleSelection) {
+    return (
+      <div className="min-h-screen flex flex-col bg-background">
+        <RoleSelectionModal onComplete={() => setRoleJustSelected(true)} />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Move role selection logic from RoleGate overlay to home page content
- Prevents modal flash by showing loading until profile is fetched

## Changes
- `app/page.tsx` - Add role check, show modal as content when no role
- `app/ClientLayout.tsx` - Remove RoleGate wrapper

## Test plan
- [ ] Load app as user with role - no flash, goes to phrases
- [ ] Load app as new user - loading then role selection appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role selection modal appears during initial user onboarding to establish preferences
  * Loading indicators display while user profile data is being fetched

* **Refactor**
  * Simplified application layout structure for improved clarity and maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->