### PR TITLE
Add cleanup for longPressTimer on unmount

### DIFF
--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PencilIcon, SpeakerWaveIcon } from '@heroicons/react/24/outline';
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
 
 interface PhraseTileProps {
@@ -45,6 +45,15 @@ export default function PhraseTile({ phrase, onPress, onEdit, onLongPress, class
       clearTimeout(longPressTimer.current);
       longPressTimer.current = null;
     }
+  }, []);
+
+  // Cleanup timer on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+      }
+    };
   }, []);
 
   const handleClick = () => {


### PR DESCRIPTION
## Summary
- Clear timer in useEffect cleanup to prevent memory leaks
- Prevents state updates on unmounted component

## Test plan
- [ ] Long press on phrase tile, then navigate away quickly - verify no console warnings
- [ ] Long press on phrase tile and wait for callback - verify still works

Fixes #248