### PR TITLE
Touch Target & Accessibility Audit

### DIFF
--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -63,10 +63,15 @@ export default function PhraseTile({ phrase, onPress, onEdit, onLongPress, class
     }
   };
 
+  // Check for reduced motion preference
+  const prefersReducedMotion = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
   return (
     <motion.div
       className={`relative bg-surface rounded-2xl shadow-md cursor-pointer
         flex flex-col items-center justify-center min-h-[80px]
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
         ${onEdit ? 'ring-2 ring-blue-400' : ''}
         ${isSpeaking ? 'ring-2 ring-orange' : ''}
         ${className}`}
@@ -77,12 +82,22 @@ export default function PhraseTile({ phrase, onPress, onEdit, onLongPress, class
       onMouseDown={handleTouchStart}
       onMouseUp={handleTouchEnd}
       onMouseLeave={handleTouchEnd}
-      whileTap={{ scale: 0.95 }}
-      animate={{
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
+      animate={prefersReducedMotion ? undefined : {
         scale: isPressed ? 0.95 : 1,
         backgroundColor: isPressed ? 'var(--surface-hover)' : 'var(--surface)',
       }}
       transition={{ duration: 0.15 }}
+      role="button"
+      tabIndex={0}
+      aria-label={onEdit ? `Edit phrase: ${phrase.text}` : `Speak phrase: ${phrase.text}`}
+      aria-pressed={isSpeaking}
     >
       {onEdit && (
         <div className="absolute top-2 right-2 z-10">

--- a/app/components/ui/BottomSheet.tsx
+++ b/app/components/ui/BottomSheet.tsx
@@ -237,10 +237,10 @@ export default function BottomSheet({
                 {showCloseButton && (
                   <button
                     onClick={onClose}
-                    className="p-2 -mr-2 rounded-full hover:bg-surface-hover transition-colors"
+                    className="p-3 -mr-2 min-h-[44px] min-w-[44px] rounded-full hover:bg-surface-hover transition-colors flex items-center justify-center"
                     aria-label="Close"
                   >
-                    <XMarkIcon className="w-5 h-5 text-text-secondary" />
+                    <XMarkIcon className="w-6 h-6 text-text-secondary" />
                   </button>
                 )}
               </div>

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -21,10 +21,11 @@ const buttonVariants = cva(
         link: 'text-foreground underline-offset-4 hover:underline hover:text-primary-500',
       },
       size: {
-        default: 'h-10 px-6 py-2',
-        sm: 'h-8 rounded-3xl px-4 text-xs',
-        lg: 'h-12 rounded-3xl px-10',
-        icon: 'h-10 w-10',
+        // All sizes meet minimum 44px touch target requirement
+        default: 'h-11 min-h-[44px] px-6 py-2',
+        sm: 'h-10 min-h-[44px] rounded-3xl px-4 text-xs',
+        lg: 'h-12 min-h-[48px] rounded-3xl px-10',
+        icon: 'h-11 w-11 min-h-[44px] min-w-[44px]',
       },
     },
     defaultVariants: {
@@ -56,11 +57,15 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       );
     }
 
+    // Check for reduced motion preference
+    const prefersReducedMotion = typeof window !== 'undefined'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     return (
       <motion.button
         className={cn(buttonVariants({ variant, size, className }))}
-        whileHover={{ scale: 1.05 }}
-        whileTap={{ scale: 0.98 }}
+        whileHover={prefersReducedMotion ? undefined : { scale: 1.05 }}
+        whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
         transition={{ duration: 0.2 }}
         ref={ref}
         {...(props as ButtonAsMotionProps)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -123,3 +123,46 @@ body {
     }
   }
 }
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  :root {
+    --border: #666666;
+    --text-secondary: #d0d0d0;
+    --text-tertiary: #a0a0a0;
+  }
+}
+
+/* Focus visible styles for better keyboard navigation */
+:focus-visible {
+  outline: 2px solid var(--color-primary-500, #3b82f6);
+  outline-offset: 2px;
+}
+
+/* Skip link for screen readers */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  padding: 8px 16px;
+  background: var(--surface);
+  color: var(--foreground);
+  z-index: 100;
+  transition: top 0.2s;
+}
+
+.skip-link:focus {
+  top: 0;
+}

--- a/lib/hooks/useReducedMotion.ts
+++ b/lib/hooks/useReducedMotion.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook to detect if the user prefers reduced motion
+ * Respects the prefers-reduced-motion media query
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    // Check if window is available (SSR safety)
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    // Set initial value
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    // Listen for changes
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}


### PR DESCRIPTION
## Summary
- Increase button touch targets to minimum 44px (WCAG requirement)
- Increase BottomSheet close button to 44px minimum
- Add keyboard navigation to PhraseTile (Enter/Space to activate)
- Add ARIA labels and roles to PhraseTile for screen readers
- Add focus-visible states for keyboard navigation
- Add reduced motion support in CSS and components
- Add high contrast mode support
- Add useReducedMotion hook for motion preference detection
- Add skip-link utility class for screen readers

## Test plan
- [ ] Verify all buttons are at least 44x44px
- [ ] Test keyboard navigation (Tab, Enter, Space)
- [ ] Test with screen reader
- [ ] Enable "Reduce motion" in OS settings and verify animations are disabled
- [ ] Enable high contrast mode and verify improved visibility

Closes #205