### PR TITLE
Update API routes to Next.js App Router config exports

### DIFF
--- a/app/api/fix-text/route.ts
+++ b/app/api/fix-text/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from 'next/server';
 import { fixText } from '@/lib/openrouter';
 
-export const config = {
-  runtime: 'nodejs',
-  api: {
-    bodyParser: {
-      sizeLimit: '1mb',
-    },
-  },
-};
+// Next.js App Router route segment config
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function POST(request: Request) {
   try {

--- a/app/api/flesh-out/route.ts
+++ b/app/api/flesh-out/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from 'next/server';
 import { generate } from '@/lib/openrouter';
 
-export const config = {
-  runtime: 'nodejs',
-  api: {
-    bodyParser: {
-      sizeLimit: '1mb',
-    },
-  },
-};
+// Next.js App Router route segment config
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function POST(request: Request) {
   try {

--- a/app/api/text-to-speech/route.ts
+++ b/app/api/text-to-speech/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from 'next/server';
 import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 
-export const config = {
-  runtime: 'nodejs',
-  api: {
-    bodyParser: {
-      sizeLimit: '1mb',
-    },
-  },
-};
+// Next.js App Router route segment config
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function POST(request: Request) {
   try {


### PR DESCRIPTION
## Summary
Replace deprecated `export const config` with individual route segment exports.

**Before (deprecated):**
```typescript
export const config = {
  runtime: 'nodejs',
  api: { bodyParser: { sizeLimit: '1mb' } },
};
```

**After:**
```typescript
export const runtime = 'nodejs';
export const dynamic = 'force-dynamic';
```

## Files updated
- `app/api/text-to-speech/route.ts`
- `app/api/fix-text/route.ts`
- `app/api/flesh-out/route.ts`

## Test plan
- [ ] Verify TTS API still works
- [ ] Verify fix-text API still works
- [ ] Verify flesh-out API still works
- [ ] Confirm no deprecation warnings in build output