### PR TITLE
Undo clear: restore last text

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -8,11 +8,13 @@ import { useAuth } from '../contexts/AuthContext';
 import SubscriptionWrapper from './SubscriptionWrapper';
 import { useTypingShare } from '@/lib/hooks/useTypingShare';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
+import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import ShareLinkModal from './typing-share/ShareLinkModal';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import TabBar from './typing-tabs/TabBar';
 import TabManagementDialog from './typing-tabs/TabManagementDialog';
 import DoubleEnterHint from './typing/DoubleEnterHint';
+import UndoClearHint from './typing/UndoClearHint';
 
 interface TypingAreaProps {
   initialText?: string
@@ -34,6 +36,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
   const [showShareModal, setShowShareModal] = useState(false);
   const [showTabManagementDialog, setShowTabManagementDialog] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const prevActiveTabIdRef = useRef<string | null>(null);
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
   const { speak, stop, isSpeaking, isAvailable } = tts;
@@ -73,6 +76,16 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
       updateActiveTabText(externalText);
     }
   }, [externalText, activeTab.text, updateActiveTabText]);
+
+  useEffect(() => {
+    if (!activeTabId) return;
+
+    if (prevActiveTabIdRef.current && prevActiveTabIdRef.current !== activeTabId) {
+      onChange?.(activeTab.text);
+    }
+
+    prevActiveTabIdRef.current = activeTabId;
+  }, [activeTabId, activeTab.text, onChange]);
 
   // Keyboard shortcuts for tabs
   useEffect(() => {
@@ -131,12 +144,39 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
     }
   };
 
