### PR TITLE
TypingDock: adjust fullscreen layout for mobile keyboards

### DIFF
--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -17,6 +17,7 @@ import {
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useTypingShare } from '@/lib/hooks/useTypingShare';
+import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import SubscriptionWrapper from './SubscriptionWrapper';
 import ShareBottomSheet from './typing-share/ShareBottomSheet';
@@ -53,6 +54,7 @@ export default function TypingDock({
   const [error, setError] = useState<string | null>(null);
   const [showShareSheet, setShowShareSheet] = useState(false);
   const [showTabList, setShowTabList] = useState(false);
+  const { top: viewportTop, height: viewportHeight } = useVisualViewport();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -226,10 +228,18 @@ export default function TypingDock({
 
   return (
     <>
-      <div
-        className={`border-t border-border ${className} ${isFullscreen ? 'fixed inset-0 z-50 flex flex-col' : ''}`}
-        style={{ backgroundColor: '#242424' }}
-      >
+        <div
+          className={`border-t border-border ${className} ${isFullscreen ? 'fixed left-0 right-0 z-50 flex flex-col' : ''}`}
+          style={
+            isFullscreen
+              ? {
+                top: viewportTop,
+                height: viewportHeight ? `${viewportHeight}px` : '100dvh',
+                backgroundColor: '#242424',
+              }
+              : { backgroundColor: '#242424' }
+          }
+        >
         <div className={`px-3 py-2 ${isFullscreen ? 'flex-1 flex flex-col' : ''}`}>
           <AnimatePresence mode="wait">
             {isExpanded ? (

--- a/app/components/ui/BottomSheet.tsx
+++ b/app/components/ui/BottomSheet.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useCallback, useState } from 'react';
 import { motion, AnimatePresence, PanInfo, useAnimation } from 'framer-motion';
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 
 export interface BottomSheetProps {
   isOpen: boolean;
@@ -32,7 +33,7 @@ export default function BottomSheet({
   const sheetRef = useRef<HTMLDivElement>(null);
   const controls = useAnimation();
   const [currentSnapIndex, setCurrentSnapIndex] = useState(initialSnap);
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const { height: viewportHeight, innerHeight } = useVisualViewport();
 
   // Use refs for callbacks to avoid re-registering event listeners
   const onCloseRef = useRef(onClose);
@@ -52,23 +53,7 @@ export default function BottomSheet({
   // Get the current snap point percentage
   const currentSnapPercent = snapPoints[currentSnapIndex] || snapPoints[0];
 
-  // Handle keyboard visibility (for mobile)
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const handleResize = () => {
-      // Detect virtual keyboard by comparing visualViewport to window height
-      if (window.visualViewport) {
-        const keyboardH = window.innerHeight - window.visualViewport.height;
-        setKeyboardHeight(keyboardH > 100 ? keyboardH : 0);
-      }
-    };
-
-    window.visualViewport?.addEventListener('resize', handleResize);
-    return () => {
-      window.visualViewport?.removeEventListener('resize', handleResize);
-    };
-  }, []);
+  const keyboardHeight = viewportHeight && innerHeight ? Math.max(0, innerHeight - viewportHeight) : 0;
 
   // Handle ESC key to close - uses refs to avoid re-registering listener
   useEffect(() => {

--- a/lib/hooks/useVisualViewport.ts
+++ b/lib/hooks/useVisualViewport.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type VisualViewportState = {
+  top: number;
+  height: number | null;
+  innerHeight: number | null;
+};
+
+const DEFAULT_VIEWPORT: VisualViewportState = {
+  top: 0,
+  height: null,
+  innerHeight: null,
+};
+
+export function useVisualViewport(): VisualViewportState {
+  const [viewport, setViewport] = useState<VisualViewportState>(DEFAULT_VIEWPORT);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const updateViewport = () => {
+      if (window.visualViewport) {
+        setViewport({
+          top: window.visualViewport.offsetTop,
+          height: window.visualViewport.height,
+          innerHeight: window.innerHeight,
+        });
+      } else {
+        setViewport({ top: 0, height: window.innerHeight, innerHeight: window.innerHeight });
+      }
+    };
+
+    updateViewport();
+    window.visualViewport?.addEventListener('resize', updateViewport);
+    window.visualViewport?.addEventListener('scroll', updateViewport);
+    window.addEventListener('resize', updateViewport);
+
+    return () => {
+      window.visualViewport?.removeEventListener('resize', updateViewport);
+      window.visualViewport?.removeEventListener('scroll', updateViewport);
+      window.removeEventListener('resize', updateViewport);
+    };
+  }, []);
+
+  return viewport;
+}


### PR DESCRIPTION
## Summary
- add a reusable visual viewport hook for keyboard-aware layout
- use the hook to resize fullscreen TypingDock above the keyboard
- reuse the hook in BottomSheet keyboard padding

## Testing
- npm run build

## Issue
- #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fullscreen container positioning to dynamically respond to viewport dimensions and keyboard visibility
  * Improved keyboard height detection for more accurate layout adjustments in bottom sheet and related UI elements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->