### PR TITLE
Add feature parity to mobile TypingDock

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -47,6 +47,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
     createTab,
     switchTab,
     closeTab,
+    closeAllTabs,
     renameTab,
     updateActiveTabText,
     switchToTabByIndex,
@@ -428,6 +429,10 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
           activeTabId={activeTabId}
           onSwitchTab={switchTab}
           onCloseTab={closeTab}
+          onCloseAllTabs={() => {
+            closeAllTabs();
+            onChange?.('');
+          }}
           onRenameTab={renameTab}
         />
       )}

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -8,37 +8,94 @@ import {
   XMarkIcon,
   ChevronUpIcon,
   ChevronDownIcon,
+  ArrowPathIcon,
+  ShareIcon,
 } from '@heroicons/react/24/outline';
 import { useSettings } from '../contexts/SettingsContext';
+import { useAuth } from '../contexts/AuthContext';
+import { useTypingShare } from '@/lib/hooks/useTypingShare';
+import { useTypingTabs } from './typing-tabs/useTypingTabs';
+import SubscriptionWrapper from './SubscriptionWrapper';
+import FleshOutBottomSheet from './flesh-out/FleshOutBottomSheet';
+import ShareBottomSheet from './typing-share/ShareBottomSheet';
+import MobileTabIndicator from './typing-tabs/MobileTabIndicator';
+import MobileTabList from './typing-tabs/MobileTabList';
 
 interface TypingDockProps {
   text: string;
   onChange: (text: string) => void;
   onSpeak: () => void;
-  onAiAssist?: () => void;
   isSpeaking?: boolean;
   isAvailable?: boolean;
   className?: string;
+  // Feature flags
+  enableTabs?: boolean;
+  enableShare?: boolean;
+  enableFleshOut?: boolean;
+  enableFixText?: boolean;
 }
 
 export default function TypingDock({
   text,
   onChange,
   onSpeak,
-  onAiAssist,
   isSpeaking = false,
   isAvailable = true,
   className = '',
+  enableTabs = false,
+  enableShare = false,
+  enableFleshOut = false,
+  enableFixText = false,
 }: TypingDockProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+  const [isFixingText, setIsFixingText] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showFleshOutSheet, setShowFleshOutSheet] = useState(false);
+  const [showShareSheet, setShowShareSheet] = useState(false);
+  const [showTabList, setShowTabList] = useState(false);
+
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const { settings } = useSettings();
+  const { user } = useAuth();
+
+  // Typing share hook
+  const typingShare = useTypingShare();
+  const shareableLink = typingShare.getShareableLink();
+
+  // Typing tabs hook (only used when enableTabs is true)
+  const {
+    tabs,
+    activeTab,
+    activeTabId,
+    createTab,
+    switchTab,
+    closeTab,
+    closeAllTabs,
+    renameTab,
+    updateActiveTabText,
+  } = useTypingTabs(text);
+
+  // Sync tabs text with external text prop when tabs are enabled
+  useEffect(() => {
+    if (enableTabs && text !== activeTab.text) {
+      updateActiveTabText(text);
+    }
+  }, [enableTabs, text, activeTab.text, updateActiveTabText]);
 
   // Character count
   const charCount = text.length;
   const maxChars = 500;
