### PR TITLE
Add swipeable board navigation for mobile

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -5,6 +5,8 @@ import { Id } from '@/convex/_generated/dataModel';
 import PhrasesActionMenu from '../phrases/PhrasesActionMenu';
 import ReaderPopup from '../phrases/ReaderPopup';
 import BoardSelector from '../phrases/BoardSelector';
+import SwipeableBoardNavigator from '../phrases/SwipeableBoardNavigator';
+import BoardGridPopup from '../phrases/BoardGridPopup';
 import TypingArea from '../TypingArea';
 import TypingDock from '../TypingDock';
 import { useTTS } from '@/lib/hooks/useTTS';
@@ -25,6 +27,7 @@ export default function PhrasesInterface() {
   const [typingText, setTypingText] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
   const [isReaderOpen, setIsReaderOpen] = useState(false);
+  const [isBoardPickerOpen, setIsBoardPickerOpen] = useState(false);
   const selectedBoardId = uiPreferences.selectedBoardId;
   const isMobile = useIsMobile();
 
@@ -178,6 +181,17 @@ export default function PhrasesInterface() {
 
   const selectedBoard = transformedBoards.find(board => board.id === selectedBoardId) || null;
 
+  // Get current board index for swipeable navigator
+  const currentBoardIndex = transformedBoards.findIndex(board => board.id === selectedBoardId);
+  const validBoardIndex = currentBoardIndex >= 0 ? currentBoardIndex : 0;
+
+  // Handle board index change for swipeable navigation
+  const handleBoardIndexChange = (index: number) => {
+    if (transformedBoards[index]) {
+      updateUIPreference('selectedBoardId', transformedBoards[index].id);
+    }
+  };
+
   // Check if current board allows editing
   const canEditCurrentBoard = !selectedBoard?.isShared || selectedBoard?.accessLevel === 'edit';
 
@@ -220,50 +234,92 @@ export default function PhrasesInterface() {
         </div>
       ) : (
         <div className="flex-1 flex flex-col">
-          <div className="flex-none">
-            <BoardSelector
+          {/* Mobile: Swipeable Board Navigator */}
+          {isMobile ? (
+            <SwipeableBoardNavigator
               boards={transformedBoards}
-              selectedBoard={selectedBoard}
-              isEditMode={isEditMode}
-              onSelectBoard={handleSelectBoard}
-              onEditBoard={(boardId) => router.push(`/phrases/boards/edit/${boardId}`)}
-            />
-          </div>
-
-          <div className="flex-1 p-1 overflow-auto">
-            {!loading && (
-              <div className="flex flex-col h-full">
-                <div className="flex-1 p-1 overflow-auto">
-                  <div className="grid grid-cols-2 gap-2 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-                    {phrases.map((phrase) => (
-                      <PhraseTile
-                        key={phrase.id}
-                        phrase={phrase}
-                        onPress={() => handlePhrasePress(phrase)}
-                        onEdit={isEditMode && canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
-                        onLongPress={canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
-                        className="aspect-square"
-                      />
-                    ))}
-                    {typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
-                      <ActionTile
-                        text="+ Add as Phrase"
-                        onClick={handleAddTypingAsPhrase}
-                        className="aspect-square"
-                      />
-                    )}
-                    {isEditMode && canEditCurrentBoard && (
-                      <ActionTile
-                        text="+ Add Phrase"
-                        onClick={handleAddPhrase}
-                        className="aspect-square"
-                      />
-                    )}
-                  </div>
+              currentBoardIndex={validBoardIndex}
+              onBoardChange={handleBoardIndexChange}
+              onOpenBoardPicker={() => setIsBoardPickerOpen(true)}
+            >
+              <div className="p-2 pb-32 overflow-auto">
+                <div className="grid grid-cols-2 gap-2">
+                  {phrases.map((phrase) => (
+                    <PhraseTile
+                      key={phrase.id}
+                      phrase={phrase}
+                      onPress={() => handlePhrasePress(phrase)}
+                      onEdit={isEditMode && canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
+                      onLongPress={canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
+                      className="aspect-square"
+                    />
+                  ))}
+                  {typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
+                    <ActionTile
+                      text="+ Add as Phrase"
+                      onClick={handleAddTypingAsPhrase}
+                      className="aspect-square"
+                    />
+                  )}
+                  {isEditMode && canEditCurrentBoard && (
+                    <ActionTile
+                      text="+ Add Phrase"
+                      onClick={handleAddPhrase}
+                      className="aspect-square"
+                    />
+                  )}
                 </div>
               </div>
-            )}
-          </div>
+            </SwipeableBoardNavigator>
+          ) : (
+            /* Desktop: Traditional Board Selector */
+            <>
+              <div className="flex-none">
+                <BoardSelector
+                  boards={transformedBoards}
+                  selectedBoard={selectedBoard}
+                  isEditMode={isEditMode}
+                  onSelectBoard={handleSelectBoard}
+                  onEditBoard={(boardId) => router.push(`/phrases/boards/edit/${boardId}`)}
+                />
+              </div>
+
+              <div className="flex-1 p-1 overflow-auto">
+                {!loading && (
+                  <div className="flex flex-col h-full">
+                    <div className="flex-1 p-1 overflow-auto">
+                      <div className="grid grid-cols-2 gap-2 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+                        {phrases.map((phrase) => (
+                          <PhraseTile
+                            key={phrase.id}
+                            phrase={phrase}
+                            onPress={() => handlePhrasePress(phrase)}
+                            onEdit={isEditMode && canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
+                            onLongPress={canEditCurrentBoard ? () => handleEditPhrase(phrase) : undefined}
+                            className="aspect-square"
+                          />
+                        ))}
+                        {typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
+                          <ActionTile
+                            text="+ Add as Phrase"
+                            onClick={handleAddTypingAsPhrase}
+                            className="aspect-square"
+                          />
+                        )}
+                        {isEditMode && canEditCurrentBoard && (
+                          <ActionTile
+                            text="+ Add Phrase"
+                            onClick={handleAddPhrase}
+                            className="aspect-square"
+                          />
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       )}
       <PhrasesActionMenu
@@ -293,6 +349,16 @@ export default function PhrasesInterface() {
           />
         </div>
       )}
+      {/* Mobile: Board picker popup */}
+      <BoardGridPopup
+        boards={transformedBoards}
+        selectedBoard={selectedBoard}
+        isEditMode={isEditMode}
+        isOpen={isBoardPickerOpen}
+        onClose={() => setIsBoardPickerOpen(false)}
+        onSelectBoard={handleSelectBoard}
+        onEditBoard={(boardId) => router.push(`/phrases/boards/edit/${boardId}`)}
+      />
     </>
   );
 }

