### PR TITLE
Replace text size dropdown with slider (8-72px)

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -98,14 +98,8 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [createTab, closeTab, activeTabId, switchToTabByIndex, switchToPreviousTab, switchToNextTab]);
 
-  const textSizeClasses = {
-    small: 'text-sm',
-    medium: 'text-lg',
-    large: 'text-2xl',
-    xlarge: 'text-4xl',
-  };
-
-  const currentTextSizeClass = textSizeClasses[settings.textSize];
+  // Text size from settings (now a number in px)
+  const textSizePx = settings.textSize;
 
   // Update shared session content when text changes
   useEffect(() => {
@@ -217,7 +211,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
           <div className="flex-1 relative">
             <textarea
               ref={textareaRef}
-              className={`w-full bg-transparent text-foreground ${currentTextSizeClass} placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-inset resize-none p-8 overflow-auto transition-all duration-300 rounded-3xl`}
+              className="w-full bg-transparent text-foreground placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-inset resize-none p-8 overflow-auto transition-all duration-300 rounded-3xl"
               value={text}
               onChange={(e) => {
                 updateActiveTabText(e.target.value);
@@ -250,6 +244,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
               }}
               placeholder="Type your message here..."
               style={{
+                fontSize: `${textSizePx}px`,
                 minHeight: textareaHeight,
                 maxHeight: textareaHeight,
                 lineHeight: '1.5',

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -98,14 +98,8 @@ export default function TypingDock({
     }
   }, [enableTabs, text, activeTab.text, updateActiveTabText]);
 
-  // Text size classes
-  const textSizeClasses = {
-    small: 'text-sm',
-    medium: 'text-base',
-    large: 'text-xl',
-    xlarge: 'text-2xl',
-  };
-  const currentTextSizeClass = textSizeClasses[settings.textSize];
+  // Text size from settings (now a number in px)
+  const textSizePx = settings.textSize;
 
   // Auto-expand when text gets long (but don't change fullscreen)
   useEffect(() => {
@@ -329,9 +323,9 @@ export default function TypingDock({
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     placeholder="Type your message..."
-                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-16'} ${currentTextSizeClass} resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 ${isFullscreen ? 'flex-1' : ''}`}
+                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-16'} resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 ${isFullscreen ? 'flex-1' : ''}`}
                     rows={isFullscreen ? undefined : 3}
-                    style={isFullscreen ? { minHeight: '100%' } : undefined}
+                    style={{ fontSize: `${textSizePx}px`, ...(isFullscreen ? { minHeight: '100%' } : {}) }}
                   />
                   {/* Control buttons (when tabs are not enabled) */}
                   {!enableTabs && (
@@ -516,7 +510,8 @@ export default function TypingDock({
                       onFocus={handleFocus}
                       onBlur={handleBlur}
                       placeholder="Type to speak..."
-                      className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-full px-4 py-3 pr-10 ${currentTextSizeClass} focus:outline-none focus:ring-2 focus:ring-primary-500`}
+                      className="w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-full px-4 py-3 pr-10 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                      style={{ fontSize: `${textSizePx}px` }}
                     />
                     {/* Expand button */}
                     <button

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -6,7 +6,7 @@ import { api } from '@/convex/_generated/api';
 import { TTSProviderType } from '@/lib/tts-provider';
 import { useAuth } from './AuthContext';
 
-type TextSize = 'small' | 'medium' | 'large' | 'xlarge';
+type TextSize = number;
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
 type TypingDockMode = 'compact' | 'expanded' | 'fullscreen';
 
@@ -44,7 +44,7 @@ interface SettingsContextType {
 }
 
 const defaultSettings: Settings = {
-  textSize: 'medium',
+  textSize: 16,
   speechRate: 1.0,
   speechPitch: 1.0,
   speechVolume: 1.0,

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -16,11 +16,11 @@ import RoleChangeSection from '@/app/components/settings/RoleChangeSection';
 import { useAuth } from '../contexts/AuthContext';
 import BottomSheet from '@/app/components/ui/BottomSheet';
 import { Dropdown } from '@/app/components/ui/Dropdown';
+import { Slider } from '@/app/components/ui/Slider';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { UserButton } from '@clerk/nextjs';
 
 // Import types from SettingsContext
-type TextSize = 'small' | 'medium' | 'large' | 'xlarge';
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
 
 // Import TTSSettings dynamically with SSR disabled
@@ -92,13 +92,6 @@ export default function SettingsPage() {
       </div>
     );
   }
-
-  const textSizeOptions = [
-    { value: 'small' as TextSize, label: 'Small' },
-    { value: 'medium' as TextSize, label: 'Medium' },
-    { value: 'large' as TextSize, label: 'Large' },
-    { value: 'xlarge' as TextSize, label: 'Extra Large' },
-  ];
 
   const enterKeyOptions = [
     { value: 'newline' as EnterKeyBehavior, label: 'New Line' },
@@ -179,11 +172,14 @@ export default function SettingsPage() {
           snapPoints={[60, 80]}
         >
           <div className="p-4 space-y-6">
-            <Dropdown
+            <Slider
               label="Text Size"
-              options={textSizeOptions}
+              min={8}
+              max={72}
+              step={2}
               value={settings.textSize}
               onChange={(value) => updateSetting('textSize', value)}
+              valueLabel={(v) => `${v}px`}
             />
             <Dropdown
               label="Enter Key Behavior"
@@ -288,12 +284,14 @@ export default function SettingsPage() {
                       <p className="text-sm text-text-secondary mt-1">Adjust the size of text in the typing area</p>
                     </div>
                   </div>
-                  <div className="flex justify-end">
-                    <Dropdown
-                      options={textSizeOptions}
+                  <div className="mt-4">
+                    <Slider
+                      min={8}
+                      max={72}
+                      step={2}
                       value={settings.textSize}
                       onChange={(value) => updateSetting('textSize', value)}
-                      className="w-48"
+                      valueLabel={(v) => `${v}px`}
                     />
                   </div>
                 </div>

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,7 +66,7 @@ export default defineSchema({
     userId: v.string(), // Clerk user ID
 
     // Main Settings (from SettingsContext)
-    textSize: v.union(v.literal('small'), v.literal('medium'), v.literal('large'), v.literal('xlarge')),
+    textSize: v.number(), // Font size in pixels (8-72)
     speechRate: v.number(),
     speechPitch: v.number(),
     speechVolume: v.number(),

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -4,7 +4,7 @@ import { getUserIdentity } from './users';
 
 // Default settings that match SettingsContext defaults
 const defaultSettings = {
-  textSize: 'medium' as const,
+  textSize: 16, // Font size in pixels
   speechRate: 1.0,
   speechPitch: 1.0,
   speechVolume: 1.0,
@@ -41,7 +41,7 @@ export const getUserSettings = query({
 // Mutation to initialize settings (called on first sign-in or when settings don't exist)
 export const initializeSettings = mutation({
   args: {
-    textSize: v.union(v.literal('small'), v.literal('medium'), v.literal('large'), v.literal('xlarge')),
+    textSize: v.number(), // Font size in pixels (8-72)
     speechRate: v.number(),
     speechPitch: v.number(),
     speechVolume: v.number(),
@@ -66,6 +66,9 @@ export const initializeSettings = mutation({
     }
 
     // Validate numeric fields
+    if (!Number.isFinite(args.textSize) || args.textSize < 8 || args.textSize > 72) {
+      throw new Error('textSize must be a valid number between 8 and 72');
+    }
     if (!Number.isFinite(args.speechRate) || args.speechRate < 0.1 || args.speechRate > 2.0) {
       throw new Error('speechRate must be a valid number between 0.1 and 2.0');
     }
@@ -124,7 +127,7 @@ export const initializeSettings = mutation({
 // Mutation to update settings (supports partial updates)
 export const updateSettings = mutation({
   args: {
-    textSize: v.optional(v.union(v.literal('small'), v.literal('medium'), v.literal('large'), v.literal('xlarge'))),
+    textSize: v.optional(v.number()), // Font size in pixels (8-72)
     speechRate: v.optional(v.number()),
     speechPitch: v.optional(v.number()),
     speechVolume: v.optional(v.number()),
@@ -166,6 +169,11 @@ export const updateSettings = mutation({
     }
 
     // Validate numeric fields
+    if (updates.textSize !== undefined) {
+      if (!Number.isFinite(updates.textSize) || updates.textSize < 8 || updates.textSize > 72) {
+        throw new Error('textSize must be a valid number between 8 and 72');
+      }
+    }
     if (updates.speechRate !== undefined) {
       if (!Number.isFinite(updates.speechRate) || updates.speechRate < 0.1 || updates.speechRate > 2.0) {
         throw new Error('speechRate must be a valid number between 0.1 and 2.0');


### PR DESCRIPTION
## Summary
- Replace the Dropdown-based font size setting with a Slider (8-72px range, step of 2)
- Change TextSize type from enum (`'small' | 'medium' | 'large' | 'xlarge'`) to number
- Update TypingDock and TypingArea to use inline `fontSize` style instead of Tailwind classes
- Update Convex schema and validators

## Test plan
- [ ] Slider works on desktop settings page
- [ ] Slider works on mobile settings sheet
- [ ] Font size changes apply immediately to typing area
- [ ] Setting persists after refresh
- [ ] Build passes with no type errors
- [ ] All tests pass

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text size setting now uses an interactive slider with pixel-level precision (8-72px) instead of preset categories, enabling finer control over text sizing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->