### PR TITLE
Fix: Clear last tab text instead of creating new tab

### DIFF
--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -134,13 +134,18 @@ export function useTypingTabs(initialText?: string) {
   // Close a tab
   const closeTab = useCallback((tabId: string) => {
     setTabsState(prev => {
-      // Special handling for last tab: create new empty tab instead of preventing close
+      // Special handling for last tab: clear text instead of closing
       if (prev.tabs.length === 1) {
-        const newTab = createDefaultTab(prev.nextTabNumber);
+        const tabIndex = 0;
         return {
-          tabs: [...prev.tabs, newTab],
-          activeTabId: newTab.id,
-          nextTabNumber: prev.nextTabNumber + 1,
+          ...prev,
+          tabs: prev.tabs.map(tab => ({
+            ...tab,
+            text: '',
+            label: generateLabelFromText('', tabIndex + 1),
+            isCustomLabel: false,
+            lastModified: Date.now(),
+          })),
         };
       }
 


### PR DESCRIPTION
Implements #173

## Summary
Fixes the behavior introduced in #169 where closing the last tab created a new tab, leading to tab proliferation. Now closing the last tab simply clears its text.

## Changes
**Before (from #169):**
- Closing last tab → Creates new empty tab
- Results in 2 tabs total
- Leads to tab accumulation

**After (this PR):**
- Closing last tab → Clears the current tab's text
- Stays at 1 tab
- Tab label updates to reflect empty state
- Resets `isCustomLabel` flag

## Implementation
Modified `closeTab()` in `useTypingTabs.ts`:
- When `tabs.length === 1`, clear the tab's text instead of creating a new one
- Update label using `generateLabelFromText('', tabIndex + 1)`
- Reset `isCustomLabel` to `false`
- Update `lastModified` timestamp

## Example Flow
1. User has 1 tab with text: "Hello world"
2. User clicks X on that tab
3. Tab text is cleared to ""
4. Tab label updates to "Message 1"
5. User stays on the same (now empty) tab
6. Still only 1 tab total

## Testing
- ✅ Build passes
- ✅ Clicking X on last tab clears its text
- ✅ No new tab is created
- ✅ Tab label updates to default state
- ✅ User stays on the same tab
- ✅ Minimum 1 tab maintained

## Related
- Fixes behavior introduced in #169
- Works alongside #170 (auto-create on load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved last tab handling: when closing your final tab in the editor, it is now preserved with cleared content and reset to its default state, rather than automatically creating a new replacement tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->