### PR TITLE
Add release workflow and branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+
+      - name: Create GitHub Release
+        run: gh release create ${{ github.ref_name }} --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,20 +90,16 @@ This command will:
 git push && git push --tags
 ```
 
-**Step 6: Create GitHub Release**
-```bash
-# Create release with auto-generated notes (no title specified)
-gh release create v1.15.0 --generate-notes
-```
+Pushing the tag triggers the **Release GitHub Action** (`.github/workflows/release.yml`) which will:
+- Build the project
+- Automatically create the GitHub Release with auto-generated notes
 
-The release will:
-- Use the version tag created by `npm version`
-- Auto-generate release notes from merged PRs
+Vercel automatically deploys to production when the release is created.
 
-**Step 7: Close Milestone**
+**Step 6: Close Milestone**
 ```bash
 # Close the milestone (use milestone number from GitHub)
-gh api repos/:owner/:repo/milestones/<number> -X PATCH -f state=closed
+gh api repos/enaboapps/sayit-web/milestones/<number> -X PATCH -f state=closed
 ```
 
 ## Working with AI Agents


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml`: triggered on `v*` tag pushes, builds the project and creates a GitHub Release with auto-generated notes
- Updates `AGENTS.md`: removes manual `gh release create` step (now automated by the action), fixes milestone close command with full repo path
- Branch protection already enabled on `main` via GitHub API: enforce admins, dismiss stale reviews, require conversation resolution, no force pushes or deletions

## How releases work now
1. Run tests, lint, version bump (`npm version minor/patch/major`), push commits + tags
2. Tag push triggers the workflow → build + auto GitHub Release
3. Vercel auto-deploys on release
4. Close milestone

## Test plan
- [ ] Verify branch protection is active (this PR itself proves it)
- [ ] Verify workflow triggers correctly on next release tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release workflow that builds and publishes releases when version tags are pushed.
  * Updated release process documentation to reflect the automated workflow and production deployment mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->