### PR TITLE
Fix OpenRouter env check to be lazy-loaded

### DIFF
--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -1,17 +1,28 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { generateText as aiGenerateText } from 'ai';
 
-if (!process.env.OPENROUTER_API_KEY) {
-  throw new Error('OPENROUTER_API_KEY is not set in environment variables');
-}
-
-const openrouter = createOpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
-
 // Model configuration (easy to change)
 const MODEL = 'google/gemini-2.5-flash';
+
+// Lazy-initialized client to avoid build-time env var requirement
+let openrouterClient: ReturnType<typeof createOpenAI> | null = null;
+
+/**
+ * Get the OpenRouter client, creating it lazily on first use.
+ * Throws an error if OPENROUTER_API_KEY is not set.
+ */
+function getOpenRouterClient() {
+  if (!openrouterClient) {
+    if (!process.env.OPENROUTER_API_KEY) {
+      throw new Error('OPENROUTER_API_KEY is not set in environment variables');
+    }
+    openrouterClient = createOpenAI({
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKey: process.env.OPENROUTER_API_KEY,
+    });
+  }
+  return openrouterClient;
+}
 
 const sharedGuidelines = `
 Guidelines:
@@ -220,6 +231,7 @@ export async function generate(
   options?: GenerationOptions
 ): Promise<Record<string, unknown>> {
   try {
+    const openrouter = getOpenRouterClient();
     const { text } = await aiGenerateText({
       model: openrouter(MODEL),
       system: systemPrompts[type],


### PR DESCRIPTION
## Summary
Move `OPENROUTER_API_KEY` check from module load time to request time.

## Problem
Build was failing without the env var present because the check happened at module evaluation time.

## Solution
- Create `getOpenRouterClient()` for lazy initialization
- Check API key only when the client is first needed
- Client is cached after first creation

## Test results
- Build passes without `OPENROUTER_API_KEY`
- All 227 tests pass