### PR TITLE
Fix dropdown z-index appearing below bottom sheets

### DIFF
--- a/app/components/phrases/BoardGridPopup.tsx
+++ b/app/components/phrases/BoardGridPopup.tsx
@@ -26,7 +26,7 @@ export default function BoardGridPopup({
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={onClose}>
+      <Dialog as="div" className="relative z-[65]" onClose={onClose}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/app/components/typing-tabs/TabManagementDialog.tsx
+++ b/app/components/typing-tabs/TabManagementDialog.tsx
@@ -81,7 +81,7 @@ export default function TabManagementDialog({
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={onClose}>
+      <Dialog as="div" className="relative z-[65]" onClose={onClose}>
         {/* Backdrop with fade animation */}
         <Transition.Child
           as={Fragment}

--- a/app/components/ui/Dropdown.tsx
+++ b/app/components/ui/Dropdown.tsx
@@ -77,7 +77,7 @@ export function Dropdown<T = string>({
       </button>
 
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-50" onClose={() => setIsOpen(false)}>
+        <Dialog as="div" className="relative z-[65]" onClose={() => setIsOpen(false)}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"


### PR DESCRIPTION
Fixes #313

Raises headless UI dialog z-index from `z-50` to `z-[65]` so they render above the bottom sheet stack (backdrop `z-[55]`, content `z-[60]`).