+
+  // Text size classes
+  const textSizeClasses = {
+    small: 'text-sm',
+    medium: 'text-base',
+    large: 'text-xl',
+    xlarge: 'text-2xl',
+  };
+  const currentTextSizeClass = textSizeClasses[settings.textSize];
 
   // Auto-expand when text gets long
   useEffect(() => {
@@ -46,6 +103,13 @@ export default function TypingDock({
       setIsExpanded(true);
     }
   }, [text, isExpanded]);
+
+  // Update shared session content when text changes
+  useEffect(() => {
+    if (enableShare && typingShare.isSharing) {
+      typingShare.updateContent(text);
+    }
+  }, [text, enableShare, typingShare.isSharing, typingShare.updateContent]);
 
   // Handle Enter key
   const handleKeyDown = useCallback(
@@ -94,6 +158,7 @@ export default function TypingDock({
 
   const handleClear = () => {
     onChange('');
+    setError(null);
     if (isExpanded) {
       textareaRef.current?.focus();
     } else {
@@ -113,148 +178,374 @@ export default function TypingDock({
     }, 100);
   };
 
+  // Fix Text handler
+  const handleFixText = async () => {
+    if (!text.trim() || isFixingText) return;
+
+    setIsFixingText(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/fix-text', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ text }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (data.text && data.text !== text) {
+        onChange(data.text);
+      }
+    } catch (err) {
+      console.error('Error fixing text:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fix text');
+    } finally {
+      setIsFixingText(false);
+    }
+  };
+
+  // Flesh out handler
+  const handleFleshOut = () => {
+    if (!text.trim()) return;
+    setShowFleshOutSheet(true);
+  };
+
+  const handleApplyFleshedOutText = (newText: string) => {
+    onChange(newText);
+    setShowFleshOutSheet(false);
+  };
+
+  // Share handler
+  const handleShare = async () => {
+    if (!enableShare || !user) return;
+
+    if (typingShare.isSharing) {
+      setShowShareSheet(true);
+      return;
+    }
+
+    await typingShare.createSession();
+
+    if (typingShare.isSharing) {
+      typingShare.updateContent(text);
+      setShowShareSheet(true);
+    }
+  };
+
   return (
-    <div className={`border-t border-border ${className}`} style={{ backgroundColor: '#242424' }}>
-      <div className="px-3 py-2">
-        <AnimatePresence mode="wait">
-          {isExpanded ? (
-            <motion.div
-              key="expanded"
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.2 }}
-              className="space-y-2"
-            >
-              {/* Expanded textarea */}
-              <div className="relative">
-                <textarea
-                  ref={textareaRef}
-                  value={text}
-                  onChange={(e) => onChange(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onFocus={handleFocus}
-                  onBlur={handleBlur}
-                  placeholder="Type your message..."
-                  className="w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 pr-12 text-base resize-none focus:outline-none focus:ring-2 focus:ring-primary-500"
-                  rows={3}
-                  maxLength={maxChars}
-                />
-                {/* Collapse button */}
-                <button
-                  onClick={toggleExpanded}
-                  className="absolute top-2 right-2 p-1.5 rounded-full hover:bg-surface transition-colors"
-                  aria-label="Collapse"
-                >
-                  <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
-                </button>
-              </div>
-
-              {/* Character count */}
-              <div className="flex justify-between items-center px-1">
-                <span className={`text-xs ${charCount > maxChars * 0.9 ? 'text-orange-500' : 'text-text-tertiary'}`}>
-                  {charCount}/{maxChars}
-                </span>
-              </div>
-
-              {/* Action buttons row */}
-              <div className="flex items-center gap-2">
-                {/* AI Assist button */}
-                {onAiAssist && (
-                  <button
-                    onClick={onAiAssist}
-                    disabled={!text.trim()}
-                    className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-purple text-text-secondary hover:text-purple-500 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label="AI Assist"
-                  >
-                    <SparklesIcon className="w-4 h-4" />
-                    <span className="text-sm font-medium">AI</span>
-                  </button>
+    <>
+      <div className={`border-t border-border ${className}`} style={{ backgroundColor: '#242424' }}>
+        <div className="px-3 py-2">
+          <AnimatePresence mode="wait">
+            {isExpanded ? (
+              <motion.div
+                key="expanded"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2 }}
+                className="space-y-2"
+              >
+                {/* Tab indicator row (expanded mode) */}
+                {enableTabs && (
+                  <div className="flex items-center justify-between">
+                    <MobileTabIndicator
+                      tabs={tabs}
+                      activeTab={activeTab}
+                      onClick={() => setShowTabList(true)}
+                    />
+                    <button
+                      onClick={toggleExpanded}
+                      className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                      aria-label="Collapse"
+                    >
+                      <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
+                    </button>
+                  </div>
                 )}
 
-                {/* Clear button */}
-                <button
-                  onClick={handleClear}
-                  disabled={!text.trim()}
-                  className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-error text-text-secondary hover:text-red-500 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
-                  aria-label="Clear"
-                >
-                  <XMarkIcon className="w-4 h-4" />
-                  <span className="text-sm font-medium">Clear</span>
-                </button>
+                {/* Expanded textarea */}
+                <div className="relative">
+                  <textarea
+                    ref={textareaRef}
+                    value={text}
+                    onChange={(e) => onChange(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                    placeholder="Type your message..."
+                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-12'} ${currentTextSizeClass} resize-none focus:outline-none focus:ring-2 focus:ring-primary-500`}
+                    rows={3}
+                    maxLength={maxChars}
+                  />
+                  {/* Collapse button (when tabs are not enabled) */}
+                  {!enableTabs && (
+                    <button
+                      onClick={toggleExpanded}
+                      className="absolute top-2 right-2 p-1.5 rounded-full hover:bg-surface transition-colors"
+                      aria-label="Collapse"
+                    >
+                      <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
+                    </button>
+                  )}
+                </div>
 
-                {/* Spacer */}
-                <div className="flex-1" />
+                {/* Character count and error */}
+                <div className="flex justify-between items-center px-1">
+                  <span className={`text-xs ${charCount > maxChars * 0.9 ? 'text-orange-500' : 'text-text-tertiary'}`}>
+                    {charCount}/{maxChars}
+                  </span>
+                  {error && (
+                    <span className="text-xs text-red-500">{error}</span>
+                  )}
+                </div>
 
-                {/* Speak button - primary CTA */}
-                <motion.button
-                  onClick={onSpeak}
-                  disabled={!isAvailable || !text.trim()}
-                  className={`flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
-                    isSpeaking
-                      ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white'
-                      : 'bg-primary-500 hover:bg-primary-600 text-white'
-                  }`}
-                  whileTap={{ scale: 0.95 }}
-                  aria-label={isSpeaking ? 'Speaking...' : 'Speak'}
-                >
-                  <SpeakerWaveIcon className={`w-5 h-5 ${isSpeaking ? 'animate-pulse' : ''}`} />
-                  <span>{isSpeaking ? 'Speaking...' : 'Speak'}</span>
-                </motion.button>
-              </div>
-            </motion.div>
-          ) : (
-            <motion.div
-              key="compact"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              className="flex items-center gap-2"
-            >
-              {/* Compact input */}
-              <div className="flex-1 relative">
-                <input
-                  ref={inputRef}
-                  type="text"
-                  value={text}
-                  onChange={(e) => onChange(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onFocus={handleFocus}
-                  onBlur={handleBlur}
-                  placeholder="Type to speak..."
-                  className="w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-full px-4 py-3 pr-10 text-base focus:outline-none focus:ring-2 focus:ring-primary-500"
-                />
-                {/* Expand button */}
-                <button
-                  onClick={toggleExpanded}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-full hover:bg-surface transition-colors"
-                  aria-label="Expand"
-                >
-                  <ChevronUpIcon className="w-4 h-4 text-text-secondary" />
-                </button>
-              </div>
+                {/* Row 1: AI Features (when text exists) */}
+                {text.trim() && (enableFleshOut || enableFixText || (enableShare && user)) && (
+                  <div className="flex items-center gap-2">
+                    {/* Flesh Out button */}
+                    {enableFleshOut && (
+                      <button
+                        onClick={handleFleshOut}
+                        disabled={!text.trim()}
+                        className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-purple text-text-secondary hover:text-purple-500 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
+                        aria-label="Flesh Out"
+                      >
+                        <ArrowPathIcon className="w-4 h-4" />
+                        <span className="text-sm font-medium">Flesh Out</span>
+                      </button>
+                    )}
 
-              {/* Speak button - primary CTA */}
-              <motion.button
-                onClick={onSpeak}
-                disabled={!isAvailable || !text.trim()}
-                className={`flex-shrink-0 p-4 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
-                  isSpeaking
-                    ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white'
-                    : text.trim()
-                    ? 'bg-primary-500 hover:bg-primary-600 text-white'
-                    : 'bg-surface-hover text-text-tertiary'
-                }`}
-                whileTap={{ scale: 0.95 }}
-                aria-label={isSpeaking ? 'Speaking...' : 'Speak'}
+                    {/* Fix Text button (Pro) */}
+                    {enableFixText && (
+                      <SubscriptionWrapper
+                        fallback={
+                          <button
+                            onClick={() => window.location.href = '/pricing'}
+                            className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-warning text-text-secondary hover:text-amber-500 transition-all duration-200"
+                            aria-label="Fix Text (Pro)"
+                          >
+                            <SparklesIcon className="w-4 h-4" />
+                            <span className="text-sm font-medium">Fix Text</span>
+                          </button>
+                        }
+                      >
+                        <button
+                          onClick={handleFixText}
+                          disabled={!text.trim() || isFixingText}
+                          className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed ${
+                            isFixingText
+                              ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
+                              : 'bg-surface-hover hover:bg-status-purple text-text-secondary hover:text-purple-500'
+                          }`}
+                          aria-label="Fix Text"
+                        >
+                          {isFixingText ? (
+                            <>
+                              <ArrowPathIcon className="w-4 h-4 animate-spin" />
+                              <span className="text-sm font-medium">Fixing...</span>
+                            </>
+                          ) : (
+                            <>
+                              <SparklesIcon className="w-4 h-4" />
+                              <span className="text-sm font-medium">Fix Text</span>
+                            </>
+                          )}
+                        </button>
+                      </SubscriptionWrapper>
+                    )}
+
+                    {/* Share button */}
+                    {enableShare && user && (
+                      <button
+                        onClick={() => setShowShareSheet(true)}
+                        className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 ${
+                          typingShare.isSharing
+                            ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
+                            : 'bg-surface-hover hover:bg-status-success text-text-secondary hover:text-green-500'
+                        }`}
+                        aria-label="Share"
+                      >
+                        <ShareIcon className="w-4 h-4" />
+                        <span className="text-sm font-medium">
+                          {typingShare.isSharing ? 'Sharing' : 'Share'}
+                        </span>
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Row 2: Primary Actions */}
+                <div className="flex items-center gap-2">
+                  {/* Clear button */}
+                  <button
+                    onClick={handleClear}
+                    disabled={!text.trim()}
+                    className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-error text-text-secondary hover:text-red-500 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
+                    aria-label="Clear"
+                  >
+                    <XMarkIcon className="w-4 h-4" />
+                    <span className="text-sm font-medium">Clear</span>
+                  </button>
+
+                  {/* Spacer */}
+                  <div className="flex-1" />
+
+                  {/* Speak button - primary CTA */}
+                  <motion.button
+                    onClick={onSpeak}
+                    disabled={!isAvailable || !text.trim()}
+                    className={`flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
+                      isSpeaking
+                        ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white'
+                        : 'bg-primary-500 hover:bg-primary-600 text-white'
+                    }`}
+                    whileTap={{ scale: 0.95 }}
+                    aria-label={isSpeaking ? 'Speaking...' : 'Speak'}
+                  >
+                    <SpeakerWaveIcon className={`w-5 h-5 ${isSpeaking ? 'animate-pulse' : ''}`} />
+                    <span>{isSpeaking ? 'Speaking...' : 'Speak'}</span>
+                  </motion.button>
+                </div>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="compact"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.15 }}
+                className="space-y-2"
               >
-                <SpeakerWaveIcon className={`w-6 h-6 ${isSpeaking ? 'animate-pulse' : ''}`} />
-              </motion.button>
-            </motion.div>
-          )}
-        </AnimatePresence>
+                {/* Tab indicator (compact mode) */}
+                {enableTabs && (
+                  <div className="flex justify-center">
+                    <MobileTabIndicator
+                      tabs={tabs}
+                      activeTab={activeTab}
+                      onClick={() => setShowTabList(true)}
+                    />
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2">
+                  {/* Compact input */}
+                  <div className="flex-1 relative">
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      value={text}
+                      onChange={(e) => onChange(e.target.value)}
+                      onKeyDown={handleKeyDown}
+                      onFocus={handleFocus}
+                      onBlur={handleBlur}
+                      placeholder="Type to speak..."
+                      className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-full px-4 py-3 pr-10 ${currentTextSizeClass} focus:outline-none focus:ring-2 focus:ring-primary-500`}
+                    />
+                    {/* Expand button */}
+                    <button
+                      onClick={toggleExpanded}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-full hover:bg-surface transition-colors"
+                      aria-label="Expand"
+                    >
+                      <ChevronUpIcon className="w-4 h-4 text-text-secondary" />
+                    </button>
+                  </div>
+
+                  {/* Speak button - primary CTA */}
+                  <motion.button
+                    onClick={onSpeak}
+                    disabled={!isAvailable || !text.trim()}
+                    className={`flex-shrink-0 p-4 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
+                      isSpeaking
+                        ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white'
+                        : text.trim()
+                        ? 'bg-primary-500 hover:bg-primary-600 text-white'
+                        : 'bg-surface-hover text-text-tertiary'
+                    }`}
+                    whileTap={{ scale: 0.95 }}
+                    aria-label={isSpeaking ? 'Speaking...' : 'Speak'}
+                  >
+                    <SpeakerWaveIcon className={`w-6 h-6 ${isSpeaking ? 'animate-pulse' : ''}`} />
+                  </motion.button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
       </div>
-    </div>
+
+      {/* Flesh Out Bottom Sheet */}
+      {enableFleshOut && (
+        <FleshOutBottomSheet
+          isOpen={showFleshOutSheet}
+          initialText={text}
+          onClose={() => setShowFleshOutSheet(false)}
+          onApply={handleApplyFleshedOutText}
+        />
+      )}
+
+      {/* Share Bottom Sheet */}
+      {enableShare && user && (
+        <ShareBottomSheet
+          isOpen={showShareSheet}
+          onClose={() => setShowShareSheet(false)}
+          isSharing={typingShare.isSharing}
+          isCreating={typingShare.isCreating}
+          shareableLink={shareableLink}
+          onStartSharing={async () => {
+            await typingShare.createSession();
+            if (typingShare.isSharing) {
+              typingShare.updateContent(text);
+            }
+          }}
+          onEndSession={async () => {
+            await typingShare.endSession();
+          }}
+        />
+      )}
+
+      {/* Tab List Bottom Sheet */}
+      {enableTabs && (
+        <MobileTabList
+          isOpen={showTabList}
+          onClose={() => setShowTabList(false)}
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onSwitchTab={(tabId) => {
+            switchTab(tabId);
+            const tab = tabs.find(t => t.id === tabId);
+            if (tab) {
+              onChange(tab.text);
+            }
+          }}
+          onCloseTab={(tabId) => {
+            closeTab(tabId);
+            // Update the text to the new active tab's text
+            const remainingTabs = tabs.filter(t => t.id !== tabId);
+            if (remainingTabs.length > 0) {
+              onChange(remainingTabs[0].text);
+            }
+          }}
+          onCloseAllTabs={() => {
+            closeAllTabs();
+            onChange('');
+          }}
+          onCreateTab={() => {
+            createTab();
+            onChange('');
+          }}
+          onRenameTab={renameTab}
+        />
+      )}
+    </>
   );
 }

--- a/app/components/flesh-out/FleshOutBottomSheet.tsx
+++ b/app/components/flesh-out/FleshOutBottomSheet.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { Button } from '@/app/components/ui/Button';
+import SubscriptionWrapper from '@/app/components/SubscriptionWrapper';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+
+interface FleshOutBottomSheetProps {
+  isOpen: boolean;
+  initialText: string;
+  onClose: () => void;
+  onApply: (text: string) => void;
+}
+
+type GenerationMode = 'want' | 'need' | 'feel' | 'think' | 'ask' | 'like' | 'dislike' | 'remember' | 'wonder' | 'hope';
+
+const MODES: { mode: GenerationMode; label: string }[] = [
+  { mode: 'want', label: 'I want...' },
+  { mode: 'need', label: 'I need...' },
+  { mode: 'feel', label: 'I feel...' },
+  { mode: 'think', label: 'I think...' },
+  { mode: 'ask', label: 'I want to ask...' },
+  { mode: 'like', label: 'I like...' },
+  { mode: 'dislike', label: "I don't like..." },
+  { mode: 'remember', label: 'I remember...' },
+  { mode: 'wonder', label: 'I wonder...' },
+  { mode: 'hope', label: 'I hope...' },
+];
+
+export default function FleshOutBottomSheet({ isOpen, initialText, onClose, onApply }: FleshOutBottomSheetProps) {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeMode, setActiveMode] = useState<GenerationMode | null>(null);
+
+  const handleModeSelect = async (mode: GenerationMode) => {
+    setActiveMode(mode);
+    setIsGenerating(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/flesh-out', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: initialText,
+          mode
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Failed to parse error response' }));
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (!data.text) {
+        throw new Error('No text returned from server');
+      }
+
+      onApply(data.text);
+      onClose();
+    } catch (err) {
+      console.error('Error generating text:', err);
+      setError(err instanceof Error ? err.message : 'Failed to generate text');
+    } finally {
+      setIsGenerating(false);
+      setActiveMode(null);
+    }
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Flesh Out"
+      snapPoints={[60]}
+      initialSnap={0}
+    >
+      <div className="p-4 space-y-4">
+        {/* Preview of current text */}
+        <div className="bg-surface-hover p-3 rounded-xl text-foreground text-sm line-clamp-2">
+          {initialText}
+        </div>
+
+        {/* Subscription gate for the mode buttons */}
+        <SubscriptionWrapper
+          fallback={
+            <div className="bg-surface-hover p-6 rounded-xl text-center">
+              <svg className="w-10 h-10 mx-auto text-text-secondary mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+              <h3 className="text-lg font-semibold text-foreground mb-2">Pro Feature</h3>
+              <p className="text-text-secondary text-sm mb-4">
+                Enhance your messages with AI assistance.
+              </p>
+              <Button
+                onClick={() => window.location.href = '/pricing'}
+                className="w-full"
+              >
+                Upgrade to Pro
+              </Button>
+            </div>
+          }
+        >
+          <div>
+            <p className="text-sm text-text-secondary mb-3">
+              Select how you want to continue:
+            </p>
+
+            {/* 2-column grid of mode buttons */}
+            <div className="grid grid-cols-2 gap-2">
+              {MODES.map(({ mode, label }) => (
+                <button
+                  key={mode}
+                  onClick={() => handleModeSelect(mode)}
+                  disabled={isGenerating}
+                  className={`min-h-[48px] px-4 py-3 rounded-xl font-medium text-sm transition-all duration-200 flex items-center justify-center gap-2 ${
+                    isGenerating && activeMode === mode
+                      ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
+                      : 'bg-surface hover:bg-surface-hover text-foreground border border-border hover:border-purple-500'
+                  } disabled:opacity-50 disabled:cursor-not-allowed`}
+                >
+                  {isGenerating && activeMode === mode ? (
+                    <>
+                      <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                      <span>Generating...</span>
+                    </>
+                  ) : (
+                    label
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        </SubscriptionWrapper>
+
+        {error && (
+          <div className="text-red-500 text-sm text-center p-2 bg-status-error rounded-lg">
+            {error}
+          </div>
+        )}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -359,6 +359,10 @@ export default function PhrasesInterface() {
             onSpeak={handleSpeak}
             isSpeaking={tts.isSpeaking}
             isAvailable={tts.isAvailable}
+            enableTabs={true}
+            enableShare={!!user}
+            enableFleshOut={true}
+            enableFixText={true}
           />
         </MobileDockPortal>
       )}

--- a/app/components/typing-share/ShareBottomSheet.tsx
+++ b/app/components/typing-share/ShareBottomSheet.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import { ClipboardIcon, CheckIcon, ArrowPathIcon, ShareIcon, StopIcon } from '@heroicons/react/24/outline';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+
+interface ShareBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  isSharing: boolean;
+  isCreating: boolean;
+  shareableLink: string | null;
+  onStartSharing: () => Promise<void>;
+  onEndSession: () => Promise<void>;
+}
+
+export default function ShareBottomSheet({
+  isOpen,
+  onClose,
+  isSharing,
+  isCreating,
+  shareableLink,
+  onStartSharing,
+  onEndSession,
+}: ShareBottomSheetProps) {
+  const [copied, setCopied] = useState(false);
+  const [isEnding, setIsEnding] = useState(false);
+
+  const handleCopy = async () => {
+    if (!shareableLink) return;
+
+    try {
+      await navigator.clipboard.writeText(shareableLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy link:', err);
+    }
+  };
+
+  const handleStartSharing = async () => {
+    try {
+      await onStartSharing();
+    } catch (err) {
+      console.error('Failed to start sharing:', err);
+    }
+  };
+
+  const handleEndSession = async () => {
+    setIsEnding(true);
+    try {
+      await onEndSession();
+      onClose();
+    } catch (err) {
+      console.error('Failed to end session:', err);
+    } finally {
+      setIsEnding(false);
+    }
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Share Session"
+      snapPoints={[40]}
+      initialSnap={0}
+    >
+      <div className="p-4 space-y-4">
+        {!isSharing ? (
+          /* Not sharing - show start button */
+          <div className="text-center py-4">
+            <ShareIcon className="w-12 h-12 mx-auto text-text-secondary mb-3" />
+            <h3 className="text-lg font-medium text-foreground mb-2">Share Your Typing</h3>
+            <p className="text-text-secondary text-sm mb-6">
+              Let others see what you're typing in real-time. The session expires in 24 hours.
+            </p>
+
+            <button
+              onClick={handleStartSharing}
+              disabled={isCreating}
+              className={`w-full min-h-[48px] px-6 py-3 rounded-xl font-semibold transition-all duration-200 flex items-center justify-center gap-2 ${
+                isCreating
+                  ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
+                  : 'bg-green-500 hover:bg-green-600 text-white'
+              } disabled:opacity-50 disabled:cursor-not-allowed`}
+            >
+              {isCreating ? (
+                <>
+                  <ArrowPathIcon className="w-5 h-5 animate-spin" />
+                  <span>Creating Session...</span>
+                </>
+              ) : (
+                <>
+                  <ShareIcon className="w-5 h-5" />
+                  <span>Start Sharing</span>
+                </>
+              )}
+            </button>
+          </div>
+        ) : (
+          /* Currently sharing - show link and controls */
+          <div className="space-y-4">
+            <div className="bg-status-success p-3 rounded-xl flex items-center gap-2">
+              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+              <span className="text-green-400 text-sm font-medium">Sharing Active</span>
+            </div>
+
+            <p className="text-text-secondary text-sm">
+              Share this link with others to let them see what you're typing in real-time.
+            </p>
+
+            {/* Link display with copy button */}
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={shareableLink || ''}
+                readOnly
+                className="flex-1 px-4 py-3 bg-background border border-border rounded-xl text-foreground text-sm"
+              />
+              <button
+                onClick={handleCopy}
+                className={`min-w-[48px] min-h-[48px] px-4 rounded-xl transition-colors flex items-center justify-center ${
+                  copied
+                    ? 'bg-green-500 text-white'
+                    : 'bg-primary-500 hover:bg-primary-600 text-white'
+                }`}
+                aria-label="Copy link"
+              >
+                {copied ? (
+                  <CheckIcon className="w-5 h-5" />
+                ) : (
+                  <ClipboardIcon className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+
+            {/* End session button */}
+            <button
+              onClick={handleEndSession}
+              disabled={isEnding}
+              className="w-full min-h-[48px] px-6 py-3 rounded-xl font-medium transition-all duration-200 flex items-center justify-center gap-2 bg-red-500 hover:bg-red-600 text-white disabled:opacity-50"
+            >
+              {isEnding ? (
+                <>
+                  <ArrowPathIcon className="w-5 h-5 animate-spin" />
+                  <span>Ending Session...</span>
+                </>
+              ) : (
+                <>
+                  <StopIcon className="w-5 h-5" />
+                  <span>End Session</span>
+                </>
+              )}
+            </button>
+          </div>
+        )}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/app/components/typing-tabs/MobileTabIndicator.tsx
+++ b/app/components/typing-tabs/MobileTabIndicator.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { DocumentTextIcon } from '@heroicons/react/24/outline';
+import type { TypingTab } from '@/app/types/typing-tabs';
+
+interface MobileTabIndicatorProps {
+  tabs: TypingTab[];
+  activeTab: TypingTab;
+  onClick: () => void;
+}
+
+export default function MobileTabIndicator({ tabs, activeTab, onClick }: MobileTabIndicatorProps) {
+  const tabCount = tabs.length;
+  const activeIndex = tabs.findIndex(t => t.id === activeTab.id) + 1;
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-surface-hover hover:bg-surface transition-colors min-h-[32px]"
+      aria-label={`Tab ${activeIndex} of ${tabCount}: ${activeTab.label}`}
+    >
+      <DocumentTextIcon className="w-4 h-4 text-text-secondary" />
+      <span className="text-xs font-medium text-text-secondary truncate max-w-[80px]">
+        {activeTab.label}
+      </span>
+      {tabCount > 1 && (
+        <span className="text-xs text-text-tertiary">
+          ({activeIndex}/{tabCount})
+        </span>
+      )}
+    </button>
+  );
+}

--- a/app/components/typing-tabs/MobileTabList.tsx
+++ b/app/components/typing-tabs/MobileTabList.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState } from 'react';
+import { PlusIcon, XMarkIcon, PencilIcon, CheckIcon, TrashIcon } from '@heroicons/react/24/outline';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+import type { TypingTab } from '@/app/types/typing-tabs';
+
+interface MobileTabListProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tabs: TypingTab[];
+  activeTabId: string | null;
+  onSwitchTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onCloseAllTabs: () => void;
+  onCreateTab: () => void;
+  onRenameTab: (tabId: string, newLabel: string) => void;
+}
+
+export default function MobileTabList({
+  isOpen,
+  onClose,
+  tabs,
+  activeTabId,
+  onSwitchTab,
+  onCloseTab,
+  onCloseAllTabs,
+  onCreateTab,
+  onRenameTab,
+}: MobileTabListProps) {
+  const [editingTabId, setEditingTabId] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState('');
+
+  const handleStartEditing = (tab: TypingTab) => {
+    setEditingTabId(tab.id);
+    setEditLabel(tab.label);
+  };
+
+  const handleSaveEdit = (tabId: string) => {
+    if (editLabel.trim()) {
+      onRenameTab(tabId, editLabel.trim());
+    }
+    setEditingTabId(null);
+    setEditLabel('');
+  };
+
+  const handleCancelEdit = () => {
+    setEditingTabId(null);
+    setEditLabel('');
+  };
+
+  const handleSelectTab = (tabId: string) => {
+    onSwitchTab(tabId);
+    onClose();
+  };
+
+  const handleCreateTab = () => {
+    onCreateTab();
+    onClose();
+  };
+
+  const handleCloseAll = () => {
+    onCloseAllTabs();
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Messages"
+      snapPoints={[50, 80]}
+      initialSnap={0}
+    >
+      <div className="p-2">
+        {/* Tab list */}
+        <div className="space-y-1">
+          {tabs.map((tab) => (
+            <div
+              key={tab.id}
+              className={`flex items-center gap-2 p-3 rounded-xl transition-colors ${
+                tab.id === activeTabId
+                  ? 'bg-primary-500/20 border border-primary-500'
+                  : 'bg-surface-hover hover:bg-surface'
+              }`}
+            >
+              {editingTabId === tab.id ? (
+                /* Editing mode */
+                <div className="flex-1 flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={editLabel}
+                    onChange={(e) => setEditLabel(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleSaveEdit(tab.id);
+                      if (e.key === 'Escape') handleCancelEdit();
+                    }}
+                    autoFocus
+                    className="flex-1 px-3 py-2 bg-background border border-border rounded-lg text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    maxLength={20}
+                  />
+                  <button
+                    onClick={() => handleSaveEdit(tab.id)}
+                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-green-500 text-white"
+                    aria-label="Save"
+                  >
+                    <CheckIcon className="w-5 h-5" />
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-surface hover:bg-surface-hover text-text-secondary"
+                    aria-label="Cancel"
+                  >
+                    <XMarkIcon className="w-5 h-5" />
+                  </button>
+                </div>
+              ) : (
+                /* Normal mode */
+                <>
+                  <button
+                    onClick={() => handleSelectTab(tab.id)}
+                    className="flex-1 text-left"
+                  >
+                    <div className="font-medium text-foreground truncate">
+                      {tab.label}
+                    </div>
+                    {tab.text && (
+                      <div className="text-xs text-text-tertiary truncate mt-0.5">
+                        {tab.text.slice(0, 50)}{tab.text.length > 50 ? '...' : ''}
+                      </div>
+                    )}
+                  </button>
+
+                  <button
+                    onClick={() => handleStartEditing(tab)}
+                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg hover:bg-surface transition-colors"
+                    aria-label={`Rename ${tab.label}`}
+                  >
+                    <PencilIcon className="w-4 h-4 text-text-secondary" />
+                  </button>
+
+                  {tabs.length > 1 && (
+                    <button
+                      onClick={() => onCloseTab(tab.id)}
+                      className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg hover:bg-status-error transition-colors"
+                      aria-label={`Close ${tab.label}`}
+                    >
+                      <XMarkIcon className="w-4 h-4 text-text-secondary hover:text-red-500" />
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Action buttons row */}
+        <div className="flex gap-2 mt-3">
+          {/* Add new tab button */}
+          <button
+            onClick={handleCreateTab}
+            className="flex-1 min-h-[48px] px-4 py-3 rounded-xl border-2 border-dashed border-border hover:border-primary-500 flex items-center justify-center gap-2 text-text-secondary hover:text-primary-500 transition-colors"
+          >
+            <PlusIcon className="w-5 h-5" />
+            <span className="font-medium">New</span>
+          </button>
+
+          {/* Close all tabs button - only show if more than 1 tab */}
+          {tabs.length > 1 && (
+            <button
+              onClick={handleCloseAll}
+              className="flex-1 min-h-[48px] px-4 py-3 rounded-xl bg-red-500 hover:bg-red-600 flex items-center justify-center gap-2 text-white transition-colors"
+            >
+              <TrashIcon className="w-5 h-5" />
+              <span className="font-medium">Close All</span>
+            </button>
+          )}
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/app/components/typing-tabs/TabManagementDialog.tsx
+++ b/app/components/typing-tabs/TabManagementDialog.tsx
@@ -12,6 +12,7 @@ interface TabManagementDialogProps {
   activeTabId: string | null;
   onSwitchTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
+  onCloseAllTabs: () => void;
   onRenameTab: (tabId: string, newLabel: string) => void;
 }
 
@@ -22,11 +23,11 @@ export default function TabManagementDialog({
   activeTabId,
   onSwitchTab,
   onCloseTab,
+  onCloseAllTabs,
   onRenameTab,
 }: TabManagementDialogProps) {
   const [editingTabId, setEditingTabId] = useState<string | null>(null);
   const [editLabel, setEditLabel] = useState('');
-  const [showCloseAllConfirm, setShowCloseAllConfirm] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
 
   // Reset editing state if tab being edited is closed
@@ -74,16 +75,8 @@ export default function TabManagementDialog({
   };
 
   const handleCloseAll = () => {
-    setShowCloseAllConfirm(true);
-  };
-
-  const handleConfirmCloseAll = () => {
-    tabs.forEach(tab => {
-      if (tab.id !== activeTabId) {
-        onCloseTab(tab.id);
-      }
-    });
-    setShowCloseAllConfirm(false);
+    onCloseAllTabs();
+    onClose();
   };
 
   return (
@@ -205,40 +198,13 @@ export default function TabManagementDialog({
                 {tabs.length > 1 && (
                   <button
                     onClick={handleCloseAll}
-                    className="w-full h-12 rounded-full bg-status-error hover:bg-red-900 text-red-500 hover:text-red-400 border-2 border-red-900 transition-all duration-200 font-medium flex items-center justify-center gap-2"
+                    className="w-full h-12 rounded-full bg-red-500 hover:bg-red-600 text-white transition-all duration-200 font-medium flex items-center justify-center gap-2"
                   >
                     <XMarkIcon className="w-5 h-5" />
-                    <span>Close All (Keep Active)</span>
+                    <span>Close All</span>
                   </button>
                 )}
 
-                {/* Confirmation overlay */}
-                {showCloseAllConfirm && (
-                  <div className="absolute inset-0 bg-overlay flex items-center justify-center rounded-2xl z-10">
-                    <div className="bg-surface p-6 rounded-2xl shadow-2xl max-w-sm mx-4">
-                      <h4 className="text-lg font-bold text-foreground mb-2">
-                        Close All Other Tabs?
-                      </h4>
-                      <p className="text-text-secondary mb-4">
-                        This will close {tabs.length - 1} tab{tabs.length - 1 !== 1 ? 's' : ''} and keep only the active tab.
-                      </p>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={handleConfirmCloseAll}
-                          className="flex-1 px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-xl font-medium transition-colors"
-                        >
-                          Confirm
-                        </button>
-                        <button
-                          onClick={() => setShowCloseAllConfirm(false)}
-                          className="flex-1 px-4 py-2 bg-surface-hover hover:bg-background text-foreground rounded-xl transition-colors"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -223,6 +223,16 @@ export function useTypingTabs(initialText?: string) {
     }
   }, [tabsState.tabs, tabsState.activeTabId, switchTab]);
 
+  // Close all tabs (resets to a single empty tab)
+  const closeAllTabs = useCallback(() => {
+    const newTab = createDefaultTab(1);
+    setTabsState({
+      tabs: [newTab],
+      activeTabId: newTab.id,
+      nextTabNumber: 2,
+    });
+  }, []);
+
   return {
     tabs: tabsState.tabs,
     activeTab,
@@ -230,6 +240,7 @@ export function useTypingTabs(initialText?: string) {
     createTab,
     switchTab,
     closeTab,
+    closeAllTabs,
     renameTab,
     updateActiveTabText,
     switchToTabByIndex,

--- a/tests/components/typing-tabs/TabManagementDialog.test.tsx
+++ b/tests/components/typing-tabs/TabManagementDialog.test.tsx
@@ -23,6 +23,7 @@ describe('TabManagementDialog', () => {
   const mockOnClose = jest.fn();
   const mockOnSwitchTab = jest.fn();
   const mockOnCloseTab = jest.fn();
+  const mockOnCloseAllTabs = jest.fn();
   const mockOnRenameTab = jest.fn();
 
   beforeEach(() => {
@@ -41,6 +42,7 @@ describe('TabManagementDialog', () => {
           activeTabId="test-tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -59,6 +61,7 @@ describe('TabManagementDialog', () => {
           activeTabId="test-tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -81,6 +84,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -104,6 +108,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -124,6 +129,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -144,6 +150,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -165,6 +172,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -185,6 +193,7 @@ describe('TabManagementDialog', () => {
           activeTabId="test-tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -206,6 +215,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -230,6 +240,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -254,6 +265,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -280,6 +292,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -304,6 +317,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -328,6 +342,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -351,6 +366,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -374,6 +390,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -399,6 +416,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -426,6 +444,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -452,6 +471,7 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
@@ -465,7 +485,7 @@ describe('TabManagementDialog', () => {
   });
 
   describe('close all functionality', () => {
-    it('shows confirmation when Close All is clicked', async () => {
+    it('calls onCloseAllTabs when Close All is clicked', async () => {
       const user = userEvent.setup();
       const tabs = [
         createTab({ id: 'tab-1', label: 'Tab 1' }),
@@ -480,93 +500,15 @@ describe('TabManagementDialog', () => {
           activeTabId="tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );
 
       await user.click(screen.getByText(/Close All/));
 
-      expect(screen.getByText('Close All Other Tabs?')).toBeInTheDocument();
-      expect(screen.getByText(/This will close 1 tab/)).toBeInTheDocument();
-    });
-
-    it('displays correct count in confirmation', async () => {
-      const user = userEvent.setup();
-      const tabs = [
-        createTab({ id: 'tab-1', label: 'Tab 1' }),
-        createTab({ id: 'tab-2', label: 'Tab 2' }),
-        createTab({ id: 'tab-3', label: 'Tab 3' }),
-      ];
-
-      render(
-        <TabManagementDialog
-          isOpen={true}
-          onClose={mockOnClose}
-          tabs={tabs}
-          activeTabId="tab-1"
-          onSwitchTab={mockOnSwitchTab}
-          onCloseTab={mockOnCloseTab}
-          onRenameTab={mockOnRenameTab}
-        />
-      );
-
-      await user.click(screen.getByText(/Close All/));
-
-      expect(screen.getByText(/This will close 2 tabs/)).toBeInTheDocument();
-    });
-
-    it('closes all tabs except active when confirmed', async () => {
-      const user = userEvent.setup();
-      const tabs = [
-        createTab({ id: 'tab-1', label: 'Tab 1' }),
-        createTab({ id: 'tab-2', label: 'Tab 2' }),
-        createTab({ id: 'tab-3', label: 'Tab 3' }),
-      ];
-
-      render(
-        <TabManagementDialog
-          isOpen={true}
-          onClose={mockOnClose}
-          tabs={tabs}
-          activeTabId="tab-1"
-          onSwitchTab={mockOnSwitchTab}
-          onCloseTab={mockOnCloseTab}
-          onRenameTab={mockOnRenameTab}
-        />
-      );
-
-      await user.click(screen.getByText(/Close All/));
-      await user.click(screen.getByText('Confirm'));
-
-      expect(mockOnCloseTab).toHaveBeenCalledWith('tab-2');
-      expect(mockOnCloseTab).toHaveBeenCalledWith('tab-3');
-      expect(mockOnCloseTab).not.toHaveBeenCalledWith('tab-1');
-    });
-
-    it('cancels close all when Cancel is clicked', async () => {
-      const user = userEvent.setup();
-      const tabs = [
-        createTab({ id: 'tab-1', label: 'Tab 1' }),
-        createTab({ id: 'tab-2', label: 'Tab 2' }),
-      ];
-
-      render(
-        <TabManagementDialog
-          isOpen={true}
-          onClose={mockOnClose}
-          tabs={tabs}
-          activeTabId="tab-1"
-          onSwitchTab={mockOnSwitchTab}
-          onCloseTab={mockOnCloseTab}
-          onRenameTab={mockOnRenameTab}
-        />
-      );
-
-      await user.click(screen.getByText(/Close All/));
-      await user.click(screen.getByText('Cancel'));
-
-      expect(mockOnCloseTab).not.toHaveBeenCalled();
-      expect(screen.queryByText('Close All Other Tabs?')).not.toBeInTheDocument();
+      expect(mockOnCloseAllTabs).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
     });
   });
 
@@ -583,6 +525,7 @@ describe('TabManagementDialog', () => {
           activeTabId="test-tab-1"
           onSwitchTab={mockOnSwitchTab}
           onCloseTab={mockOnCloseTab}
+          onCloseAllTabs={mockOnCloseAllTabs}
           onRenameTab={mockOnRenameTab}
         />
       );


### PR DESCRIPTION
## Summary
- Add text size support from settings to TypingDock
- Add Fix Text (Pro) feature with API integration
- Add Flesh Out with new FleshOutBottomSheet component
- Add Share functionality with ShareBottomSheet component  
- Add multi-tab support with MobileTabIndicator and MobileTabList
- Add closeAllTabs function to useTypingTabs hook
- Update desktop TabManagementDialog with Close All button (no confirmation)

## New Files
- `app/components/flesh-out/FleshOutBottomSheet.tsx`
- `app/components/typing-share/ShareBottomSheet.tsx`
- `app/components/typing-tabs/MobileTabIndicator.tsx`
- `app/components/typing-tabs/MobileTabList.tsx`

## Test plan
- [ ] Set text size in Settings → verify TypingDock respects it
- [ ] Type text → tap Flesh Out → select mode → verify text is enhanced
- [ ] Type text → tap Fix Text → verify grammar/spelling corrected
- [ ] Tap Share → Start Sharing → copy link → verify real-time sync
- [ ] Create multiple tabs → switch between them → verify text persists
- [ ] Tap Close All → verify all tabs cleared immediately
- [ ] Test all features at 320px, 375px, 414px widths
- [ ] Verify all touch targets are ≥44px