--- a/app/components/phrases/SwipeableBoardNavigator.tsx
+++ b/app/components/phrases/SwipeableBoardNavigator.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { motion, PanInfo, AnimatePresence } from 'framer-motion';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import type { BoardSummary } from './types';
+
+interface SwipeableBoardNavigatorProps {
+  boards: BoardSummary[];
+  currentBoardIndex: number;
+  onBoardChange: (index: number) => void;
+  onOpenBoardPicker?: () => void;
+  children: React.ReactNode;
+}
+
+export default function SwipeableBoardNavigator({
+  boards,
+  currentBoardIndex,
+  onBoardChange,
+  onOpenBoardPicker,
+  children,
+}: SwipeableBoardNavigatorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const currentBoard = boards[currentBoardIndex];
+
+  // Navigate to previous board
+  const goToPrevious = useCallback(() => {
+    if (currentBoardIndex > 0) {
+      // Haptic feedback
+      if (navigator.vibrate) {
+        navigator.vibrate(30);
+      }
+      onBoardChange(currentBoardIndex - 1);
+    }
+  }, [currentBoardIndex, onBoardChange]);
+
+  // Navigate to next board
+  const goToNext = useCallback(() => {
+    if (currentBoardIndex < boards.length - 1) {
+      // Haptic feedback
+      if (navigator.vibrate) {
+        navigator.vibrate(30);
+      }
+      onBoardChange(currentBoardIndex + 1);
+    }
+  }, [currentBoardIndex, boards.length, onBoardChange]);
+
+  // Handle swipe gestures
+  const handleDragEnd = useCallback(
+    (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+      const threshold = 50; // Minimum swipe distance
+      const velocity = info.velocity.x;
+      const offset = info.offset.x;
+
+      // Swipe left (next board)
+      if ((offset < -threshold || velocity < -500) && currentBoardIndex < boards.length - 1) {
+        goToNext();
+      }
+      // Swipe right (previous board)
+      else if ((offset > threshold || velocity > 500) && currentBoardIndex > 0) {
+        goToPrevious();
+      }
+    },
+    [currentBoardIndex, boards.length, goToNext, goToPrevious]
+  );
+
+  const hasPrevious = currentBoardIndex > 0;
+  const hasNext = currentBoardIndex < boards.length - 1;
+
+  return (
+    <div className="flex flex-col">
+      {/* Board Header with Navigation */}
+      <div className="flex items-center justify-between px-4 py-3 bg-surface rounded-t-2xl">
+        {/* Previous Arrow */}
+        <button
+          onClick={goToPrevious}
+          disabled={!hasPrevious}
+          className={`p-2 rounded-full transition-all duration-200 ${
+            hasPrevious
+              ? 'hover:bg-surface-hover text-foreground'
+              : 'text-text-tertiary cursor-not-allowed'
+          }`}
+          aria-label="Previous board"
+        >
+          <ChevronLeftIcon className="w-5 h-5" />
+        </button>
+
+        {/* Board Name (tappable to open picker) */}
+        <button
+          onClick={onOpenBoardPicker}
+          className="flex-1 text-center px-4"
+        >
+          <h2 className="font-semibold text-foreground text-base truncate">
+            {currentBoard?.name || 'No Board Selected'}
+          </h2>
+          {boards.length > 1 && (
+            <span className="text-xs text-text-tertiary">
+              Tap to select • Swipe to navigate
+            </span>
+          )}
+        </button>
+
+        {/* Next Arrow */}
+        <button
+          onClick={goToNext}
+          disabled={!hasNext}
+          className={`p-2 rounded-full transition-all duration-200 ${
+            hasNext
+              ? 'hover:bg-surface-hover text-foreground'
+              : 'text-text-tertiary cursor-not-allowed'
+          }`}
+          aria-label="Next board"
+        >
+          <ChevronRightIcon className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* Dot Indicators */}
+      {boards.length > 1 && (
+        <div className="flex items-center justify-center gap-1.5 py-2 bg-surface">
+          {boards.map((_, index) => (
+            <button
+              key={index}
+              onClick={() => {
+                if (index !== currentBoardIndex) {
+                  if (navigator.vibrate) {
+                    navigator.vibrate(20);
+                  }
+                  onBoardChange(index);
+                }
+              }}
+              className={`w-2 h-2 rounded-full transition-all duration-200 ${
+                index === currentBoardIndex
+                  ? 'bg-primary-500 w-4'
+                  : 'bg-text-tertiary hover:bg-text-secondary'
+              }`}
+              aria-label={`Go to board ${index + 1}`}
+              aria-current={index === currentBoardIndex ? 'true' : 'false'}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Swipeable Content Area */}
+      <motion.div
+        ref={containerRef}
+        className="flex-1 overflow-hidden touch-pan-y"
+        drag="x"
+        dragConstraints={{ left: 0, right: 0 }}
+        dragElastic={{ left: hasPrevious ? 0.2 : 0, right: hasNext ? 0.2 : 0 }}
+        onDragEnd={handleDragEnd}
+      >
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={currentBoardIndex}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.15 }}
+          >
+            {children}
+          </motion.div>
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create SwipeableBoardNavigator component for mobile board navigation
- Support horizontal swipe gestures to navigate between boards
- Add dot indicators showing current board position
- Add left/right arrows in header for tap navigation
- Haptic feedback on board changes (on supported devices)
- Keep dropdown picker accessible for quick board jumping

## Layout
```
┌─────────────────────────────────────┐
│    ◀  Daily Phrases  ▶              │
│         ● ○ ○ ○ ○                   │
├─────────────────────────────────────┤
│      [Swipeable Grid Area]          │
└─────────────────────────────────────┘
```

## Test plan
- [ ] Verify swipe left navigates to next board
- [ ] Verify swipe right navigates to previous board
- [ ] Test dot indicators update correctly
- [ ] Test arrow buttons work for navigation
- [ ] Verify haptic feedback on supported devices
- [ ] Test board picker popup opens on header tap

Closes #201