### PR TITLE
Add mobile-first bottom tab navigation

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -8,6 +8,7 @@ import { ConvexReactClient } from 'convex/react';
 import { AuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import Sidebar from './components/Sidebar';
+import BottomTabBar from './components/navigation/BottomTabBar';
 
 export default function ClientLayout({
   children,
@@ -46,11 +47,12 @@ export default function ClientLayout({
           <SettingsProvider>
             <div className="min-h-screen flex">
               <Sidebar />
-              <div className="flex-1 pl-16">
-                <main>
+              <div className="flex-1 md:pl-16">
+                <main className="pb-20 md:pb-0">
                   {children}
                 </main>
               </div>
+              <BottomTabBar />
             </div>
           </SettingsProvider>
         </AuthProvider>

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -27,7 +27,7 @@ export default function Sidebar() {
   const isCaregiver = profile?.role === 'caregiver';
 
   return (
-    <aside className="fixed left-0 top-0 h-full w-16 bg-surface z-50 shadow-2xl flex flex-col">
+    <aside className="fixed left-0 top-0 h-full w-16 bg-surface z-50 shadow-2xl hidden md:flex flex-col">
       <div className="p-4 flex justify-center items-center">
         <div className="rounded-3xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-110">
           <Image

--- a/app/components/navigation/BottomTabBar.tsx
+++ b/app/components/navigation/BottomTabBar.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/app/contexts/AuthContext';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  HomeIcon as HomeOutline,
+  Squares2X2Icon as BoardsOutline,
+  PlusCircleIcon as PlusOutline,
+  Cog6ToothIcon as SettingsOutline,
+  UserCircleIcon as ProfileOutline,
+} from '@heroicons/react/24/outline';
+import {
+  HomeIcon as HomeSolid,
+  Squares2X2Icon as BoardsSolid,
+  PlusCircleIcon as PlusSolid,
+  Cog6ToothIcon as SettingsSolid,
+  UserCircleIcon as ProfileSolid,
+} from '@heroicons/react/24/solid';
+
+interface TabItem {
+  href: string;
+  label: string;
+  iconOutline: React.ReactNode;
+  iconSolid: React.ReactNode;
+  matchPaths?: string[];
+}
+
+const tabs: TabItem[] = [
+  {
+    href: '/',
+    label: 'Home',
+    iconOutline: <HomeOutline className="w-6 h-6" />,
+    iconSolid: <HomeSolid className="w-6 h-6" />,
+    matchPaths: ['/', '/phrases'],
+  },
+  {
+    href: '/phrases/boards',
+    label: 'Boards',
+    iconOutline: <BoardsOutline className="w-6 h-6" />,
+    iconSolid: <BoardsSolid className="w-6 h-6" />,
+    matchPaths: ['/phrases/boards'],
+  },
+  {
+    href: '/phrases/add',
+    label: 'New',
+    iconOutline: <PlusOutline className="w-6 h-6" />,
+    iconSolid: <PlusSolid className="w-6 h-6" />,
+    matchPaths: ['/phrases/add'],
+  },
+  {
+    href: '/settings',
+    label: 'Settings',
+    iconOutline: <SettingsOutline className="w-6 h-6" />,
+    iconSolid: <SettingsSolid className="w-6 h-6" />,
+    matchPaths: ['/settings'],
+  },
+  {
+    href: '/sign-in',
+    label: 'Profile',
+    iconOutline: <ProfileOutline className="w-6 h-6" />,
+    iconSolid: <ProfileSolid className="w-6 h-6" />,
+    matchPaths: ['/sign-in', '/sign-up'],
+  },
+];
+
+export default function BottomTabBar() {
+  const pathname = usePathname();
+  const { user } = useAuth();
+  const [isVisible, setIsVisible] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  // Hide on scroll down, show on scroll up
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+
+      if (currentScrollY > lastScrollY && currentScrollY > 100) {
+        setIsVisible(false);
+      } else {
+        setIsVisible(true);
+      }
+
+      setLastScrollY(currentScrollY);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [lastScrollY]);
+
+  const isActive = (tab: TabItem) => {
+    if (tab.matchPaths) {
+      return tab.matchPaths.some(path =>
+        path === '/' ? pathname === '/' : pathname?.startsWith(path)
+      );
+    }
+    return pathname === tab.href;
+  };
+
+  // Adjust profile tab based on auth state
+  const getTabHref = (tab: TabItem) => {
+    if (tab.label === 'Profile') {
+      return user ? '/settings' : '/sign-in';
+    }
+    return tab.href;
+  };
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.nav
+          initial={{ y: 100 }}
+          animate={{ y: 0 }}
+          exit={{ y: 100 }}
+          transition={{ duration: 0.2 }}
+          className="fixed bottom-0 left-0 right-0 z-50 md:hidden"
+        >
+          <div className="bg-surface/95 backdrop-blur-lg border-t border-white/10 shadow-2xl">
+            {/* Safe area padding for notched devices */}
+            <div className="flex justify-around items-center px-2 pb-safe">
+              {tabs.map((tab) => {
+                const active = isActive(tab);
+                const href = getTabHref(tab);
+
+                // Skip profile tab display differently if logged in
+                if (tab.label === 'Profile' && user) {
+                  return null;
+                }
+
+                return (
+                  <Link
+                    key={tab.label}
+                    href={href}
+                    className={`flex flex-col items-center justify-center min-w-[64px] min-h-[56px] py-2 px-3 rounded-2xl transition-all duration-200 ${
+                      active
+                        ? 'text-primary-500'
+                        : 'text-text-tertiary hover:text-text-secondary'
+                    }`}
+                  >
+                    <motion.div
+                      whileTap={{ scale: 0.9 }}
+                      className="relative"
+                    >
+                      {active ? tab.iconSolid : tab.iconOutline}
+                      {active && (
+                        <motion.div
+                          layoutId="activeTab"
+                          className="absolute -inset-2 bg-primary-500/10 rounded-2xl -z-10"
+                          transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                        />
+                      )}
+                    </motion.div>
+                    <span className={`text-xs mt-1 font-medium ${
+                      active ? 'opacity-100' : 'opacity-70'
+                    }`}>
+                      {tab.label}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </motion.nav>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,4 +56,18 @@ body {
   .scrollbar-hide::-webkit-scrollbar {
     display: none;  /* Chrome, Safari and Opera */
   }
+
+  /* Safe area padding for notched devices */
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .pt-safe {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+  .pl-safe {
+    padding-left: env(safe-area-inset-left, 0px);
+  }
+  .pr-safe {
+    padding-right: env(safe-area-inset-right, 0px);
+  }
 }


### PR DESCRIPTION
## Summary
- Add `BottomTabBar` component with 5 tabs (Home, Boards, New, Settings, Profile)
- Hide sidebar on mobile (`md:hidden`), show bottom nav instead
- Scroll hide/show behavior - hides on scroll down, shows on scroll up
- Safe area padding for notched devices (iPhone X+)
- Responsive layout padding (`md:pl-16` instead of fixed `pl-16`)

## Changes
- `app/components/navigation/BottomTabBar.tsx` - New bottom tab bar component
- `app/components/Sidebar.tsx` - Added `hidden md:flex` for responsive hiding
- `app/ClientLayout.tsx` - Integrated bottom nav, responsive padding
- `app/globals.css` - Added safe area padding utilities

## Test plan
- [ ] Open on mobile viewport (< 768px) - should see bottom tab bar
- [ ] Open on desktop (>= 768px) - should see sidebar
- [ ] Scroll down on mobile - bottom nav should hide
- [ ] Scroll up on mobile - bottom nav should show
- [ ] Tap each tab - should navigate correctly
- [ ] Check active tab highlighting

Closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive bottom navigation bar for mobile devices with Home, Boards, New, Settings, and Profile tabs.
  * Made sidebar hidden on mobile screens for improved space utilization.
  * Bottom navigation bar automatically hides when scrolling down and reappears when scrolling up.
  * Added support for notched/safe-area devices to prevent content overlap.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->