### PR TITLE
Remove 10-tab limit from typing tabs

### DIFF
--- a/app/components/typing-tabs/TabBar.tsx
+++ b/app/components/typing-tabs/TabBar.tsx
@@ -4,7 +4,6 @@ import { useRef, useEffect } from 'react';
 import { PlusIcon, QueueListIcon } from '@heroicons/react/24/outline';
 import { TypingTab } from '@/app/types/typing-tabs';
 import Tab from './Tab';
-import { MAX_TABS } from './utils';
 
 interface TabBarProps {
   tabs: TypingTab[];
@@ -25,7 +24,6 @@ export default function TabBar({
   onTabRename,
   onManage,
 }: TabBarProps) {
-  const canCreateTab = tabs.length < MAX_TABS;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const prevTabCountRef = useRef(tabs.length);
 
@@ -72,17 +70,9 @@ export default function TabBar({
 
         <button
           onClick={onTabCreate}
-          disabled={!canCreateTab}
-          className={`
-            flex items-center justify-center p-1.5 md:p-2 rounded-2xl transition-all duration-200
-            ${
-    canCreateTab
-      ? 'bg-surface-hover hover:bg-primary-500/10 text-text-secondary hover:text-primary-500 cursor-pointer'
-      : 'bg-surface text-text-tertiary cursor-not-allowed opacity-50'
-    }
-          `}
+          className="flex items-center justify-center p-1.5 md:p-2 rounded-2xl transition-all duration-200 bg-surface-hover hover:bg-primary-500/10 text-text-secondary hover:text-primary-500 cursor-pointer"
           aria-label="Create new tab"
-          title={canCreateTab ? 'Create new tab (Cmd/Ctrl+T)' : `Maximum of ${MAX_TABS} tabs reached`}
+          title="Create new tab (Cmd/Ctrl+T)"
         >
           <PlusIcon className="w-4 h-4 md:w-5 md:h-5" />
         </button>

--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -4,7 +4,7 @@ import { api } from '@/convex/_generated/api';
 import { useSettings } from '@/app/contexts/SettingsContext';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { TypingTab, TypingTabsState } from '@/app/types/typing-tabs';
-import { createDefaultTab, validateTabLabel, generateLabelFromText, MAX_TABS } from './utils';
+import { createDefaultTab, validateTabLabel, generateLabelFromText } from './utils';
 
 const STORAGE_KEY = 'typingTabs';
 const DEBOUNCE_DELAY = 300;
@@ -59,8 +59,8 @@ export function useTypingTabs(initialText?: string) {
     if (hasAutoCreated.current) return;
     hasAutoCreated.current = true;
 
-    // Check if active tab has text and we're not at max tabs
-    if (activeTab.text.trim().length > 0 && tabsState.tabs.length < MAX_TABS) {
+    // Check if active tab has text - auto-create a new empty tab
+    if (activeTab.text.trim().length > 0) {
       const newTab = createDefaultTab(tabsState.nextTabNumber);
       setTabsState(prev => ({
         tabs: [...prev.tabs, newTab],
@@ -110,11 +110,6 @@ export function useTypingTabs(initialText?: string) {
 
   // Create a new tab
   const createTab = useCallback(() => {
-    if (tabsState.tabs.length >= MAX_TABS) {
-      alert(`Maximum of ${MAX_TABS} tabs reached`);
-      return;
-    }
-
     const newTab = createDefaultTab(tabsState.nextTabNumber);
     setTabsState(prev => ({
       tabs: [...prev.tabs, newTab],

--- a/app/components/typing-tabs/utils.ts
+++ b/app/components/typing-tabs/utils.ts
@@ -1,7 +1,6 @@
 import { nanoid } from 'nanoid';
 import { TypingTab } from '@/app/types/typing-tabs';
 
-export const MAX_TABS = 10;
 export const MAX_LABEL_LENGTH = 20;
 
 export function generateLabelFromText(text: string, tabNumber: number): string {

--- a/tests/components/typing-tabs/TabBar.test.tsx
+++ b/tests/components/typing-tabs/TabBar.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TabBar from '@/app/components/typing-tabs/TabBar';
 import { TypingTab } from '@/app/types/typing-tabs';
-import { MAX_TABS } from '@/app/components/typing-tabs/utils';
 
 // Mock nanoid to avoid ESM issues
 jest.mock('nanoid', () => ({
@@ -25,6 +24,7 @@ describe('TabBar', () => {
   const mockOnTabClose = jest.fn();
   const mockOnTabCreate = jest.fn();
   const mockOnTabRename = jest.fn();
+  const mockOnManage = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,6 +46,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -65,13 +66,14 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
       expect(screen.getByLabelText('Create new tab')).toBeInTheDocument();
     });
 
-    it('enables create button when below MAX_TABS', () => {
+    it('create button is always enabled', () => {
       const tabs = [createTab()];
 
       render(
@@ -82,31 +84,12 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
       const createButton = screen.getByLabelText('Create new tab');
       expect(createButton).not.toBeDisabled();
-    });
-
-    it('disables create button when at MAX_TABS', () => {
-      const tabs = Array.from({ length: MAX_TABS }, (_, i) =>
-        createTab({ id: `tab-${i}`, label: `Tab ${i}` })
-      );
-
-      render(
-        <TabBar
-          tabs={tabs}
-          activeTabId={tabs[0].id}
-          onTabSelect={mockOnTabSelect}
-          onTabClose={mockOnTabClose}
-          onTabCreate={mockOnTabCreate}
-          onTabRename={mockOnTabRename}
-        />
-      );
-
-      const createButton = screen.getByLabelText('Create new tab');
-      expect(createButton).toBeDisabled();
     });
 
     it('renders with no active tab', () => {
@@ -120,6 +103,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -140,35 +124,13 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
       await user.click(screen.getByLabelText('Create new tab'));
 
       expect(mockOnTabCreate).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not call onTabCreate when create button is disabled', async () => {
-      const user = userEvent.setup();
-      const tabs = Array.from({ length: MAX_TABS }, (_, i) =>
-        createTab({ id: `tab-${i}`, label: `Tab ${i}` })
-      );
-
-      render(
-        <TabBar
-          tabs={tabs}
-          activeTabId={tabs[0].id}
-          onTabSelect={mockOnTabSelect}
-          onTabClose={mockOnTabClose}
-          onTabCreate={mockOnTabCreate}
-          onTabRename={mockOnTabRename}
-        />
-      );
-
-      const createButton = screen.getByLabelText('Create new tab');
-      await user.click(createButton);
-
-      expect(mockOnTabCreate).not.toHaveBeenCalled();
     });
 
     it('calls onTabSelect when a tab is selected', async () => {
@@ -186,6 +148,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -209,6 +172,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -229,6 +193,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -253,6 +218,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -270,14 +236,15 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
       expect(screen.getByText('Only Tab')).toBeInTheDocument();
     });
 
-    it('renders with MAX_TABS tabs', () => {
-      const tabs = Array.from({ length: MAX_TABS }, (_, i) =>
+    it('renders with many tabs', () => {
+      const tabs = Array.from({ length: 15 }, (_, i) =>
         createTab({ id: `tab-${i}`, label: `Tab ${i}` })
       );
 
@@ -289,11 +256,12 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
       expect(screen.getByText('Tab 0')).toBeInTheDocument();
-      expect(screen.getByText(`Tab ${MAX_TABS - 1}`)).toBeInTheDocument();
+      expect(screen.getByText('Tab 14')).toBeInTheDocument();
     });
 
     it('handles activeTabId not matching any tab', () => {
@@ -307,6 +275,7 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
@@ -315,7 +284,7 @@ describe('TabBar', () => {
   });
 
   describe('create button tooltip', () => {
-    it('shows keyboard shortcut in tooltip when create is enabled', () => {
+    it('shows keyboard shortcut in tooltip', () => {
       const tabs = [createTab()];
 
       render(
@@ -326,31 +295,12 @@ describe('TabBar', () => {
           onTabClose={mockOnTabClose}
           onTabCreate={mockOnTabCreate}
           onTabRename={mockOnTabRename}
+          onManage={mockOnManage}
         />
       );
 
       const createButton = screen.getByLabelText('Create new tab');
       expect(createButton).toHaveAttribute('title', 'Create new tab (Cmd/Ctrl+T)');
-    });
-
-    it('shows max tabs message in tooltip when create is disabled', () => {
-      const tabs = Array.from({ length: MAX_TABS }, (_, i) =>
-        createTab({ id: `tab-${i}`, label: `Tab ${i}` })
-      );
-
-      render(
-        <TabBar
-          tabs={tabs}
-          activeTabId={tabs[0].id}
-          onTabSelect={mockOnTabSelect}
-          onTabClose={mockOnTabClose}
-          onTabCreate={mockOnTabCreate}
-          onTabRename={mockOnTabRename}
-        />
-      );
-
-      const createButton = screen.getByLabelText('Create new tab');
-      expect(createButton).toHaveAttribute('title', `Maximum of ${MAX_TABS} tabs reached`);
     });
   });
 });

--- a/tests/components/typing-tabs/useTypingTabs.test.ts
+++ b/tests/components/typing-tabs/useTypingTabs.test.ts
@@ -1,6 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useTypingTabs } from '@/app/components/typing-tabs/useTypingTabs';
-import { MAX_TABS } from '@/app/components/typing-tabs/utils';
 
 // Mock nanoid to avoid ESM issues
 jest.mock('nanoid', () => {
@@ -168,25 +167,18 @@ describe('useTypingTabs', () => {
       expect(result.current.activeTabId).toBe(result.current.tabs[1].id);
     });
 
-    it('prevents creating tabs beyond MAX_TABS', () => {
+    it('allows creating many tabs without limit', () => {
       const { result } = renderHook(() => useTypingTabs());
 
-      // Create MAX_TABS - 1 additional tabs (we already have 1)
+      // Create 15 additional tabs (we already have 1)
       act(() => {
-        for (let i = 0; i < MAX_TABS - 1; i++) {
+        for (let i = 0; i < 15; i++) {
           result.current.createTab();
         }
       });
 
-      expect(result.current.tabs).toHaveLength(MAX_TABS);
-
-      // Try to create one more
-      act(() => {
-        result.current.createTab();
-      });
-
-      expect(result.current.tabs).toHaveLength(MAX_TABS);
-      expect(global.alert).toHaveBeenCalledWith(`Maximum of ${MAX_TABS} tabs reached`);
+      expect(result.current.tabs).toHaveLength(16);
+      expect(global.alert).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/components/typing-tabs/utils.test.ts
+++ b/tests/components/typing-tabs/utils.test.ts
@@ -1,4 +1,4 @@
-import { generateLabelFromText, createDefaultTab, validateTabLabel, MAX_TABS, MAX_LABEL_LENGTH } from '@/app/components/typing-tabs/utils';
+import { generateLabelFromText, createDefaultTab, validateTabLabel, MAX_LABEL_LENGTH } from '@/app/components/typing-tabs/utils';
 
 // Mock nanoid to avoid ESM issues
 jest.mock('nanoid', () => ({
@@ -7,10 +7,6 @@ jest.mock('nanoid', () => ({
 
 describe('typing-tabs utils', () => {
   describe('constants', () => {
-    it('has MAX_TABS constant', () => {
-      expect(MAX_TABS).toBe(10);
-    });
-
     it('has MAX_LABEL_LENGTH constant', () => {
       expect(MAX_LABEL_LENGTH).toBe(20);
     });


### PR DESCRIPTION
## Summary
- Remove the `MAX_TABS = 10` constant that limited users to 10 typing tabs
- Allow unlimited typing tabs to be created
- The create tab button is now always enabled

## Test plan
- [x] Verified all 105 typing-tabs tests pass
- [ ] Create more than 10 tabs to verify the limit is removed
- [ ] Verify tabs still persist to localStorage
- [ ] Verify tab creation, deletion, and switching still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Removed the tab creation limit in the typing interface—users can now create unlimited tabs without restrictions.
  * Create New Tab button is now consistently available for a seamless workflow.
  * Improved auto-tab creation behavior when content is added to the active tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->