### PR TITLE
Keep add button visible in right corner

### DIFF
--- a/app/components/typing-tabs/Tab.tsx
+++ b/app/components/typing-tabs/Tab.tsx
@@ -73,7 +73,7 @@ export default function Tab({ tab, isActive, onSelect, onClose, onRename }: TabP
           onChange={(e) => setEditLabel(e.target.value)}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
-          className="bg-transparent outline-none border-b border-current w-24 text-sm"
+          className="bg-transparent outline-none border-b border-current min-w-24 text-sm"
           autoFocus
           onClick={(e) => e.stopPropagation()}
         />

--- a/app/components/typing-tabs/Tab.tsx
+++ b/app/components/typing-tabs/Tab.tsx
@@ -60,7 +60,7 @@ export default function Tab({ tab, isActive, onSelect, onClose, onRename }: TabP
         ${
     isActive
       ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white shadow-lg'
-      : 'bg-surface hover:bg-surface-hover text-text-secondary hover:text-foreground'
+      : 'bg-surface hover:bg-surface-hover text-text-secondary hover:text-foreground opacity-50 hover:opacity-100'
     }
       `}
       onClick={onSelect}
@@ -81,16 +81,15 @@ export default function Tab({ tab, isActive, onSelect, onClose, onRename }: TabP
         <span className="text-sm font-medium select-none">{tab.label}</span>
       )}
 
-      <button
-        onClick={handleClose}
-        className={`
-          p-0.5 rounded-full transition-opacity
-          ${isActive ? 'opacity-100 hover:bg-white/20' : 'opacity-100 md:opacity-0 md:group-hover:opacity-100 hover:bg-surface'}
-        `}
-        aria-label={`Close ${tab.label}`}
-      >
-        <XMarkIcon className="w-4 h-4" />
-      </button>
+      {isActive && (
+        <button
+          onClick={handleClose}
+          className="p-0.5 rounded-full transition-opacity opacity-100 hover:bg-white/20"
+          aria-label={`Close ${tab.label}`}
+        >
+          <XMarkIcon className="w-4 h-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/app/components/typing-tabs/Tab.tsx
+++ b/app/components/typing-tabs/Tab.tsx
@@ -78,7 +78,7 @@ export default function Tab({ tab, isActive, onSelect, onClose, onRename }: TabP
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
-        <span className="text-sm font-medium select-none max-w-[120px] md:max-w-[200px] overflow-hidden text-ellipsis block">{tab.label}</span>
+        <span className="text-sm font-medium select-none">{tab.label}</span>
       )}
 
       <button

--- a/app/components/typing-tabs/TabBar.tsx
+++ b/app/components/typing-tabs/TabBar.tsx
@@ -25,36 +25,42 @@ export default function TabBar({
   const canCreateTab = tabs.length < MAX_TABS;
 
   return (
-    <div className="flex items-center gap-2 p-2 bg-surface-hover rounded-t-3xl overflow-x-auto scrollbar-hide">
-      <div className="flex gap-1 flex-1 min-w-0">
-        {tabs.map((tab) => (
-          <Tab
-            key={tab.id}
-            tab={tab}
-            isActive={tab.id === activeTabId}
-            onSelect={() => onTabSelect(tab.id)}
-            onClose={() => onTabClose(tab.id)}
-            onRename={(newLabel) => onTabRename(tab.id, newLabel)}
-          />
-        ))}
+    <div className="flex gap-2 p-2 bg-surface-hover rounded-t-3xl">
+      {/* Scrollable tabs container */}
+      <div className="flex-1 overflow-x-auto scrollbar-hide">
+        <div className="flex gap-1 min-w-max">
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.id}
+              tab={tab}
+              isActive={tab.id === activeTabId}
+              onSelect={() => onTabSelect(tab.id)}
+              onClose={() => onTabClose(tab.id)}
+              onRename={(newLabel) => onTabRename(tab.id, newLabel)}
+            />
+          ))}
+        </div>
       </div>
 
-      <button
-        onClick={onTabCreate}
-        disabled={!canCreateTab}
-        className={`
-          flex items-center justify-center p-1.5 md:p-2 rounded-2xl transition-all duration-200
-          ${
+      {/* Fixed button - stays visible */}
+      <div className="flex-shrink-0">
+        <button
+          onClick={onTabCreate}
+          disabled={!canCreateTab}
+          className={`
+            flex items-center justify-center p-1.5 md:p-2 rounded-2xl transition-all duration-200
+            ${
     canCreateTab
       ? 'bg-surface hover:bg-primary-500/10 text-text-secondary hover:text-primary-500 cursor-pointer'
       : 'bg-surface text-text-tertiary cursor-not-allowed opacity-50'
     }
-        `}
-        aria-label="Create new tab"
-        title={canCreateTab ? 'Create new tab (Cmd/Ctrl+T)' : `Maximum of ${MAX_TABS} tabs reached`}
-      >
-        <PlusIcon className="w-4 h-4 md:w-5 md:h-5" />
-      </button>
+          `}
+          aria-label="Create new tab"
+          title={canCreateTab ? 'Create new tab (Cmd/Ctrl+T)' : `Maximum of ${MAX_TABS} tabs reached`}
+        >
+          <PlusIcon className="w-4 h-4 md:w-5 md:h-5" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/components/typing-tabs/TabBar.tsx
+++ b/app/components/typing-tabs/TabBar.tsx
@@ -30,8 +30,11 @@ export default function TabBar({
   // Auto-scroll to end when new tab is added
   useEffect(() => {
     if (tabs.length > prevTabCountRef.current && scrollContainerRef.current) {
-      // Scroll to the far right to show the new tab
-      scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth;
+      // Smoothly scroll to the far right to show the new tab
+      scrollContainerRef.current.scrollTo({
+        left: scrollContainerRef.current.scrollWidth,
+        behavior: 'smooth'
+      });
     }
     prevTabCountRef.current = tabs.length;
   }, [tabs.length]);
@@ -63,7 +66,7 @@ export default function TabBar({
             flex items-center justify-center p-1.5 md:p-2 rounded-2xl transition-all duration-200
             ${
     canCreateTab
-      ? 'bg-surface hover:bg-primary-500/10 text-text-secondary hover:text-primary-500 cursor-pointer'
+      ? 'bg-surface-hover hover:bg-primary-500/10 text-text-secondary hover:text-primary-500 cursor-pointer'
       : 'bg-surface text-text-tertiary cursor-not-allowed opacity-50'
     }
           `}

--- a/app/components/typing-tabs/TabBar.tsx
+++ b/app/components/typing-tabs/TabBar.tsx
@@ -25,10 +25,10 @@ export default function TabBar({
   const canCreateTab = tabs.length < MAX_TABS;
 
   return (
-    <div className="flex gap-2 p-2 bg-surface-hover rounded-t-3xl">
-      {/* Scrollable tabs container */}
-      <div className="flex-1 overflow-x-auto scrollbar-hide">
-        <div className="flex gap-1 min-w-max">
+    <div className="grid grid-cols-[1fr_auto] gap-2 p-2 bg-surface-hover rounded-t-3xl">
+      {/* Scrollable tabs column */}
+      <div className="overflow-x-auto scrollbar-hide min-w-0">
+        <div className="flex gap-1 items-center">
           {tabs.map((tab) => (
             <Tab
               key={tab.id}
@@ -42,8 +42,8 @@ export default function TabBar({
         </div>
       </div>
 
-      {/* Fixed button - stays visible */}
-      <div className="flex-shrink-0">
+      {/* Fixed button column */}
+      <div className="flex items-center">
         <button
           onClick={onTabCreate}
           disabled={!canCreateTab}

--- a/app/components/typing-tabs/TabBar.tsx
+++ b/app/components/typing-tabs/TabBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef, useEffect } from 'react';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import { TypingTab } from '@/app/types/typing-tabs';
 import Tab from './Tab';
@@ -23,11 +24,22 @@ export default function TabBar({
   onTabRename,
 }: TabBarProps) {
   const canCreateTab = tabs.length < MAX_TABS;
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const prevTabCountRef = useRef(tabs.length);
+
+  // Auto-scroll to end when new tab is added
+  useEffect(() => {
+    if (tabs.length > prevTabCountRef.current && scrollContainerRef.current) {
+      // Scroll to the far right to show the new tab
+      scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth;
+    }
+    prevTabCountRef.current = tabs.length;
+  }, [tabs.length]);
 
   return (
     <div className="grid grid-cols-[1fr_auto] gap-2 p-2 bg-surface-hover rounded-t-3xl">
       {/* Scrollable tabs column */}
-      <div className="overflow-x-auto scrollbar-hide min-w-0">
+      <div ref={scrollContainerRef} className="overflow-x-auto scrollbar-hide min-w-0">
         <div className="flex gap-1 items-center">
           {tabs.map((tab) => (
             <Tab


### PR DESCRIPTION
Fixes #177

## Changes

**Grid Layout Approach:**
- Restructured TabBar with CSS Grid: `grid-cols-[1fr_auto]`
- Left column (1fr, min-w-0): scrollable tabs container with `overflow-x-auto`
- Right column (auto): fixed add button that never scrolls
- Background: `bg-surface-hover` for both parent and button (visual consistency)

**Auto-Scroll:**
- Smoothly scrolls to show newly created tabs using `scrollTo({ behavior: 'smooth' })`
- Tracks tab count changes to trigger scroll

**Visual Improvements:**
- Inactive tabs: 50% opacity (hover: 100%)
- Active tab: full opacity, gradient, white text, shadow
- Close button (X): only visible on active tab
- Edit input: uses `min-w-24` to prevent visual jump when editing

## Result

The add button stays visible in the right corner while tabs scroll horizontally. The grid layout ensures the button column can't be pushed away, and smooth scrolling provides better UX when adding new tabs.

## Testing

✅ Build passes without errors
✅ Add button stays visible when adding multiple tabs
✅ Tabs scroll horizontally but button remains fixed
✅ Active tab is clearly distinguished from inactive tabs
✅ Smooth scroll animation when creating new tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved tab bar layout with a fixed create button and scrollable tabs area
  * Enhanced visual hierarchy with opacity changes for inactive tabs
  * Refined close button visibility and styling

* **Refactor**
  * Auto-scroll tabs container when new tabs are added for better usability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->