### PR TITLE
Add window.matchMedia mock to jest setup

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,20 @@
 require('@testing-library/jest-dom');
 
+// Mock window.matchMedia for components using media queries (e.g., prefers-reduced-motion)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
 // Mock next/navigation
 jest.mock('next/navigation', () => ({
   useRouter: () => ({


### PR DESCRIPTION
## Summary
Add `window.matchMedia` mock to jest setup for components using media queries.

## Problem
Tests were failing because `PhraseTile` uses `window.matchMedia('(prefers-reduced-motion: reduce)')` which is not available in jsdom.

## Solution
Added a mock implementation of `matchMedia` in `jest.setup.js`.

## Test results
All 227 tests passing.