### PR TITLE
Add fullscreen mode to TypingDock

### DIFF
--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -10,6 +10,8 @@ import {
   ChevronDownIcon,
   ArrowPathIcon,
   ShareIcon,
+  ArrowsPointingOutIcon,
+  ArrowsPointingInIcon,
 } from '@heroicons/react/24/outline';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -47,7 +49,6 @@ export default function TypingDock({
   enableFleshOut = false,
   enableFixText = false,
 }: TypingDockProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isFixingText, setIsFixingText] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -57,8 +58,13 @@ export default function TypingDock({
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const { settings } = useSettings();
+  const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
+
+  // Get current mode from settings
+  const dockMode = uiPreferences.typingDockMode;
+  const isExpanded = dockMode === 'expanded' || dockMode === 'fullscreen';
+  const isFullscreen = dockMode === 'fullscreen';
 
   // Typing share hook
   const typingShare = useTypingShare();
@@ -97,12 +103,12 @@ export default function TypingDock({
   };
   const currentTextSizeClass = textSizeClasses[settings.textSize];
 
-  // Auto-expand when text gets long
+  // Auto-expand when text gets long (but don't change fullscreen)
   useEffect(() => {
-    if (text.length > 50 && !isExpanded) {
-      setIsExpanded(true);
+    if (text.length > 50 && dockMode === 'compact') {
+      updateUIPreference('typingDockMode', 'expanded');
     }
-  }, [text, isExpanded]);
+  }, [text, dockMode, updateUIPreference]);
 
   // Update shared session content when text changes
   useEffect(() => {
@@ -150,9 +156,9 @@ export default function TypingDock({
 
   const handleBlur = () => {
     setIsFocused(false);
-    // Collapse if text is short
-    if (text.length <= 50) {
-      setIsExpanded(false);
+    // Collapse if text is short (but don't change fullscreen)
+    if (text.length <= 50 && dockMode === 'expanded') {
+      updateUIPreference('typingDockMode', 'compact');
     }
   };
 
@@ -167,14 +173,25 @@ export default function TypingDock({
   };
 
   const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
+    // Cycle: compact -> expanded -> compact
+    const newMode = dockMode === 'compact' ? 'expanded' : 'compact';
+    updateUIPreference('typingDockMode', newMode);
     // Focus the appropriate input after toggle
     setTimeout(() => {
-      if (!isExpanded) {
+      if (newMode === 'expanded') {
         textareaRef.current?.focus();
       } else {
         inputRef.current?.focus();
       }
+    }, 100);
+  };
+
+  const toggleFullscreen = () => {
+    const newMode = isFullscreen ? 'expanded' : 'fullscreen';
+    updateUIPreference('typingDockMode', newMode);
+    // Focus textarea in both expanded and fullscreen modes
+    setTimeout(() => {
+      textareaRef.current?.focus();
     }, 100);
   };
 
@@ -242,17 +259,20 @@ export default function TypingDock({
 
   return (
     <>
-      <div className={`border-t border-border ${className}`} style={{ backgroundColor: '#242424' }}>
-        <div className="px-3 py-2">
+      <div
+        className={`border-t border-border ${className} ${isFullscreen ? 'fixed inset-0 z-50 flex flex-col' : ''}`}
+        style={{ backgroundColor: '#242424' }}
+      >
+        <div className={`px-3 py-2 ${isFullscreen ? 'flex-1 flex flex-col' : ''}`}>
           <AnimatePresence mode="wait">
             {isExpanded ? (
               <motion.div
                 key="expanded"
                 initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
+                animate={{ opacity: 1, height: isFullscreen ? '100%' : 'auto' }}
                 exit={{ opacity: 0, height: 0 }}
                 transition={{ duration: 0.2 }}
-                className="space-y-2"
+                className={`space-y-2 ${isFullscreen ? 'flex-1 flex flex-col' : ''}`}
               >
                 {/* Tab indicator row (expanded mode) */}
                 {enableTabs && (
@@ -262,18 +282,33 @@ export default function TypingDock({
                       activeTab={activeTab}
                       onClick={() => setShowTabList(true)}
                     />
-                    <button
-                      onClick={toggleExpanded}
-                      className="p-1.5 rounded-full hover:bg-surface transition-colors"
-                      aria-label="Collapse"
-                    >
-                      <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
-                    </button>
+                    <div className="flex items-center gap-1">
+                      {/* Fullscreen toggle */}
+                      <button
+                        onClick={toggleFullscreen}
+                        className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                        aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                      >
+                        {isFullscreen ? (
+                          <ArrowsPointingInIcon className="w-4 h-4 text-text-secondary" />
+                        ) : (
+                          <ArrowsPointingOutIcon className="w-4 h-4 text-text-secondary" />
+                        )}
+                      </button>
+                      {/* Collapse button */}
+                      <button
+                        onClick={toggleExpanded}
+                        className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                        aria-label="Collapse"
+                      >
+                        <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
+                      </button>
+                    </div>
                   </div>
                 )}
 
                 {/* Expanded textarea */}
-                <div className="relative">
+                <div className={`relative ${isFullscreen ? 'flex-1 flex flex-col' : ''}`}>
                   <textarea
                     ref={textareaRef}
                     value={text}
@@ -282,19 +317,35 @@ export default function TypingDock({
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     placeholder="Type your message..."
-                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-12'} ${currentTextSizeClass} resize-none focus:outline-none focus:ring-2 focus:ring-primary-500`}
-                    rows={3}
+                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-16'} ${currentTextSizeClass} resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 ${isFullscreen ? 'flex-1' : ''}`}
+                    rows={isFullscreen ? undefined : 3}
+                    style={isFullscreen ? { minHeight: '100%' } : undefined}
                     maxLength={maxChars}
                   />
-                  {/* Collapse button (when tabs are not enabled) */}
+                  {/* Control buttons (when tabs are not enabled) */}
                   {!enableTabs && (
-                    <button
-                      onClick={toggleExpanded}
-                      className="absolute top-2 right-2 p-1.5 rounded-full hover:bg-surface transition-colors"
-                      aria-label="Collapse"
-                    >
-                      <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
-                    </button>
+                    <div className="absolute top-2 right-2 flex items-center gap-1">
+                      {/* Fullscreen toggle */}
+                      <button
+                        onClick={toggleFullscreen}
+                        className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                        aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                      >
+                        {isFullscreen ? (
+                          <ArrowsPointingInIcon className="w-4 h-4 text-text-secondary" />
+                        ) : (
+                          <ArrowsPointingOutIcon className="w-4 h-4 text-text-secondary" />
+                        )}
+                      </button>
+                      {/* Collapse button */}
+                      <button
+                        onClick={toggleExpanded}
+                        className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                        aria-label="Collapse"
+                      >
+                        <ChevronDownIcon className="w-4 h-4 text-text-secondary" />
+                      </button>
+                    </div>
                   )}
                 </div>
 

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -8,6 +8,7 @@ import { useAuth } from './AuthContext';
 
 type TextSize = 'small' | 'medium' | 'large' | 'xlarge';
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
+type TypingDockMode = 'compact' | 'expanded' | 'fullscreen';
 
 interface Settings {
   textSize: TextSize;
@@ -28,6 +29,7 @@ interface UIPreferences {
   selectedBoardId: string | null;
   typingShareFontSize: number;
   activeTypingTabId: string | null;
+  typingDockMode: TypingDockMode;
 }
 
 type AllSettings = Settings & UIPreferences;
@@ -60,6 +62,7 @@ const defaultUIPreferences: UIPreferences = {
   selectedBoardId: null,
   typingShareFontSize: 18,
   activeTypingTabId: null,
+  typingDockMode: 'compact',
 };
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -82,6 +85,7 @@ function loadFromLocalStorage(): AllSettings {
   const selectedBoardId = localStorage.getItem('selectedBoardId');
   const typingShareFontSize = localStorage.getItem('typing-share-font-size');
   const activeTypingTabId = localStorage.getItem('activeTypingTabId');
+  const typingDockMode = localStorage.getItem('typingDockMode');
 
   const parsedFontSize = typingShareFontSize ? parseInt(typingShareFontSize, 10) : defaultUIPreferences.typingShareFontSize;
   const validFontSize = !isNaN(parsedFontSize)
@@ -99,12 +103,19 @@ function loadFromLocalStorage(): AllSettings {
     }
   };
 
+  // Parse typing dock mode
+  const validTypingDockModes = ['compact', 'expanded', 'fullscreen'];
+  const parsedTypingDockMode = typingDockMode && validTypingDockModes.includes(typingDockMode)
+    ? typingDockMode as TypingDockMode
+    : defaultUIPreferences.typingDockMode;
+
   const uiPreferences: UIPreferences = {
     typingAreaVisible: parseBooleanSafely(typingAreaVisible, defaultUIPreferences.typingAreaVisible),
     typingAreaExpanded: parseBooleanSafely(typingAreaExpanded, defaultUIPreferences.typingAreaExpanded),
     selectedBoardId: selectedBoardId || defaultUIPreferences.selectedBoardId,
     typingShareFontSize: validFontSize,
     activeTypingTabId: activeTypingTabId || defaultUIPreferences.activeTypingTabId,
+    typingDockMode: parsedTypingDockMode,
   };
 
   return { ...settings, ...uiPreferences };
@@ -143,6 +154,7 @@ function saveToLocalStorage(allSettings: AllSettings) {
   } else {
     localStorage.removeItem('activeTypingTabId');
   }
+  localStorage.setItem('typingDockMode', allSettings.typingDockMode);
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -193,6 +205,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         selectedBoardId: localSettings.selectedBoardId ?? undefined,
         typingShareFontSize: localSettings.typingShareFontSize,
         activeTypingTabId: localSettings.activeTypingTabId ?? undefined,
+        typingDockMode: localSettings.typingDockMode,
       })
         .then(() => {
           console.log('Settings migrated to Convex successfully');
@@ -221,6 +234,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         selectedBoardId: convexSettings.selectedBoardId ?? null,
         typingShareFontSize: convexSettings.typingShareFontSize,
         activeTypingTabId: convexSettings.activeTypingTabId ?? null,
+        typingDockMode: (convexSettings.typingDockMode as TypingDockMode) ?? defaultUIPreferences.typingDockMode,
       };
 
       setAllSettings(serverSettings);
@@ -313,6 +327,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     selectedBoardId: allSettings.selectedBoardId,
     typingShareFontSize: allSettings.typingShareFontSize,
     activeTypingTabId: allSettings.activeTypingTabId,
+    typingDockMode: allSettings.typingDockMode,
   };
 
   return (

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -84,6 +84,7 @@ export default defineSchema({
     typingShareFontSize: v.number(),
     typingTabs: v.optional(v.string()), // JSON stringified TypingTabsState
     activeTypingTabId: v.optional(v.string()),
+    typingDockMode: v.optional(v.union(v.literal('compact'), v.literal('expanded'), v.literal('fullscreen'))),
 
     // Metadata for sync tracking
     lastSyncedAt: v.number(),

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -57,6 +57,7 @@ export const initializeSettings = mutation({
     typingShareFontSize: v.number(),
     typingTabs: v.optional(v.string()),
     activeTypingTabId: v.optional(v.string()),
+    typingDockMode: v.optional(v.union(v.literal('compact'), v.literal('expanded'), v.literal('fullscreen'))),
   },
   handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
@@ -113,6 +114,7 @@ export const initializeSettings = mutation({
       typingShareFontSize: args.typingShareFontSize,
       typingTabs: args.typingTabs,
       activeTypingTabId: args.activeTypingTabId,
+      typingDockMode: args.typingDockMode,
       lastSyncedAt: now,
       updatedAt: now,
     });
@@ -138,6 +140,7 @@ export const updateSettings = mutation({
     typingShareFontSize: v.optional(v.number()),
     typingTabs: v.optional(v.string()),
     activeTypingTabId: v.optional(v.string()),
+    typingDockMode: v.optional(v.union(v.literal('compact'), v.literal('expanded'), v.literal('fullscreen'))),
     lastSyncedAt: v.number(),
   },
   handler: async (ctx, args) => {
@@ -217,6 +220,7 @@ export const updateSettings = mutation({
     if (updates.typingShareFontSize !== undefined) updateData.typingShareFontSize = updates.typingShareFontSize;
     if (updates.typingTabs !== undefined) updateData.typingTabs = updates.typingTabs;
     if (updates.activeTypingTabId !== undefined) updateData.activeTypingTabId = updates.activeTypingTabId;
+    if (updates.typingDockMode !== undefined) updateData.typingDockMode = updates.typingDockMode;
 
     await ctx.db.patch(settings._id, updateData);
 


### PR DESCRIPTION
## Summary
- Add `typingDockMode` setting with three modes: compact, expanded, fullscreen
- Persist mode in localStorage and sync to Convex for cross-device consistency
- Fullscreen mode takes up the entire viewport with a maximized textarea
- Add fullscreen toggle buttons in both tab and non-tab expanded modes

## Test plan
- [ ] Toggle between compact and expanded modes
- [ ] Enter fullscreen mode via the expand icon button
- [ ] Verify fullscreen takes up entire screen
- [ ] Exit fullscreen via collapse icon or chevron down
- [ ] Verify mode persists after page refresh
- [ ] Verify mode syncs across devices (when logged in)

Closes #233