### PR TITLE
Fix ElevenLabs voices ByteString error

### DIFF
--- a/app/api/elevenlabs/voices/route.ts
+++ b/app/api/elevenlabs/voices/route.ts
@@ -12,7 +12,7 @@ type ElevenLabsVoice = {
 
 export async function GET() {
   try {
-    const apiKey = process.env.ELEVENLABS_API_KEY;
+    const apiKey = process.env.ELEVENLABS_API_KEY?.replace(/^\uFEFF/, '').trim();
 
     if (!apiKey) {
       return NextResponse.json(

--- a/app/api/text-to-speech/route.ts
+++ b/app/api/text-to-speech/route.ts
@@ -8,7 +8,9 @@ export const dynamic = 'force-dynamic';
 export async function POST(request: Request) {
   try {
     // Check for API key first
-    if (!process.env.ELEVENLABS_API_KEY) {
+    const apiKey = process.env.ELEVENLABS_API_KEY?.replace(/^\uFEFF/, '').trim();
+
+    if (!apiKey) {
       console.error('ELEVENLABS_API_KEY is not set');
       return NextResponse.json(
         { error: 'API configuration error' },
@@ -34,7 +36,7 @@ export async function POST(request: Request) {
     }
 
     const client = new ElevenLabsClient({
-      apiKey: process.env.ELEVENLABS_API_KEY,
+      apiKey,
     });
 
     // Use streaming if requested


### PR DESCRIPTION
## Summary
- sanitize ELEVENLABS_API_KEY to remove BOM/whitespace before use
- prevents ByteString conversion errors when loading ElevenLabs voices

## Testing
- npm run build

## Issue
- #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ElevenLabs API key handling to properly normalize environment configuration by removing encoding artifacts and whitespace, ensuring text-to-speech and voice functionality work reliably across different system environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->