### PR TITLE
fix: restrict modal scroll above bottom nav

### DIFF
--- a/app/components/ui/BottomSheet.tsx
+++ b/app/components/ui/BottomSheet.tsx
@@ -248,7 +248,10 @@ export default function BottomSheet({
             )}
 
             {/* Content */}
-            <div className="flex-1 overflow-y-auto overscroll-contain">
+            <div
+              className="flex-1 overflow-y-auto overscroll-contain"
+              style={{ paddingBottom: 'var(--bottom-stack-height)' }}
+            >
               {children}
             </div>
           </motion.div>


### PR DESCRIPTION
## Summary
- Add padding-bottom to BottomSheet content area using `--bottom-stack-height` CSS variable
- Ensures sheet content can scroll above the bottom navigation bar without being hidden

## Test plan
- [ ] Open Settings → Voice & Speech sheet on mobile viewport
- [ ] Scroll to bottom of sheet content
- [ ] Verify all content is visible above the bottom nav