### PR TITLE
Move action prompts above typing inputs

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -290,10 +290,30 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
             onTabRename={renameTab}
             onManage={() => setShowTabManagementDialog(true)}
           />
-          <div className="flex-1 relative">
+          <div
+            className="flex-1 relative flex flex-col"
+            style={{ minHeight: textareaHeight, maxHeight: textareaHeight }}
+          >
+            {(showUndoHint || showDoubleEnterHint) && (
+              <div className="px-6 pb-3">
+                {showUndoHint ? (
+                  <ActionPromptBanner
+                    variant="undo"
+                    remainingMs={undoRemainingMs}
+                    onUndo={undo}
+                  />
+                ) : (
+                  <ActionPromptBanner
+                    variant="doubleEnter"
+                    actionLabel={doubleEnterActionLabel[settings.doubleEnterAction]}
+                    remainingMs={remainingMs}
+                  />
+                )}
+              </div>
+            )}
             <textarea
               ref={textareaRef}
-              className="w-full bg-transparent text-foreground placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-inset resize-none p-8 overflow-auto transition-all duration-300 rounded-3xl"
+              className="w-full flex-1 min-h-0 bg-transparent text-foreground placeholder:text-text-tertiary focus:outline-none resize-none p-8 overflow-auto transition-all duration-300 rounded-3xl"
               value={text}
               onChange={(e) => {
                 if (canUndo && e.target.value.trim().length > 0) {
@@ -315,19 +335,9 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
               placeholder="Type your message here..."
               style={{
                 fontSize: `${textSizePx}px`,
-                minHeight: textareaHeight,
-                maxHeight: textareaHeight,
                 lineHeight: '1.5',
               }}
             />
-            {showDoubleEnterHint && !showUndoHint && (
-              <ActionPromptBanner
-                variant="doubleEnter"
-                actionLabel={doubleEnterActionLabel[settings.doubleEnterAction]}
-                remainingMs={remainingMs}
-                className="mx-6 mb-3"
-              />
-            )}
             {error && (
               <div className="absolute bottom-0 left-0 right-0 bg-status-error text-red-400 p-4 text-sm rounded-b-3xl  transition-all duration-200">
                 {error}
@@ -405,15 +415,6 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
                 <XMarkIcon className="w-5 h-5" />
                 <span>Clear</span>
               </button>
-            </div>
-          )}
-          {showUndoHint && (
-            <div className="px-4 pb-3 bg-surface-hover transition-colors duration-200">
-              <ActionPromptBanner
-                variant="undo"
-                remainingMs={undoRemainingMs}
-                onUndo={undo}
-              />
             </div>
           )}
           {user && (

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -370,7 +370,24 @@ export default function TypingDock({
                 )}
 
                 {/* Expanded textarea */}
-                <div className={`relative ${isFullscreen ? 'flex-1 flex flex-col' : ''}`}>
+                <div className={`relative flex flex-col ${isFullscreen ? 'flex-1 min-h-0' : ''}`}>
+                  {(showUndoHint || showDoubleEnterHint) && (
+                    <div className="mb-2 shrink-0">
+                      {showUndoHint ? (
+                        <ActionPromptBanner
+                          variant="undo"
+                          remainingMs={undoRemainingMs}
+                          onUndo={undo}
+                        />
+                      ) : (
+                        <ActionPromptBanner
+                          variant="doubleEnter"
+                          actionLabel={doubleEnterActionLabel[settings.doubleEnterAction]}
+                          remainingMs={remainingMs}
+                        />
+                      )}
+                    </div>
+                  )}
                   <textarea
                     ref={textareaRef}
                     value={currentText}
@@ -386,18 +403,13 @@ export default function TypingDock({
                     onKeyDown={handleKeyDown}
                     onBlur={handleBlur}
                     placeholder="Type your message..."
-                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-16'} resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 ${isFullscreen ? 'flex-1' : ''}`}
+                    className={`w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-2xl px-4 py-3 ${enableTabs ? '' : 'pr-16'} resize-none ${isFullscreen ? 'flex-1 min-h-0' : ''}`}
                     rows={isFullscreen ? undefined : 3}
-                    style={{ fontSize: `${textSizePx}px`, ...(isFullscreen ? { minHeight: '100%' } : {}) }}
+                    style={{
+                      fontSize: `${textSizePx}px`,
+                      ...(isFullscreen ? { minHeight: '100%' } : {}),
+                    }}
                   />
-                  {showDoubleEnterHint && !showUndoHint && (
-                    <ActionPromptBanner
-                      variant="doubleEnter"
-                      actionLabel={doubleEnterActionLabel[settings.doubleEnterAction]}
-                      remainingMs={remainingMs}
-                      className="mt-2"
-                    />
-                  )}
                   {/* Control buttons (when tabs are not enabled) */}
                   {!enableTabs && (
                     <div className="absolute top-2 right-2 flex items-center gap-1">
@@ -535,14 +547,6 @@ export default function TypingDock({
                     )}
                   </motion.button>
                 </div>
-                {showUndoHint && (
-                  <ActionPromptBanner
-                    variant="undo"
-                    remainingMs={undoRemainingMs}
-                    onUndo={undo}
-                    className="mt-2"
-                  />
-                )}
               </motion.div>
             ) : (
               <motion.div
@@ -564,11 +568,29 @@ export default function TypingDock({
                   </div>
                 )}
 
-                <div className="flex items-center gap-2">
-                  {/* Compact input */}
-                  <div className="flex-1 relative">
-                    <input
-                      ref={inputRef}
+                <div className="space-y-2">
+                  {(showUndoHint || showDoubleEnterHint) && (
+                    <div>
+                      {showUndoHint ? (
+                        <ActionPromptBanner
+                          variant="undo"
+                          remainingMs={undoRemainingMs}
+                          onUndo={undo}
+                        />
+                      ) : (
+                        <ActionPromptBanner
+                          variant="doubleEnter"
+                          actionLabel={doubleEnterActionLabel[settings.doubleEnterAction]}
+                          remainingMs={remainingMs}
+                        />
+                      )}
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2">
+                    {/* Compact input */}
+                    <div className="flex-1 relative">
+                      <input
+                        ref={inputRef}
                       type="text"
                     value={currentText}
                     onChange={(e) => {
@@ -583,7 +605,7 @@ export default function TypingDock({
                       onKeyDown={handleKeyDown}
                       onBlur={handleBlur}
                       placeholder="Type to speak..."
-                      className="w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-full px-4 py-3 pr-10 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                      className="w-full bg-surface-hover text-foreground placeholder:text-text-tertiary rounded-full px-4 py-3 pr-10 focus:outline-none"
                       style={{ fontSize: `${textSizePx}px` }}
                     />
                     {/* Expand button */}
@@ -616,23 +638,8 @@ export default function TypingDock({
                       <SpeakerWaveIcon className="w-6 h-6" />
                     )}
                   </motion.button>
+                  </div>
                 </div>
-                {showUndoHint && (
-                  <ActionPromptBanner
-                    variant="undo"
-                    remainingMs={undoRemainingMs}
-                    onUndo={undo}
-                    className="mt-2"
-                  />
-                )}
-                {showDoubleEnterHint && !showUndoHint && (
-                  <ActionPromptBanner
-                    variant="doubleEnter"
-                    actionLabel={doubleEnterActionLabel[settings.doubleEnterAction]}
-                    remainingMs={remainingMs}
-                    className="mt-2"
-                  />
-                )}
               </motion.div>
             )}
           </AnimatePresence>

--- a/app/globals.css
+++ b/app/globals.css
@@ -159,6 +159,13 @@ body {
   outline-offset: 2px;
 }
 
+/* Remove focus rings for textareas (global) */
+textarea:focus,
+textarea:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 /* Skip link for screen readers */
 .skip-link {
   position: absolute;


### PR DESCRIPTION
## Summary
- move double-enter/undo banners above the typing inputs in TypingArea and TypingDock
- adjust layout so the textarea/input resizes to make room
- remove textarea focus rings globally

## Testing
- npm test
- npm run build

## Issue
- #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed focus outlines and shadows from textarea elements.

* **Refactor**
  * Reorganized typing area layout with consolidated action prompts repositioned above the textarea for improved information hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->