### PR TITLE
Add responsive phrase grid with touch enhancements

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -222,28 +222,29 @@ export default function PhrasesInterface() {
             {!loading && (
               <div className="flex flex-col h-full">
                 <div className="flex-1 p-1 overflow-auto">
-                  <div className="flex flex-col gap-2 sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 sm:gap-1 h-full">
+                  <div className="grid grid-cols-2 gap-2 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
                     {phrases.map((phrase) => (
                       <PhraseTile
                         key={phrase.id}
                         phrase={phrase}
                         onPress={() => handlePhrasePress(phrase)}
                         onEdit={isEditMode && canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
-                        className="sm:aspect-square"
+                        onLongPress={canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
+                        className="aspect-square"
                       />
                     ))}
                     {typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
                       <ActionTile
                         text="+ Add as Phrase"
                         onClick={handleAddTypingAsPhrase}
-                        className="sm:aspect-square"
+                        className="aspect-square"
                       />
                     )}
                     {isEditMode && canEditCurrentBoard && (
                       <ActionTile
                         text="+ Add Phrase"
                         onClick={handleAddPhrase}
-                        className="sm:aspect-square"
+                        className="aspect-square"
                       />
                     )}
                   </div>

--- a/app/components/phrases/ActionTile.tsx
+++ b/app/components/phrases/ActionTile.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { motion } from 'framer-motion';
+
 interface ActionTileProps {
   text: string;
   onClick: () => void;
@@ -8,12 +10,14 @@ interface ActionTileProps {
 
 export default function ActionTile({ text, onClick, className = '' }: ActionTileProps) {
   return (
-    <button
+    <motion.button
       onClick={onClick}
-      className={`aspect-square flex items-center justify-center bg-surface hover:bg-surface-hover active:ring-2 active:ring-orange active:scale-[0.98] rounded-lg border-2 border-dashed border-border transition-all duration-200 ${className}`}
+      className={`flex items-center justify-center bg-surface hover:bg-surface-hover rounded-2xl border-2 border-dashed border-border min-h-[80px] ${className}`}
       aria-label={text}
+      whileTap={{ scale: 0.95 }}
+      transition={{ duration: 0.15 }}
     >
-      <span className="text-text-secondary text-lg">{text}</span>
-    </button>
+      <span className="text-text-secondary text-base sm:text-lg font-medium">{text}</span>
+    </motion.button>
   );
 } 

--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { PencilIcon, SpeakerWaveIcon } from '@heroicons/react/24/outline';
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
+import { motion } from 'framer-motion';
 
 interface PhraseTileProps {
   phrase: {
@@ -11,13 +12,48 @@ interface PhraseTileProps {
   };
   onPress: () => void;
   onEdit?: () => void;
+  onLongPress?: () => void;
   className?: string;
 }
 
-export default function PhraseTile({ phrase, onPress, onEdit, className = '' }: PhraseTileProps) {
+export default function PhraseTile({ phrase, onPress, onEdit, onLongPress, className = '' }: PhraseTileProps) {
   const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isPressed, setIsPressed] = useState(false);
+  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const isLongPress = useRef(false);
+
+  const handleTouchStart = useCallback(() => {
+    isLongPress.current = false;
+    setIsPressed(true);
+
+    if (onLongPress && !onEdit) {
+      longPressTimer.current = setTimeout(() => {
+        isLongPress.current = true;
+        setIsPressed(false);
+        // Haptic feedback if available
+        if (navigator.vibrate) {
+          navigator.vibrate(50);
+        }
+        onLongPress();
+      }, 500);
+    }
+  }, [onLongPress, onEdit]);
+
+  const handleTouchEnd = useCallback(() => {
+    setIsPressed(false);
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
 
   const handleClick = () => {
+    // Ignore click if it was a long press
+    if (isLongPress.current) {
+      isLongPress.current = false;
+      return;
+    }
+
     if (onEdit) {
       onEdit();
     } else {
@@ -28,13 +64,25 @@ export default function PhraseTile({ phrase, onPress, onEdit, className = '' }: 
   };
 
   return (
-    <div
-      className={`relative bg-surface rounded-lg shadow-sm p-4 cursor-pointer hover:shadow-md hover:bg-surface-hover active:ring-2 active:ring-orange active:scale-[0.98] transition-all duration-300 flex flex-col items-center justify-center h-full ${
-        onEdit ? 'ring-2 ring-blue-400' : ''
-      } ${
-        isSpeaking ? 'ring-2 ring-orange scale-[0.98]' : ''
-      } ${className}`}
+    <motion.div
+      className={`relative bg-surface rounded-2xl shadow-md cursor-pointer
+        flex flex-col items-center justify-center min-h-[80px]
+        ${onEdit ? 'ring-2 ring-blue-400' : ''}
+        ${isSpeaking ? 'ring-2 ring-orange' : ''}
+        ${className}`}
       onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+      onMouseDown={handleTouchStart}
+      onMouseUp={handleTouchEnd}
+      onMouseLeave={handleTouchEnd}
+      whileTap={{ scale: 0.95 }}
+      animate={{
+        scale: isPressed ? 0.95 : 1,
+        backgroundColor: isPressed ? 'var(--surface-hover)' : 'var(--surface)',
+      }}
+      transition={{ duration: 0.15 }}
     >
       {onEdit && (
         <div className="absolute top-2 right-2 z-10">
@@ -44,19 +92,24 @@ export default function PhraseTile({ phrase, onPress, onEdit, className = '' }: 
         </div>
       )}
       {isSpeaking && !onEdit && (
-        <div className="absolute top-2 right-2 z-10">
+        <motion.div
+          className="absolute top-2 right-2 z-10"
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+        >
           <div className="bg-orange rounded-full p-1.5 shadow-sm animate-pulse">
             <SpeakerWaveIcon className="h-4 w-4 text-white" />
           </div>
-        </div>
+        </motion.div>
       )}
-      <div className="flex flex-col items-center justify-center w-full h-full">
+      <div className="flex flex-col items-center justify-center w-full h-full p-3">
         <div className="text-center w-full">
-          <p className="text-foreground text-lg font-semibold line-clamp-2 px-2 leading-tight">
+          <p className="text-foreground text-base sm:text-lg font-semibold line-clamp-3 leading-tight">
             {phrase.text}
           </p>
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- Update phrase grid to mobile-first responsive layout (2 columns on mobile, scaling up to 5 on desktop)
- Add long-press gesture support for quick access to edit mode
- Increase touch targets to 80px minimum for better accessibility
- Add framer-motion animations with visual feedback on touch

## Test plan
- [ ] Verify grid displays 2 columns on mobile devices
- [ ] Verify grid scales appropriately on larger screens (3/4/5 columns)
- [ ] Test long-press on phrase tiles triggers edit navigation
- [ ] Verify haptic feedback works on supported devices
- [ ] Test speaking animation appears when tile is tapped

Closes #198