### PR TITLE
Add migration for textSize enum to number conversion

### DIFF
--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -67,6 +67,20 @@ const defaultUIPreferences: UIPreferences = {
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
 
+// Helper to convert textSize from old enum to number
+function normalizeTextSize(value: number | string): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+  const enumMap: Record<string, number> = {
+    small: 12,
+    medium: 16,
+    large: 24,
+    xlarge: 32,
+  };
+  return enumMap[value] ?? 16;
+}
+
 // Helper function to load settings from localStorage
 function loadFromLocalStorage(): AllSettings {
   if (typeof window === 'undefined') {
@@ -75,9 +89,14 @@ function loadFromLocalStorage(): AllSettings {
 
   // Load main settings
   const savedSettings = localStorage.getItem('settings');
-  const settings = savedSettings
-    ? { ...defaultSettings, ...JSON.parse(savedSettings) }
-    : defaultSettings;
+  const parsedSettings = savedSettings ? JSON.parse(savedSettings) : {};
+
+  // Normalize textSize from old enum format if needed
+  if (parsedSettings.textSize !== undefined) {
+    parsedSettings.textSize = normalizeTextSize(parsedSettings.textSize);
+  }
+
+  const settings = { ...defaultSettings, ...parsedSettings };
 
   // Load UI preferences from various localStorage keys
   const typingAreaVisible = localStorage.getItem('typingAreaVisible');
@@ -219,7 +238,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     } else if (convexSettings) {
       // Settings exist in Convex - update from server
       const serverSettings: AllSettings = {
-        textSize: convexSettings.textSize,
+        textSize: normalizeTextSize(convexSettings.textSize),
         speechRate: convexSettings.speechRate,
         speechPitch: convexSettings.speechPitch,
         speechVolume: convexSettings.speechVolume,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,37 @@
+import { internalMutation } from './_generated/server';
+
+// Migration: Convert textSize from enum strings to numbers
+// Run this once via Convex dashboard before deploying schema changes
+export const migrateTextSizeToNumber = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const enumToNumber: Record<string, number> = {
+      small: 12,
+      medium: 16,
+      large: 24,
+      xlarge: 32,
+    };
+
+    const allSettings = await ctx.db.query('userSettings').collect();
+    let migratedCount = 0;
+
+    for (const settings of allSettings) {
+      const currentValue = settings.textSize;
+
+      // If it's already a number, skip
+      if (typeof currentValue === 'number') {
+        continue;
+      }
+
+      // If it's a string enum value, convert it
+      if (typeof currentValue === 'string' && currentValue in enumToNumber) {
+        await ctx.db.patch(settings._id, {
+          textSize: enumToNumber[currentValue],
+        });
+        migratedCount++;
+      }
+    }
+
+    return { migratedCount, totalRecords: allSettings.length };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,7 +66,14 @@ export default defineSchema({
     userId: v.string(), // Clerk user ID
 
     // Main Settings (from SettingsContext)
-    textSize: v.number(), // Font size in pixels (8-72)
+    // Accepts both old enum values (for migration) and new number values
+    textSize: v.union(
+      v.number(),
+      v.literal('small'),
+      v.literal('medium'),
+      v.literal('large'),
+      v.literal('xlarge')
+    ),
     speechRate: v.number(),
     speechPitch: v.number(),
     speechVolume: v.number(),


### PR DESCRIPTION
## Summary
- Add `migrateTextSizeToNumber` internal mutation in `convex/migrations.ts`
- Update schema to accept both old enum values and new numbers during migration
- Add `normalizeTextSize` helper to convert old values when reading from Convex/localStorage

## Migration Steps
1. Deploy this code to Convex
2. Run the migration from Convex dashboard: `npx convex run migrations:migrateTextSizeToNumber`
3. After migration completes, update schema to only accept numbers (follow-up PR)

## Test plan
- [ ] Convex deployment succeeds with union schema
- [ ] Migration converts existing enum values to numbers
- [ ] Frontend normalizes any remaining enum values

Closes #268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated text size settings handling to ensure consistent formatting across the app. A data migration has been implemented to normalize existing text size preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->