+  const { clearWithUndo, undo, canUndo, remainingMs: undoRemainingMs, entry } = useUndoClear({
+    timeoutMs: 20000,
+    onRestore: ({ tabId, text: restoredText }) => {
+      if (tabId !== activeTabId && tabId) {
+        switchTab(tabId);
+        setTimeout(() => {
+          updateActiveTabText(restoredText);
+          onChange?.(restoredText);
+          textareaRef.current?.focus();
+        }, 0);
+        return;
+      }
+
+      updateActiveTabText(restoredText);
+      onChange?.(restoredText);
+      textareaRef.current?.focus();
+    },
+  });
+
+  const showUndoHint = canUndo && entry?.tabId === (activeTabId || 'default');
+
   const handleClear = useCallback(() => {
-    updateActiveTabText('');
-    setError(null);
-    onChange?.('');
-    textareaRef.current?.focus();
-  }, [onChange, updateActiveTabText]);
+    clearWithUndo({
+      tabId: activeTabId || 'default',
+      text,
+      onClear: () => {
+        updateActiveTabText('');
+        setError(null);
+        onChange?.('');
+        textareaRef.current?.focus();
+      },
+    });
+  }, [activeTabId, clearWithUndo, onChange, text, updateActiveTabText]);
 
   const handleSpeak = useCallback(() => {
     if (isSpeaking) {
@@ -347,6 +387,14 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
                 <XMarkIcon className="w-5 h-5" />
                 <span>Clear</span>
               </button>
+            </div>
+          )}
+          {showUndoHint && (
+            <div className="px-4 pb-3 bg-surface-hover transition-colors duration-200">
+              <UndoClearHint
+                remainingMs={undoRemainingMs}
+                onUndo={undo}
+              />
             </div>
           )}
           {user && (

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -18,6 +18,7 @@ import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useTypingShare } from '@/lib/hooks/useTypingShare';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
+import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import SubscriptionWrapper from './SubscriptionWrapper';
@@ -25,6 +26,7 @@ import ShareBottomSheet from './typing-share/ShareBottomSheet';
 import MobileTabIndicator from './typing-tabs/MobileTabIndicator';
 import MobileTabList from './typing-tabs/MobileTabList';
 import DoubleEnterHint from './typing/DoubleEnterHint';
+import UndoClearHint from './typing/UndoClearHint';
 
 interface TypingDockProps {
   text: string;
@@ -63,6 +65,7 @@ export default function TypingDock({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const prevTextRef = useRef(text); // Track previous text to detect external changes
+  const prevActiveTabIdRef = useRef<string | null>(null);
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
 
@@ -95,6 +98,27 @@ export default function TypingDock({
     updateActiveTabText,
   } = useTypingTabs(text);
 
+  const { clearWithUndo, undo, canUndo, remainingMs: undoRemainingMs, entry } = useUndoClear({
+    timeoutMs: 20000,
+    onRestore: ({ tabId, text: restoredText }) => {
+      if (tabId !== activeTabId && tabId) {
+        switchTab(tabId);
+        setTimeout(() => {
+          updateActiveTabText(restoredText);
+          onChange(restoredText);
+          textareaRef.current?.focus();
+        }, 0);
+        return;
+      }
+
+      updateActiveTabText(restoredText);
+      onChange(restoredText);
+      textareaRef.current?.focus();
+    },
+  });
+
+  const showUndoHint = canUndo && entry?.tabId === (activeTabId || 'default');
+
   // Sync tabs text with external text prop when tabs are enabled
   // Only sync when text prop changes externally, not when activeTab.text changes
   useEffect(() => {
@@ -106,19 +130,46 @@ export default function TypingDock({
     }
   }, [enableTabs, text, activeTab.text, updateActiveTabText]);
 
+  useEffect(() => {
+    if (!enableTabs || !activeTabId) return;
+
+    if (prevActiveTabIdRef.current && prevActiveTabIdRef.current !== activeTabId) {
+      onChange(activeTab.text);
+    }
+
+    prevActiveTabIdRef.current = activeTabId;
+  }, [activeTabId, activeTab.text, enableTabs, onChange]);
+
   // Text size from settings (now a number in px)
   const textSizePx = settings.textSize;
+  const currentText = enableTabs ? activeTab.text : text;
+
+  const handleClear = useCallback(() => {
+    clearWithUndo({
+      tabId: activeTabId || 'default',
+      text: currentText,
+      onClear: () => {
+        onChange('');
+        setError(null);
+        if (isExpanded) {
+          textareaRef.current?.focus();
+        } else {
+          inputRef.current?.focus();
+        }
+      },
+    });
+  }, [activeTabId, clearWithUndo, currentText, isExpanded, onChange]);
 
   const runEnterAction = useCallback((action: EnterKeyBehavior) => {
     switch (action) {
     case 'speak':
-      if (text.trim()) onSpeak();
+      if (currentText.trim()) onSpeak();
       break;
     case 'clear':
-      onChange('');
+      handleClear();
       break;
     case 'speakAndClear':
-      if (text.trim()) {
+      if (currentText.trim()) {
         onSpeak();
         setTimeout(() => onChange(''), 100);
       }
@@ -126,13 +177,13 @@ export default function TypingDock({
     case 'newline':
     default:
       if (isExpanded) {
-        onChange(text + '\n');
-      } else if (text.trim()) {
+        onChange(currentText + '\n');
+      } else if (currentText.trim()) {
         onSpeak();
       }
       break;
     }
-  }, [isExpanded, onChange, onSpeak, text]);
+  }, [currentText, handleClear, isExpanded, onChange, onSpeak]);
 
   const { handleEnter, resetPending, isPending, remainingMs } = useDoubleEnter({
     enabled: settings.doubleEnterEnabled,
@@ -145,17 +196,17 @@ export default function TypingDock({
 
   // Auto-expand when text gets long (but don't change fullscreen)
   useEffect(() => {
-    if (text.length > 50 && dockMode === 'compact') {
+    if (currentText.length > 50 && dockMode === 'compact') {
       updateUIPreference('typingDockMode', 'expanded');
     }
-  }, [text, dockMode, updateUIPreference]);
+  }, [currentText, dockMode, updateUIPreference]);
 
   // Update shared session content when text changes
   useEffect(() => {
     if (enableShare && isSharing) {
-      updateContent(text);
+      updateContent(currentText);
     }
-  }, [text, enableShare, isSharing, updateContent]);
+  }, [currentText, enableShare, isSharing, updateContent]);
 
   // Handle Enter key
   const handleKeyDown = useCallback(
@@ -176,16 +227,6 @@ export default function TypingDock({
     // Collapse if text is short (but don't change fullscreen)
     if (text.length <= 50 && dockMode === 'expanded') {
       updateUIPreference('typingDockMode', 'compact');
-    }
-  };
-
-  const handleClear = () => {
-    onChange('');
-    setError(null);
-    if (isExpanded) {
-      textareaRef.current?.focus();
-    } else {
-      inputRef.current?.focus();
     }
   };
 
@@ -214,7 +255,7 @@ export default function TypingDock({
 
   // Fix Text handler
   const handleFixText = async () => {
-    if (!text.trim() || isFixingText) return;
+    if (!currentText.trim() || isFixingText) return;
 
     setIsFixingText(true);
     setError(null);
@@ -225,7 +266,7 @@ export default function TypingDock({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({ text: currentText }),
       });
 
       if (!response.ok) {
@@ -235,7 +276,7 @@ export default function TypingDock({
 
       const data = await response.json();
 
-      if (data.text && data.text !== text) {
+      if (data.text && data.text !== currentText) {
         onChange(data.text);
       }
     } catch (err) {
@@ -308,8 +349,13 @@ export default function TypingDock({
                 <div className={`relative ${isFullscreen ? 'flex-1 flex flex-col' : ''}`}>
                   <textarea
                     ref={textareaRef}
-                    value={text}
-                    onChange={(e) => onChange(e.target.value)}
+                    value={currentText}
+                    onChange={(e) => {
+                      if (enableTabs) {
+                        updateActiveTabText(e.target.value);
+                      }
+                      onChange(e.target.value);
+                    }}
                     onKeyDown={handleKeyDown}
                     onBlur={handleBlur}
                     placeholder="Type your message..."
@@ -359,7 +405,7 @@ export default function TypingDock({
                 )}
 
                 {/* Row 1: AI Features (when text exists) */}
-                {text.trim() && (enableFixText || (enableShare && user)) && (
+                {currentText.trim() && (enableFixText || (enableShare && user)) && (
                   <div className="flex items-center gap-2">
                     {/* Fix Text button (Pro) */}
                     {enableFixText && (
@@ -377,7 +423,7 @@ export default function TypingDock({
                       >
                         <button
                           onClick={handleFixText}
-                          disabled={!text.trim() || isFixingText}
+                          disabled={!currentText.trim() || isFixingText}
                           className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed ${
                             isFixingText
                               ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
@@ -425,7 +471,7 @@ export default function TypingDock({
                   {/* Clear button */}
                   <button
                     onClick={handleClear}
-                    disabled={!text.trim()}
+                    disabled={!currentText.trim()}
                     className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-error text-text-secondary hover:text-red-500 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
                     aria-label="Clear"
                   >
@@ -439,7 +485,7 @@ export default function TypingDock({
                   {/* Speak/Stop button - primary CTA */}
                   <motion.button
                     onClick={isSpeaking ? onStop : onSpeak}
-                    disabled={!isAvailable || (!isSpeaking && !text.trim())}
+                    disabled={!isAvailable || (!isSpeaking && !currentText.trim())}
                     className={`flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
                       isSpeaking
                         ? 'bg-gradient-to-r from-red-500 to-red-600 text-white'
@@ -461,6 +507,13 @@ export default function TypingDock({
                     )}
                   </motion.button>
                 </div>
+                {showUndoHint && (
+                  <UndoClearHint
+                    remainingMs={undoRemainingMs}
+                    onUndo={undo}
+                    className="px-1"
+                  />
+                )}
               </motion.div>
             ) : (
               <motion.div
@@ -488,8 +541,13 @@ export default function TypingDock({
                     <input
                       ref={inputRef}
                       type="text"
-                      value={text}
-                      onChange={(e) => onChange(e.target.value)}
+                      value={currentText}
+                      onChange={(e) => {
+                        if (enableTabs) {
+                          updateActiveTabText(e.target.value);
+                        }
+                        onChange(e.target.value);
+                      }}
                       onKeyDown={handleKeyDown}
                       onBlur={handleBlur}
                       placeholder="Type to speak..."
@@ -509,11 +567,11 @@ export default function TypingDock({
                   {/* Speak/Stop button - primary CTA */}
                   <motion.button
                     onClick={isSpeaking ? onStop : onSpeak}
-                    disabled={!isAvailable || (!isSpeaking && !text.trim())}
+                    disabled={!isAvailable || (!isSpeaking && !currentText.trim())}
                     className={`flex-shrink-0 p-4 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
                       isSpeaking
                         ? 'bg-gradient-to-r from-red-500 to-red-600 text-white'
-                        : text.trim()
+                        : currentText.trim()
                           ? 'bg-primary-500 hover:bg-primary-600 text-white'
                           : 'bg-surface-hover text-text-tertiary'
                     }`}
@@ -534,6 +592,13 @@ export default function TypingDock({
                     className="px-1 text-xs text-text-tertiary"
                   />
                 )}
+                {showUndoHint && (
+                  <UndoClearHint
+                    remainingMs={undoRemainingMs}
+                    onUndo={undo}
+                    className="px-1"
+                  />
+                )}
               </motion.div>
             )}
           </AnimatePresence>
@@ -551,7 +616,7 @@ export default function TypingDock({
           onStartSharing={async () => {
             await createSession();
             if (isSharing) {
-              updateContent(text);
+              updateContent(currentText);
             }
           }}
           onEndSession={async () => {

--- a/app/components/typing/UndoClearHint.tsx
+++ b/app/components/typing/UndoClearHint.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+type UndoClearHintProps = {
+  remainingMs: number;
+  onUndo: () => void;
+  className?: string;
+};
+
+export default function UndoClearHint({ remainingMs, onUndo, className }: UndoClearHintProps) {
+  const seconds = Math.max(1, Math.ceil(remainingMs / 1000));
+
+  return (
+    <div className={cn('flex items-center gap-2 text-xs text-text-tertiary', className)}>
+      <span>Text cleared</span>
+      <button
+        type="button"
+        onClick={onUndo}
+        className="text-primary-500 hover:text-primary-400 font-semibold"
+      >
+        Undo
+      </button>
+      <span>({seconds}s)</span>
+    </div>
+  );
+}

--- a/lib/hooks/useUndoClear.ts
+++ b/lib/hooks/useUndoClear.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type UndoEntry = {
+  tabId: string;
+  text: string;
+};
+
+type UseUndoClearOptions = {
+  timeoutMs: number;
+  onRestore: (entry: UndoEntry) => void;
+};
+
+type ClearWithUndoOptions = {
+  tabId: string;
+  text: string;
+  onClear: () => void;
+};
+
+type UseUndoClearResult = {
+  clearWithUndo: (options: ClearWithUndoOptions) => void;
+  undo: () => void;
+  resetUndo: () => void;
+  canUndo: boolean;
+  remainingMs: number;
+  entry: UndoEntry | null;
+};
+
+export function useUndoClear({ timeoutMs, onRestore }: UseUndoClearOptions): UseUndoClearResult {
+  const [entry, setEntry] = useState<UndoEntry | null>(null);
+  const [remainingMs, setRemainingMs] = useState(0);
+  const timeoutRef = useRef<number | null>(null);
+  const intervalRef = useRef<number | null>(null);
+  const expiryRef = useRef<number | null>(null);
+
+  const resetUndo = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    expiryRef.current = null;
+    setEntry(null);
+    setRemainingMs(0);
+  }, []);
+
+  const startTimer = useCallback((expiresAt: number) => {
+    expiryRef.current = expiresAt;
+    setRemainingMs(Math.max(0, expiresAt - Date.now()));
+    intervalRef.current = window.setInterval(() => {
+      if (!expiryRef.current) return;
+      const nextRemaining = Math.max(0, expiryRef.current - Date.now());
+      setRemainingMs(nextRemaining);
+    }, 100);
+    timeoutRef.current = window.setTimeout(() => {
+      resetUndo();
+    }, Math.max(0, expiresAt - Date.now()));
+  }, [resetUndo]);
+
+  const clearWithUndo = useCallback(({ tabId, text, onClear }: ClearWithUndoOptions) => {
+    onClear();
+
+    if (!text.trim()) {
+      resetUndo();
+      return;
+    }
+
+    setEntry({ tabId, text });
+    startTimer(Date.now() + timeoutMs);
+  }, [resetUndo, startTimer, timeoutMs]);
+
+  const undo = useCallback(() => {
+    if (!entry) return;
+    onRestore(entry);
+    resetUndo();
+  }, [entry, onRestore, resetUndo]);
+
+  useEffect(() => () => resetUndo(), [resetUndo]);
+
+  return {
+    clearWithUndo,
+    undo,
+    resetUndo,
+    canUndo: Boolean(entry) && remainingMs > 0,
+    remainingMs,
+    entry,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable undo-clear hook with a 20s window
- show an inline Undo hint after clears in TypingArea and TypingDock
- keep tab switching in sync with active tab text

## Testing
- npm test
- npm run build

## Issue
- #286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added undo functionality allowing users to recover cleared text within a 20-second window
  * Introduced visual hint displaying when text is cleared with an Undo button and countdown timer
  * Enhanced multi-tab editing with independent text content per tab
  * Improved text synchronization across tabs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->