### PR TITLE
Allow closing last tab by creating new empty tab

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -67,7 +67,7 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
       if (isMod && e.key === 't') {
         e.preventDefault();
         createTab();
-      } else if (isMod && e.key === 'w' && tabs.length > 1) {
+      } else if (isMod && e.key === 'w') {
         e.preventDefault();
         closeTab(activeTabId!);
       } else if (isMod && e.key === '[') {
@@ -84,7 +84,7 @@ export default function TypingArea({ initialText = '', tts, onChange }: TypingAr
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [createTab, closeTab, activeTabId, switchToTabByIndex, switchToPreviousTab, switchToNextTab, tabs.length]);
+  }, [createTab, closeTab, activeTabId, switchToTabByIndex, switchToPreviousTab, switchToNextTab]);
 
   useEffect(() => {
     console.log('Current text size:', settings.textSize);

--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -116,9 +116,14 @@ export function useTypingTabs(initialText?: string) {
   // Close a tab
   const closeTab = useCallback((tabId: string) => {
     setTabsState(prev => {
-      // Always keep at least one tab
+      // Special handling for last tab: create new empty tab instead of preventing close
       if (prev.tabs.length === 1) {
-        return prev;
+        const newTab = createDefaultTab(prev.nextTabNumber);
+        return {
+          tabs: [...prev.tabs, newTab],
+          activeTabId: newTab.id,
+          nextTabNumber: prev.nextTabNumber + 1,
+        };
       }
 
       const tabIndex = prev.tabs.findIndex(t => t.id === tabId);


### PR DESCRIPTION
Implements #169

## Summary
When users click the X button on the last remaining tab, instead of preventing the close action, we now:
1. Create a new empty tab automatically
2. Switch to the new empty tab
3. Preserve the previous tab's content

This gives users a quick way to start fresh while keeping their work accessible.

## Changes
- Modified `closeTab()` in `useTypingTabs.ts` to create new tab when only 1 tab exists
- Removed `tabs.length > 1` check from Cmd/Ctrl+W keyboard shortcut in `TypingArea.tsx`

## Behavior
**Before**: Last tab's X button would not close the tab (minimum 1 tab enforced)
**After**: Clicking X on last tab creates a fresh empty tab and switches to it

## Example Flow
1. User has 1 tab with text: "Hello world"
2. User clicks X on that tab
3. System creates "Message 2" (empty tab)
4. User is switched to "Message 2"
5. "Message 1" still contains "Hello world"

## Testing
- ✅ Build passes
- ✅ Clicking X on last tab creates new empty tab
- ✅ Previous tab content is preserved
- ✅ Keyboard shortcut (Cmd/Ctrl+W) works on last tab
- ✅ Max tab limit (10) still respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users can now close the last open tab using the close hotkey
  * A new default tab automatically appears when closing the final tab, ensuring at least one tab remains available

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->