### PR TITLE
Auto-create new empty tab on load when current tab has text

### DIFF
--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -52,6 +52,24 @@ export function useTypingTabs(initialText?: string) {
   // Get active tab
   const activeTab = tabsState.tabs.find(tab => tab.id === tabsState.activeTabId) || tabsState.tabs[0];
 
+  // Auto-create new empty tab on mount if active tab has text
+  const hasAutoCreated = useRef(false);
+  useEffect(() => {
+    // Only run once on mount
+    if (hasAutoCreated.current) return;
+    hasAutoCreated.current = true;
+
+    // Check if active tab has text and we're not at max tabs
+    if (activeTab.text.trim().length > 0 && tabsState.tabs.length < MAX_TABS) {
+      const newTab = createDefaultTab(tabsState.nextTabNumber);
+      setTabsState(prev => ({
+        tabs: [...prev.tabs, newTab],
+        activeTabId: newTab.id,
+        nextTabNumber: prev.nextTabNumber + 1,
+      }));
+    }
+  }, [activeTab.text, tabsState.tabs.length, tabsState.nextTabNumber]);
+
   // Persist tabs to localStorage and Convex (debounced)
   const persistTabs = useCallback((state: TypingTabsState) => {
     // Clear existing timeout


### PR DESCRIPTION
Implements #170

## Summary
When the page loads and the active tab contains text, we now automatically:
1. Create a new empty tab
2. Switch to the new empty tab
3. Preserve the previous tab's content

This provides users with a fresh canvas to work with while keeping their previous work accessible in other tabs.

## Use Case
Users returning to the app typically want to:
- Start typing a new message immediately
- Keep their previous drafts accessible

Auto-creating a fresh tab streamlines this workflow.

## Changes
- Added `useEffect` in `useTypingTabs.ts` that runs once on mount
- Uses `useRef` to ensure it only runs once per component lifecycle
- Checks if active tab has text (`activeTab.text.trim().length > 0`)
- Respects max tab limit (10 tabs)

## Behavior
**Before**: Page loads with exact same tabs and active tab as before
**After**: If active tab has text, a new empty tab is created and selected

## Example Flow
1. User types "Hello world" in Message 1
2. User closes browser/tab
3. User returns to app
4. System detects Message 1 has text
5. System creates Message 2 (empty) and switches to it
6. User can immediately start typing a fresh message
7. "Hello world" is still accessible in Message 1

## Testing
- ✅ Build passes
- ✅ New tab auto-created when active tab has text
- ✅ Previous tab content preserved
- ✅ Runs only once on mount (doesn't create multiple tabs)
- ✅ Respects max tab limit (10)
- ✅ Does nothing if active tab is already empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-creates a new tab on app initialization when the active tab contains text and the tab limit hasn't been reached, automatically switching focus to the new tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->