### PR TITLE
Remove text size preview from mobile settings card

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -135,7 +135,6 @@ export default function SettingsPage() {
               title="Text & Display"
               description="Font size, enter key behavior"
               onClick={() => setActiveSheet('text')}
-              value={getLabel(textSizeOptions, settings.textSize)}
             />
 
             {/* Account - only when logged in */}


### PR DESCRIPTION
## Summary
Remove the text size value preview (e.g., "Medium") from the Text & Display settings card on mobile, as it doesn't add useful context.

## Test plan
- [ ] Open settings on mobile
- [ ] Verify Text & Display card no longer shows the text size value