### PR TITLE
Rename Share to Live Typing (user-facing and code-level)

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -6,10 +6,10 @@ import { Tooltip } from 'react-tooltip';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
 import SubscriptionWrapper from './SubscriptionWrapper';
-import { useTypingShare } from '@/lib/hooks/useTypingShare';
+import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
-import ShareLinkModal from './typing-share/ShareLinkModal';
+import LiveTypingLinkModal from './live-typing/LiveTypingLinkModal';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import TabBar from './typing-tabs/TabBar';
 import TabManagementDialog from './typing-tabs/TabManagementDialog';
@@ -32,7 +32,7 @@ type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
 export default function TypingArea({ initialText = '', text: externalText, tts, onChange }: TypingAreaProps) {
   const [error, setError] = useState<string | null>(null);
   const [isFixingText, setIsFixingText] = useState(false);
-  const [showShareModal, setShowShareModal] = useState(false);
+  const [showLiveTypingModal, setShowLiveTypingModal] = useState(false);
   const [showTabManagementDialog, setShowTabManagementDialog] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const prevActiveTabIdRef = useRef<string | null>(null);
@@ -46,7 +46,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
     createSession,
     endSession,
     getShareableLink,
-  } = useTypingShare();
+  } = useLiveTyping();
   const shareableLink = getShareableLink();
   const isVisible = uiPreferences.typingAreaVisible;
   const isExpanded = uiPreferences.typingAreaExpanded;
@@ -131,7 +131,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
 
   const handleShare = async () => {
     if (isSharing) {
-      setShowShareModal(true);
+      setShowLiveTypingModal(true);
       return;
     }
 
@@ -139,7 +139,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
 
     if (isSharing) {
       updateContent(text);
-      setShowShareModal(true);
+      setShowLiveTypingModal(true);
     }
   };
 
@@ -426,8 +426,8 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
                     ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
                     : 'bg-surface hover:bg-status-success text-foreground hover:text-green-500'
                 }`}
-                data-tooltip-id="share-tooltip"
-                data-tooltip-content={isSharing ? 'View share link' : 'Share your typing'}
+                data-tooltip-id="live-typing-tooltip"
+                data-tooltip-content={isSharing ? 'View live typing link' : 'Start live typing'}
                 disabled={isCreating}
               >
                 {isCreating ? (
@@ -438,7 +438,7 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
                 ) : (
                   <>
                     <ShareIcon className="w-5 h-5" />
-                    <span>{isSharing ? 'Sharing Active' : 'Share'}</span>
+                    <span>{isSharing ? 'Live Typing Active' : 'Live Typing'}</span>
                   </>
                 )}
               </button>
@@ -483,15 +483,15 @@ export default function TypingArea({ initialText = '', text: externalText, tts, 
       <Tooltip id="clear-tooltip" />
       <Tooltip id="expand-tooltip" />
       <Tooltip id="toggle-tooltip" />
-      <Tooltip id="share-tooltip" />
+      <Tooltip id="live-typing-tooltip" />
 
-      {showShareModal && shareableLink && (
-        <ShareLinkModal
+      {showLiveTypingModal && shareableLink && (
+        <LiveTypingLinkModal
           shareableLink={shareableLink}
-          onClose={() => setShowShareModal(false)}
+          onClose={() => setShowLiveTypingModal(false)}
           onEndSession={async () => {
             await endSession();
-            setShowShareModal(false);
+            setShowLiveTypingModal(false);
           }}
         />
       )}

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -15,13 +15,13 @@ import {
 } from '@heroicons/react/24/outline';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
-import { useTypingShare } from '@/lib/hooks/useTypingShare';
+import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import SubscriptionWrapper from './SubscriptionWrapper';
-import ShareBottomSheet from './typing-share/ShareBottomSheet';
+import LiveTypingBottomSheet from './live-typing/LiveTypingBottomSheet';
 import MobileTabIndicator from './typing-tabs/MobileTabIndicator';
 import MobileTabList from './typing-tabs/MobileTabList';
 import ActionPromptBanner from './typing/ActionPromptBanner';
@@ -36,7 +36,7 @@ interface TypingDockProps {
   className?: string;
   // Feature flags
   enableTabs?: boolean;
-  enableShare?: boolean;
+  enableLiveTyping?: boolean;
   enableFixText?: boolean;
 }
 
@@ -51,12 +51,12 @@ export default function TypingDock({
   isAvailable = true,
   className = '',
   enableTabs = false,
-  enableShare = false,
+  enableLiveTyping = false,
   enableFixText = false,
 }: TypingDockProps) {
   const [isFixingText, setIsFixingText] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showShareSheet, setShowShareSheet] = useState(false);
+  const [showLiveTypingSheet, setShowLiveTypingSheet] = useState(false);
   const [showTabList, setShowTabList] = useState(false);
   const { top: viewportTop, height: viewportHeight } = useVisualViewport();
 
@@ -80,7 +80,7 @@ export default function TypingDock({
     createSession,
     endSession,
     getShareableLink,
-  } = useTypingShare();
+  } = useLiveTyping();
   const shareableLink = getShareableLink();
 
   // Typing tabs hook (only used when enableTabs is true)
@@ -236,10 +236,10 @@ export default function TypingDock({
 
   // Update shared session content when text changes
   useEffect(() => {
-    if (enableShare && isSharing) {
+    if (enableLiveTyping && isSharing) {
       updateContent(currentText);
     }
-  }, [currentText, enableShare, isSharing, updateContent]);
+  }, [currentText, enableLiveTyping, isSharing, updateContent]);
 
   // Handle Enter key
   const handleKeyDown = useCallback(
@@ -313,11 +313,11 @@ export default function TypingDock({
           </svg>
         </button>
 
-        {/* Share Bottom Sheet */}
-        {enableShare && user && (
-          <ShareBottomSheet
-            isOpen={showShareSheet}
-            onClose={() => setShowShareSheet(false)}
+        {/* Live Typing Bottom Sheet */}
+        {enableLiveTyping && user && (
+          <LiveTypingBottomSheet
+            isOpen={showLiveTypingSheet}
+            onClose={() => setShowLiveTypingSheet(false)}
             isSharing={isSharing}
             isCreating={isCreating}
             shareableLink={shareableLink}
@@ -531,20 +531,20 @@ export default function TypingDock({
                 <span className="text-sm font-medium">Clear</span>
               </button>
 
-              {/* Share button */}
-              {enableShare && user && (
+              {/* Live Typing button */}
+              {enableLiveTyping && user && (
                 <button
-                  onClick={() => setShowShareSheet(true)}
+                  onClick={() => setShowLiveTypingSheet(true)}
                   className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 ${
                     isSharing
                       ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
                       : 'bg-surface-hover hover:bg-status-success text-text-secondary hover:text-green-500'
                   }`}
