### PR TITLE
Fix role selection modal flash with delayed rendering

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
@@ -14,6 +14,17 @@ export default function Home() {
   const { user, loading: authLoading } = useAuth();
   const profile = useQuery(api.profiles.getProfile);
   const [roleJustSelected, setRoleJustSelected] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+
+  // Add delay before showing role selection to prevent flash
+  useEffect(() => {
+    if (!authLoading && (!user || profile !== undefined)) {
+      const timer = setTimeout(() => {
+        setIsReady(true);
+      }, 150);
+      return () => clearTimeout(timer);
+    }
+  }, [authLoading, user, profile]);
 
   if (authLoading) {
     return <AnimatedLoading />;
@@ -21,6 +32,11 @@ export default function Home() {
 
   // Show loading while profile is being fetched for logged-in users
   if (user && profile === undefined) {
+    return <AnimatedLoading />;
+  }
+
+  // Show loading during delay period to prevent flash
+  if (!isReady) {
     return <AnimatedLoading />;
   }
 


### PR DESCRIPTION
## Changes

Adds a 150ms delay before rendering the role selection modal to prevent visual flash on app load.

## Implementation

- Added `isReady` state that delays for 150ms after auth/profile loading completes
- Shows loading spinner during delay period for smooth UX
- Ensures profile query has time to resolve before checking role requirements

## Testing

- [x] All 124 tests passing
- [x] Linter passing
- [ ] Manual testing: no flash for users with existing roles
- [ ] Manual testing: smooth appearance for new users needing role selection

Fixes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual flashing that occurred during initial page load and when authentication state was being determined.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->