### PR TITLE
Security hardening: server-only ElevenLabs and safer share keys

### DIFF
--- a/app/api/elevenlabs/voices/route.ts
+++ b/app/api/elevenlabs/voices/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type ElevenLabsVoice = {
+  voice_id: string;
+  name: string;
+  preview_url?: string;
+  description?: string;
+};
+
+export async function GET() {
+  try {
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'API configuration error' },
+        { status: 500 },
+      );
+    }
+
+    const response = await fetch('https://api.elevenlabs.io/v1/voices', {
+      headers: {
+        'xi-api-key': apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to load voices' },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    const voices: ElevenLabsVoice[] = (data?.voices ?? []).map((voice: ElevenLabsVoice) => ({
+      voice_id: voice.voice_id,
+      name: voice.name || 'Unnamed Voice',
+      preview_url: voice.preview_url,
+      description: voice.description || '',
+    }));
+
+    return NextResponse.json({ voices });
+  } catch (error) {
+    console.error('Error loading ElevenLabs voices:', error);
+    return NextResponse.json(
+      { error: 'Server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/fix-text/route.ts
+++ b/app/api/fix-text/route.ts
@@ -17,8 +17,6 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    console.log('Received fix text request:', body);
-    
     const { text } = body;
     
     if (!text) {
@@ -29,16 +27,12 @@ export async function POST(request: Request) {
       );
     }
 
-    console.log('Attempting to fix text:', text);
-    
     try {
       const result = await fixText(text, {
         maxOutputTokens: 200,
         temperature: 0.3, // Lower temperature for more consistent corrections
       });
-      
-      console.log('Successfully fixed text:', result);
-      
+
       return NextResponse.json(result);
     } catch (genError) {
       console.error('Error fixing text:', genError);

--- a/app/api/flesh-out/route.ts
+++ b/app/api/flesh-out/route.ts
@@ -17,8 +17,6 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    console.log('Received request body:', body);
-    
     const { text, mode } = body;
     
     if (!text) {
@@ -37,16 +35,12 @@ export async function POST(request: Request) {
       );
     }
 
-    console.log('Attempting to flesh out text:', text, 'with mode:', mode);
-    
     try {
       const result = await generate(mode, text, {
         maxOutputTokens: 200,
         temperature: 0.7,
       });
-      
-      console.log('Successfully generated text:', result);
-      
+
       return NextResponse.json(result);
     } catch (genError) {
       console.error('Error generating text:', genError);

--- a/app/api/text-to-speech/route.ts
+++ b/app/api/text-to-speech/route.ts
@@ -8,8 +8,8 @@ export const dynamic = 'force-dynamic';
 export async function POST(request: Request) {
   try {
     // Check for API key first
-    if (!process.env.NEXT_PUBLIC_ELEVENLABS_API_KEY) {
-      console.error('NEXT_PUBLIC_ELEVENLABS_API_KEY is not set');
+    if (!process.env.ELEVENLABS_API_KEY) {
+      console.error('ELEVENLABS_API_KEY is not set');
       return NextResponse.json(
         { error: 'API configuration error' },
         { status: 500 },
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     }
 
     const client = new ElevenLabsClient({
-      apiKey: process.env.NEXT_PUBLIC_ELEVENLABS_API_KEY,
+      apiKey: process.env.ELEVENLABS_API_KEY,
     });
 
     // Use streaming if requested

--- a/lib/elevenlabs-tts.ts
+++ b/lib/elevenlabs-tts.ts
@@ -57,10 +57,12 @@ export interface VoiceSettings {
  */
 export class ElevenLabsTTS {
   private static instance: ElevenLabsTTS;
-  private apiKey: string;
   private voices: Voice[] = [];
   private audio: HTMLAudioElement | null = null;
   private isSpeaking: boolean = false;
+  private isAvailableFlag: boolean = false;
+  private voicesLoaded: boolean = false;
+  private loadingVoices: Promise<void> | null = null;
 
   /**
    * Session ID for cancellation tracking.
@@ -88,9 +90,7 @@ export class ElevenLabsTTS {
   private constructor() {
     // Private constructor to enforce singleton pattern
     this.fallbackTTS = WebSpeechTTS.getInstance();
-    this.apiKey = process.env.NEXT_PUBLIC_ELEVENLABS_API_KEY || '';
-
-    if (this.apiKey && typeof window !== 'undefined') {
+    if (typeof window !== 'undefined') {
       this.loadVoices();
     }
   }
@@ -103,35 +103,47 @@ export class ElevenLabsTTS {
   }
 
   private async loadVoices() {
-    if (!this.apiKey) return;
+    if (typeof window === 'undefined') return;
 
-    try {
-      // Call ElevenLabs API directly to get voices
-      const response = await fetch('https://api.elevenlabs.io/v1/voices', {
-        headers: {
-          'xi-api-key': this.apiKey,
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to load voices: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-
-      // Map voices to our format
-      this.voices = data.voices.map((voice: Voice) => ({
-        voice_id: voice.voice_id,
-        name: voice.name || 'Unnamed Voice',
-        preview_url: voice.preview_url,
-        description: voice.description || ''
-      }));
-
-      this.callbacks.onVoicesChanged?.(this.voices);
-    } catch (error) {
-      console.error('Error loading ElevenLabs voices:', error);
-      this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+    if (this.loadingVoices) {
+      return this.loadingVoices;
     }
+
+    this.loadingVoices = (async () => {
+      try {
+        const response = await fetch('/api/elevenlabs/voices');
+
+        if (!response.ok) {
+          this.isAvailableFlag = false;
+          this.voices = [];
+          this.callbacks.onVoicesChanged?.(this.voices);
+          return;
+        }
+
+        const data = await response.json();
+
+        this.voices = (data?.voices ?? []).map((voice: Voice) => ({
+          voice_id: voice.voice_id,
+          name: voice.name || 'Unnamed Voice',
+          preview_url: voice.preview_url,
+          description: voice.description || ''
+        }));
+
+        this.isAvailableFlag = true;
+        this.callbacks.onVoicesChanged?.(this.voices);
+      } catch (error) {
+        this.isAvailableFlag = false;
+        this.voices = [];
+        this.callbacks.onVoicesChanged?.(this.voices);
+        console.error('Error loading ElevenLabs voices:', error);
+        this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+      } finally {
+        this.voicesLoaded = true;
+        this.loadingVoices = null;
+      }
+    })();
+
+    return this.loadingVoices;
   }
 
   public setCallbacks(callbacks: {
@@ -179,10 +191,16 @@ export class ElevenLabsTTS {
     similarityBoost?: number;
     streaming?: boolean;
   }) {
-    if (!this.apiKey) {
-      console.warn('ElevenLabs API key not found, falling back to browser TTS');
-      this.fallbackTTS.speak(text);
-      return;
+    if (!this.isAvailableFlag) {
+      if (!this.voicesLoaded) {
+        await this.loadVoices();
+      }
+
+      if (!this.isAvailableFlag) {
+        console.warn('ElevenLabs is not available, falling back to browser TTS');
+        this.fallbackTTS.speak(text);
+        return;
+      }
     }
 
     // Stop any ongoing speech and API requests
@@ -586,6 +604,6 @@ export class ElevenLabsTTS {
   }
 
   public isAvailable(): boolean {
-    return !!this.apiKey;
+    return this.isAvailableFlag;
   }
 }

--- a/lib/hooks/useTypingShare.ts
+++ b/lib/hooks/useTypingShare.ts
@@ -5,6 +5,7 @@ import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 
 const STORAGE_KEY = 'typing-share-session-key';
+const SESSION_KEY_LENGTH = 32;
 
 type TypingSession = {
   _id: Id<'typingSessions'>;
@@ -78,7 +79,7 @@ export function useTypingShare() {
     setError(null);
 
     try {
-      const newKey = nanoid(10);
+      const newKey = nanoid(SESSION_KEY_LENGTH);
       const created = await createTypingSession({ sessionKey: newKey });
 
       if (!created) {


### PR DESCRIPTION
## Summary
- move ElevenLabs voice loading to a server proxy so API keys stay server-only
- remove logging of user text/request bodies in AI routes
- lengthen typing share session keys to reduce guessability

## Testing
- npm run build

## Issue
- #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal voice caching and management system
  * Fallback to browser-based text-to-speech when ElevenLabs unavailable

* **Bug Fixes**
  * Improved error handling with explicit error responses

* **Refactor**
  * Migrated text-to-speech to use private API authentication
  * Moved voice fetching to internal API endpoint

* **Chores**
  * Removed debug logging statements
  * Enhanced session key security

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->