### PR TITLE
Fix state desync between text prop and tabs state

### DIFF
--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -61,6 +61,7 @@ export default function TypingDock({
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const prevTextRef = useRef(text); // Track previous text to detect external changes
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
 
@@ -87,9 +88,13 @@ export default function TypingDock({
   } = useTypingTabs(text);
 
   // Sync tabs text with external text prop when tabs are enabled
+  // Only sync when text prop changes externally, not when activeTab.text changes
   useEffect(() => {
-    if (enableTabs && text !== activeTab.text) {
-      updateActiveTabText(text);
+    if (enableTabs && text !== prevTextRef.current) {
+      prevTextRef.current = text;
+      if (text !== activeTab.text) {
+        updateActiveTabText(text);
+      }
     }
   }, [enableTabs, text, activeTab.text, updateActiveTabText]);
 


### PR DESCRIPTION
## Summary
- Add `prevTextRef` to track previous text value
- Only sync to tabs when text prop changes externally
- Prevents unnecessary re-syncs when `activeTab.text` changes internally

## Test plan
- [ ] Type in dock with tabs enabled - verify text syncs properly
- [ ] Switch tabs - verify text updates correctly without loops
- [ ] Clear text and type again - verify no state desync

Fixes #247