-                  aria-label="Share"
+                  aria-label="Live Typing"
                 >
                   <ShareIcon className="w-4 h-4" />
                   <span className="text-sm font-medium">
-                    {isSharing ? 'Sharing' : 'Share'}
+                    {isSharing ? 'Live Typing Active' : 'Live Typing'}
                   </span>
                 </button>
               )}
@@ -581,11 +581,11 @@ export default function TypingDock({
         </div>
       </div>
 
-      {/* Share Bottom Sheet */}
-      {enableShare && user && (
-        <ShareBottomSheet
-          isOpen={showShareSheet}
-          onClose={() => setShowShareSheet(false)}
+      {/* Live Typing Bottom Sheet */}
+      {enableLiveTyping && user && (
+        <LiveTypingBottomSheet
+          isOpen={showLiveTypingSheet}
+          onClose={() => setShowLiveTypingSheet(false)}
           isSharing={isSharing}
           isCreating={isCreating}
           shareableLink={shareableLink}

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -337,7 +337,7 @@ export default function PhrasesInterface() {
             isSpeaking={tts.isSpeaking}
             isAvailable={tts.isAvailable}
             enableTabs={true}
-            enableShare={!!user}
+            enableLiveTyping={!!user}
             enableFixText={true}
           />
         </MobileDockPortal>

--- a/app/components/live-typing/LiveTypingBottomSheet.tsx
+++ b/app/components/live-typing/LiveTypingBottomSheet.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { ClipboardIcon, CheckIcon, ArrowPathIcon, ShareIcon, StopIcon } from '@heroicons/react/24/outline';
 import BottomSheet from '@/app/components/ui/BottomSheet';
 
-interface ShareBottomSheetProps {
+interface LiveTypingBottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
   isSharing: boolean;
@@ -14,7 +14,7 @@ interface ShareBottomSheetProps {
   onEndSession: () => Promise<void>;
 }
 
-export default function ShareBottomSheet({
+export default function LiveTypingBottomSheet({
   isOpen,
   onClose,
   isSharing,
@@ -22,7 +22,7 @@ export default function ShareBottomSheet({
   shareableLink,
   onStartSharing,
   onEndSession,
-}: ShareBottomSheetProps) {
+}: LiveTypingBottomSheetProps) {
   const [copied, setCopied] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
 
@@ -42,7 +42,7 @@ export default function ShareBottomSheet({
     try {
       await onStartSharing();
     } catch (err) {
-      console.error('Failed to start sharing:', err);
+      console.error('Failed to start live typing:', err);
     }
   };
 
@@ -52,7 +52,7 @@ export default function ShareBottomSheet({
       await onEndSession();
       onClose();
     } catch (err) {
-      console.error('Failed to end session:', err);
+      console.error('Failed to end live typing session:', err);
     } finally {
       setIsEnding(false);
     }
@@ -62,16 +62,16 @@ export default function ShareBottomSheet({
     <BottomSheet
       isOpen={isOpen}
       onClose={onClose}
-      title="Share Session"
+      title="Live Typing Session"
       snapPoints={[40]}
       initialSnap={0}
     >
       <div className="p-4 space-y-4">
         {!isSharing ? (
-          /* Not sharing - show start button */
+          /* Not active - show start button */
           <div className="text-center py-4">
             <ShareIcon className="w-12 h-12 mx-auto text-text-secondary mb-3" />
-            <h3 className="text-lg font-medium text-foreground mb-2">Share Your Typing</h3>
+            <h3 className="text-lg font-medium text-foreground mb-2">Live Typing</h3>
             <p className="text-text-secondary text-sm mb-6">
               Let others see what you're typing in real-time. The session expires in 24 hours.
             </p>
@@ -93,17 +93,17 @@ export default function ShareBottomSheet({
               ) : (
                 <>
                   <ShareIcon className="w-5 h-5" />
-                  <span>Start Sharing</span>
+                  <span>Start Live Typing</span>
                 </>
               )}
             </button>
           </div>
         ) : (
-          /* Currently sharing - show link and controls */
+          /* Currently active - show link and controls */
           <div className="space-y-4">
             <div className="bg-status-success p-3 rounded-xl flex items-center gap-2">
               <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-              <span className="text-green-400 text-sm font-medium">Sharing Active</span>
+              <span className="text-green-400 text-sm font-medium">Live Typing Active</span>
             </div>
 
             <p className="text-text-secondary text-sm">
@@ -149,7 +149,7 @@ export default function ShareBottomSheet({
               ) : (
                 <>
                   <StopIcon className="w-5 h-5" />
-                  <span>End Session</span>
+                  <span>End Live Typing</span>
                 </>
               )}
             </button>

--- a/app/components/live-typing/LiveTypingLinkModal.tsx
+++ b/app/components/live-typing/LiveTypingLinkModal.tsx
@@ -3,13 +3,13 @@
 import { useState } from 'react';
 import { XMarkIcon, ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
 
-interface ShareLinkModalProps {
+interface LiveTypingLinkModalProps {
   shareableLink: string;
   onClose: () => void;
   onEndSession: () => Promise<void>;
 }
 
-export default function ShareLinkModal({ shareableLink, onClose, onEndSession }: ShareLinkModalProps) {
+export default function LiveTypingLinkModal({ shareableLink, onClose, onEndSession }: LiveTypingLinkModalProps) {
   const [copied, setCopied] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
 
@@ -28,7 +28,7 @@ export default function ShareLinkModal({ shareableLink, onClose, onEndSession }:
     try {
       await onEndSession();
     } catch (err) {
-      console.error('Failed to end session:', err);
+      console.error('Failed to end live typing session:', err);
       setIsEnding(false);
     }
   };
@@ -37,7 +37,7 @@ export default function ShareLinkModal({ shareableLink, onClose, onEndSession }:
     <div className="fixed inset-0 bg-overlay flex items-center justify-center p-4 z-50">
       <div className="rounded-lg shadow-xl max-w-md w-full p-6" style={{ backgroundColor: '#242424' }}>
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-2xl font-bold text-foreground">Share Your Typing</h2>
+          <h2 className="text-2xl font-bold text-foreground">Live Typing</h2>
           <button
             onClick={onClose}
             className="text-text-secondary hover:text-foreground transition-colors"
@@ -89,7 +89,7 @@ export default function ShareLinkModal({ shareableLink, onClose, onEndSession }:
             disabled={isEnding}
             className="flex-1 px-4 py-3 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors disabled:opacity-50"
           >
-            {isEnding ? 'Ending...' : 'End Session'}
+            {isEnding ? 'Ending...' : 'End Live Typing'}
           </button>
         </div>
       </div>

--- a/app/typing-share/view/[key]/page.tsx
+++ b/app/typing-share/view/[key]/page.tsx
@@ -50,7 +50,7 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
       <div className="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8">
         <div className="bg-surface rounded-3xl shadow-2xl hover:shadow-3xl transition-all duration-300">
           <div className="p-6 sm:p-8">
-            <h1 className="text-3xl font-bold text-foreground">Live Typing Share</h1>
+            <h1 className="text-3xl font-bold text-foreground">Live Typing</h1>
             <p className="text-text-secondary mt-2">
               You are viewing a live typing session. Updates appear in real-time.
             </p>

--- a/lib/hooks/useLiveTyping.ts
+++ b/lib/hooks/useLiveTyping.ts
@@ -16,7 +16,7 @@ type TypingSession = {
   _creationTime: number;
 } | null;
 
-export function useTypingShare() {
+export function useLiveTyping() {
   const [sessionKey, setSessionKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
@@ -57,7 +57,7 @@ export function useTypingShare() {
       }
       setSessionKey(null);
       setSession(null);
-      setError('This typing session has expired.');
+      setError('This live typing session has expired.');
       return;
     }
 
@@ -83,7 +83,7 @@ export function useTypingShare() {
       const created = await createTypingSession({ sessionKey: newKey });
 
       if (!created) {
-        throw new Error('Failed to create typing session');
+        throw new Error('Failed to create live typing session');
       }
 
       if (typeof window !== 'undefined') {
@@ -100,7 +100,7 @@ export function useTypingShare() {
         _creationTime: created._creationTime,
       });
     } catch (err) {
-      console.error('Error creating typing session:', err);
+      console.error('Error creating live typing session:', err);
       setError(err instanceof Error ? err.message : 'Failed to create session');
     } finally {
       setIsCreating(false);
@@ -119,7 +119,7 @@ export function useTypingShare() {
       try {
         await updateTypingSessionContent({ sessionKey, content });
       } catch (err) {
-        console.error('Error updating typing session:', err);
+        console.error('Error updating live typing session:', err);
       }
     }, 300); // 300ms debounce
   }, [sessionKey, updateTypingSessionContent]);
@@ -137,7 +137,7 @@ export function useTypingShare() {
         window.localStorage.removeItem(STORAGE_KEY);
       }
     } catch (err) {
-      console.error('Error ending typing session:', err);
+      console.error('Error ending live typing session:', err);
       setError(err instanceof Error ? err.message : 'Failed to end session');
     }
   }, [sessionKey, deleteTypingSession]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9975,6 +9975,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/tests/components/TypingArea.test.tsx
+++ b/tests/components/TypingArea.test.tsx
@@ -41,9 +41,9 @@ jest.mock('@/app/contexts/AuthContext', () => ({
   })),
 }));
 
-// Mock useTypingShare hook
-jest.mock('@/lib/hooks/useTypingShare', () => ({
-  useTypingShare: jest.fn(() => ({
+// Mock useLiveTyping hook
+jest.mock('@/lib/hooks/useLiveTyping', () => ({
+  useLiveTyping: jest.fn(() => ({
     isSharing: false,
     isCreating: false,
     createSession: jest.fn(),


### PR DESCRIPTION
Closes #300

## Summary
- Button labels updated: `Share` / `Sharing` → `Live Typing` / `Live Typing Active`
- Bottom sheet title: `Share Session` → `Live Typing Session`
- Start button: `Start Sharing` → `Start Live Typing`; End button: `End Session` → `End Live Typing`
- Modal title: `Share Your Typing` → `Live Typing`
- View page heading: `Live Typing Share` → `Live Typing`
- `useTypingShare` → `useLiveTyping` (file renamed, all imports updated)
- `ShareBottomSheet` → `LiveTypingBottomSheet`, `ShareLinkModal` → `LiveTypingLinkModal`
- `enableShare` → `enableLiveTyping`, `showShareSheet/Modal` → `showLiveTypingSheet/Modal`
- Test mock updated accordingly
- Existing `/typing-share/view/` route preserved to keep share links working

## Test plan
- [ ] 227 tests pass ✓
- [ ] Live Typing button visible and labelled correctly with no text
- [ ] Live Typing button shows "Live Typing Active" when session is active
- [ ] Bottom sheet shows "Live Typing Session" title and "Start Live Typing" / "End Live Typing" buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the "Share" feature to "Live Typing" throughout the application.
  * Updated user-facing labels, button text, and tooltips to consistently refer to "Live Typing" instead of "Share Session."
  * Adjusted error messages and status text to reflect the new terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->