### PR TITLE
feat: add minimized typing dock mode

### DIFF
--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -10,6 +10,7 @@ import {
   ShareIcon,
   ArrowsPointingOutIcon,
   ArrowsPointingInIcon,
+  MinusIcon,
   StopIcon,
 } from '@heroicons/react/24/outline';
 import { useSettings } from '../contexts/SettingsContext';
@@ -68,6 +69,8 @@ export default function TypingDock({
   // Get current mode from settings
   const dockMode = uiPreferences.typingDockMode;
   const isFullscreen = dockMode === 'fullscreen';
+  const isMinimized = dockMode === 'minimized';
+  const lastDockModeRef = useRef<'expanded' | 'fullscreen'>('expanded');
 
   // Typing share hook
   const {
@@ -122,6 +125,12 @@ export default function TypingDock({
       }
     }
   }, [enableTabs, text, activeTab.text, updateActiveTabText]);
+
+  useEffect(() => {
+    if (dockMode === 'expanded' || dockMode === 'fullscreen') {
+      lastDockModeRef.current = dockMode;
+    }
+  }, [dockMode]);
 
   useEffect(() => {
     if (!enableTabs || !activeTabId) return;
@@ -214,6 +223,17 @@ export default function TypingDock({
     }, 100);
   };
 
+  const minimizeDock = () => {
+    updateUIPreference('typingDockMode', 'minimized');
+  };
+
+  const restoreDock = () => {
+    updateUIPreference('typingDockMode', lastDockModeRef.current);
+    setTimeout(() => {
+      textareaRef.current?.focus();
+    }, 100);
+  };
+
   // Update shared session content when text changes
   useEffect(() => {
     if (enableShare && isSharing) {
@@ -269,6 +289,87 @@ export default function TypingDock({
     }
   };
 
+  if (isMinimized) {
+    return (
+      <>
+        <button
+          onClick={restoreDock}
+          className="fixed bottom-[calc(env(safe-area-inset-bottom)+80px)] right-4 z-50 flex items-center justify-center rounded-full bg-surface-hover text-text-secondary shadow-lg p-3 hover:bg-surface transition-colors md:bottom-4"
+          aria-label="Open typing dock"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="2.5" y="7" width="19" height="9" rx="2" />
+            <path d="M6 11h.01M9 11h.01M12 11h.01M15 11h.01M18 11h.01" />
+            <path d="M6 14h12" />
+          </svg>
+        </button>
+
+        {/* Share Bottom Sheet */}
+        {enableShare && user && (
+          <ShareBottomSheet
+            isOpen={showShareSheet}
+            onClose={() => setShowShareSheet(false)}
+            isSharing={isSharing}
+            isCreating={isCreating}
+            shareableLink={shareableLink}
+            onStartSharing={async () => {
+              await createSession();
+              if (isSharing) {
+                updateContent(currentText);
+              }
+            }}
+            onEndSession={async () => {
+              await endSession();
+            }}
+          />
+        )}
+
+        {/* Tab List Bottom Sheet */}
+        {enableTabs && (
+          <MobileTabList
+            isOpen={showTabList}
+            onClose={() => setShowTabList(false)}
+            tabs={tabs}
+            activeTabId={activeTabId}
+            onSwitchTab={(tabId) => {
+              switchTab(tabId);
+              const tab = tabs.find(t => t.id === tabId);
+              if (tab) {
+                onChange(tab.text);
+              }
+            }}
+            onCloseTab={(tabId) => {
+              closeTab(tabId);
+              // Update the text to the new active tab's text
+              const remainingTabs = tabs.filter(t => t.id !== tabId);
+              if (remainingTabs.length > 0) {
+                onChange(remainingTabs[0].text);
+              }
+            }}
+            onCloseAllTabs={() => {
+              closeAllTabs();
+              onChange('');
+            }}
+            onCreateTab={() => {
+              createTab();
+              onChange('');
+            }}
+            onRenameTab={renameTab}
+          />
+        )}
+      </>
+    );
+  }
+
   return (
     <>
       <div
@@ -294,7 +395,7 @@ export default function TypingDock({
               >
                 <div className="flex items-center justify-between">
                   {enableTabs ? (
-                    <div className="flex-1 flex justify-center">
+                    <div className="flex items-center">
                       <MobileTabIndicator
                         tabs={tabs}
                         activeTab={activeTab}
@@ -302,19 +403,28 @@ export default function TypingDock({
                       />
                     </div>
                   ) : (
-                    <div className="flex-1" />
+                    <div />
                   )}
-                  <button
-                    onClick={toggleFullscreen}
-                    className="p-1.5 rounded-full hover:bg-surface transition-colors"
-                    aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-                  >
-                    {isFullscreen ? (
-                      <ArrowsPointingInIcon className="w-4 h-4 text-text-secondary" />
-                    ) : (
-                      <ArrowsPointingOutIcon className="w-4 h-4 text-text-secondary" />
-                    )}
-                  </button>
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={minimizeDock}
+                      className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                      aria-label="Minimize"
+                    >
+                      <MinusIcon className="w-4 h-4 text-text-secondary" />
+                    </button>
+                    <button
+                      onClick={toggleFullscreen}
+                      className="p-1.5 rounded-full hover:bg-surface transition-colors"
+                      aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                    >
+                      {isFullscreen ? (
+                        <ArrowsPointingInIcon className="w-4 h-4 text-text-secondary" />
+                      ) : (
+                        <ArrowsPointingOutIcon className="w-4 h-4 text-text-secondary" />
+                      )}
+                    </button>
+                  </div>
                 </div>
 
                 {/* Expanded textarea */}

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -8,7 +8,7 @@ import { useAuth } from './AuthContext';
 
 type TextSize = number;
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
-type TypingDockMode = 'expanded' | 'fullscreen';
+type TypingDockMode = 'expanded' | 'fullscreen' | 'minimized';
 
 const DOUBLE_ENTER_TIMEOUT_MIN_MS = 1000;
 const DOUBLE_ENTER_TIMEOUT_MAX_MS = 10000;
@@ -148,7 +148,7 @@ function loadFromLocalStorage(): AllSettings {
   };
 
   // Parse typing dock mode
-  const validTypingDockModes = ['expanded', 'fullscreen'];
+  const validTypingDockModes = ['expanded', 'fullscreen', 'minimized'];
   const parsedTypingDockMode = typingDockMode && validTypingDockModes.includes(typingDockMode)
     ? typingDockMode as TypingDockMode
     : defaultUIPreferences.typingDockMode;
@@ -268,6 +268,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         });
     } else if (convexSettings) {
       // Settings exist in Convex - update from server
+      const serverTypingDockMode = convexSettings.typingDockMode as TypingDockMode | undefined;
       const serverSettings: AllSettings = {
         textSize: normalizeTextSize(convexSettings.textSize),
         speechRate: convexSettings.speechRate,
@@ -287,8 +288,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         selectedBoardId: convexSettings.selectedBoardId ?? null,
         typingShareFontSize: convexSettings.typingShareFontSize,
         activeTypingTabId: convexSettings.activeTypingTabId ?? null,
-        typingDockMode: convexSettings.typingDockMode === 'fullscreen'
-          ? 'fullscreen'
+        typingDockMode: serverTypingDockMode === 'fullscreen' || serverTypingDockMode === 'minimized'
+          ? serverTypingDockMode
           : defaultUIPreferences.typingDockMode,
       };
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -94,7 +94,7 @@ export default defineSchema({
     typingShareFontSize: v.number(),
     typingTabs: v.optional(v.string()), // JSON stringified TypingTabsState
     activeTypingTabId: v.optional(v.string()),
-    typingDockMode: v.optional(v.union(v.literal('expanded'), v.literal('fullscreen'))),
+    typingDockMode: v.optional(v.union(v.literal('expanded'), v.literal('fullscreen'), v.literal('minimized'))),
 
     // Metadata for sync tracking
     lastSyncedAt: v.number(),

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -42,7 +42,7 @@ export const initializeSettings = mutation({
     typingShareFontSize: v.number(),
     typingTabs: v.optional(v.string()),
     activeTypingTabId: v.optional(v.string()),
-    typingDockMode: v.optional(v.union(v.literal('expanded'), v.literal('fullscreen'))),
+    typingDockMode: v.optional(v.union(v.literal('expanded'), v.literal('fullscreen'), v.literal('minimized'))),
   },
   handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
@@ -137,7 +137,7 @@ export const updateSettings = mutation({
     typingShareFontSize: v.optional(v.number()),
     typingTabs: v.optional(v.string()),
     activeTypingTabId: v.optional(v.string()),
-    typingDockMode: v.optional(v.union(v.literal('expanded'), v.literal('fullscreen'))),
+    typingDockMode: v.optional(v.union(v.literal('expanded'), v.literal('fullscreen'), v.literal('minimized'))),
     lastSyncedAt: v.number(),
   },
   handler: async (ctx, args) => {


### PR DESCRIPTION
## Summary
- add `minimized` typing dock mode with right-corner restore button
- keep fullscreen toggle and add minimize control in the dock header
- extend typingDockMode validation/storage to include minimized

## Issues
- Closes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now minimize the typing dock using a dedicated minimize button, reducing it to a compact interface. A restore button allows quick return to the previous layout. The dock configuration is remembered across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->