### PR TITLE
Fix BottomSheet z-index to render above TypingDock

### DIFF
--- a/app/components/ui/BottomSheet.tsx
+++ b/app/components/ui/BottomSheet.tsx
@@ -190,7 +190,7 @@ export default function BottomSheet({
         <>
           {/* Backdrop */}
           <motion.div
-            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[55]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -202,7 +202,7 @@ export default function BottomSheet({
           {/* Bottom Sheet */}
           <motion.div
             ref={sheetRef}
-            className={`fixed bottom-0 left-0 right-0 z-50 rounded-t-3xl shadow-2xl flex flex-col ${className}`}
+            className={`fixed bottom-0 left-0 right-0 z-[60] rounded-t-3xl shadow-2xl flex flex-col ${className}`}
             style={{
               maxHeight: '95vh',
               paddingBottom: keyboardHeight > 0 ? keyboardHeight : 'env(safe-area-inset-bottom)',


### PR DESCRIPTION
## Summary
- Increase BottomSheet backdrop z-index from z-40 to z-[55]
- Increase BottomSheet sheet z-index from z-50 to z-[60]

This ensures BottomSheets render correctly above TypingDock when it's in fullscreen mode (z-50).

## Test plan
- [ ] Open MobileTabList from TypingDock
- [ ] Verify backdrop is visible and tappable
- [ ] Verify sheet renders above all other elements

Fixes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted visual layering for bottom sheet components to ensure proper element stacking and improved interaction precedence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->