### PR TITLE
Fix race condition and add error handling in share logic

### DIFF
--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -243,16 +243,24 @@ export default function TypingDock({
   const handleShare = async () => {
     if (!enableShare || !user) return;
 
+    // Prevent multiple clicks while creating session
+    if (typingShare.isCreating) return;
+
     if (typingShare.isSharing) {
       setShowShareSheet(true);
       return;
     }
 
-    await typingShare.createSession();
+    try {
+      await typingShare.createSession();
 
-    if (typingShare.isSharing) {
-      typingShare.updateContent(text);
-      setShowShareSheet(true);
+      if (typingShare.isSharing) {
+        typingShare.updateContent(text);
+        setShowShareSheet(true);
+      }
+    } catch (err) {
+      console.error('Error creating share session:', err);
+      setError(err instanceof Error ? err.message : 'Failed to create share session');
     }
   };
 


### PR DESCRIPTION
## Summary
- Add check for `isCreating` to prevent multiple session creation on rapid clicks
- Wrap `createSession()` in try-catch and display errors to user

## Test plan
- [ ] Click share button rapidly - should only create one session
- [ ] Test share creation failure scenario - should show error message

Fixes #244, Fixes #245