### PR TITLE
Add offline connectivity UX and fix lint CI

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -8,6 +8,7 @@ import { ConvexReactClient } from 'convex/react';
 import { AuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { MobileBottomProvider } from './contexts/MobileBottomContext';
+import ConnectivityBanner from './components/navigation/ConnectivityBanner';
 import Sidebar from './components/Sidebar';
 import MobileBottomStack from './components/navigation/MobileBottomStack';
 
@@ -53,6 +54,7 @@ export default function ClientLayout({
 
                 {/* Main content area */}
                 <div className="flex-1 md:pl-16 lg:pl-16">
+                  <ConnectivityBanner />
                   <main className="min-h-dvh pb-32 md:pb-0">
                     {children}
                   </main>

--- a/app/components/navigation/ConnectivityBanner.tsx
+++ b/app/components/navigation/ConnectivityBanner.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CheckCircleIcon, WifiIcon } from '@heroicons/react/24/outline';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+
+export default function ConnectivityBanner() {
+  const { isOnline, wasOffline, clearRecoveredState } = useOnlineStatus();
+  const [showRecovered, setShowRecovered] = useState(false);
+
+  useEffect(() => {
+    if (!isOnline || !wasOffline) {
+      setShowRecovered(false);
+      return;
+    }
+
+    setShowRecovered(true);
+
+    const timeout = window.setTimeout(() => {
+      setShowRecovered(false);
+      clearRecoveredState();
+    }, 4000);
+
+    return () => window.clearTimeout(timeout);
+  }, [clearRecoveredState, isOnline, wasOffline]);
+
+  if (isOnline && !showRecovered) {
+    return null;
+  }
+
+  const isOfflineBanner = !isOnline;
+
+  return (
+    <div
+      className={`sticky top-0 z-40 border-b px-4 py-3 text-sm ${
+        isOfflineBanner
+          ? 'border-amber-900 bg-amber-500/10 text-amber-200'
+          : 'border-emerald-900 bg-emerald-500/10 text-emerald-200'
+      }`}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="mx-auto flex max-w-4xl items-start gap-3">
+        {isOfflineBanner ? (
+          <WifiIcon className="mt-0.5 h-5 w-5 shrink-0" />
+        ) : (
+          <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+        )}
+        <p>
+          {isOfflineBanner
+            ? 'You are offline. Text communication and browser speech still work, but boards, AI tools, and cloud sync may be unavailable.'
+            : 'Connection restored. Online features are available again.'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from 'react';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
 import { Button } from '@/app/components/ui/Button';
 
 export default function OfflinePage() {
@@ -19,15 +20,27 @@ export default function OfflinePage() {
         </div>
         <h1 className="text-3xl font-bold text-foreground mb-4">You're Offline</h1>
         <p className="text-text-secondary mb-8">
-          Please check your internet connection and try again.
+          You can still use text communication and browser speech from the home screen. Boards, AI features,
+          and cloud sync need an internet connection.
         </p>
-        <Button
-          onClick={handleRetry}
-          className="w-full gap-2"
-        >
-          <ArrowPathIcon className="w-5 h-5" />
-          <span>Retry Connection</span>
-        </Button>
+        <div className="flex flex-col gap-3">
+          <Button
+            asChild
+            className="w-full gap-2"
+          >
+            <Link href="/">
+              <span>Go to Home</span>
+            </Link>
+          </Button>
+          <Button
+            onClick={handleRetry}
+            variant="outline"
+            className="w-full gap-2"
+          >
+            <ArrowPathIcon className="w-5 h-5" />
+            <span>Retry Connection</span>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -176,8 +176,9 @@ export default function PrivacyPolicyPage() {
             </p>
             <ul className="list-disc ml-6 my-4 text-text-secondary">
               <li>Application resources are cached locally on your device</li>
-              <li>Your data syncs with our servers when you're online</li>
-              <li>Some features require an internet connection (AI, TTS, account sync)</li>
+              <li>Core text communication and browser speech can keep working offline after the app has been opened</li>
+              <li>Your cloud-backed data syncs with our servers when you're online</li>
+              <li>Some features require an internet connection (AI, ElevenLabs, boards, account sync)</li>
             </ul>
 
             <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">6.3 AI-Powered Features</h3>

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -57,9 +57,9 @@ export default function SupportPage() {
             <div>
               <h3 className="text-lg font-semibold text-foreground mb-2">Can I use SayIt! offline?</h3>
               <p className="text-text-secondary">
-                Yes! SayIt! is designed as a Progressive Web App (PWA), which means you can install it on your
-                device and use many features offline. Some features like account management and syncing require
-                an internet connection.
+                Yes. If you install SayIt! as a PWA, the app shell can open offline and you can continue typing
+                and using browser text-to-speech. Saved boards, AI features, account management, and cloud sync
+                still require an internet connection.
               </p>
             </div>
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 
 export default [
   {
-    ignores: ['.next/**', 'node_modules/**', 'out/**', '.vercel/**'],
+    ignores: ['.next/**', 'node_modules/**', 'out/**', '.vercel/**', 'next-env.d.ts', '**/*.d.ts'],
   },
   {
     files: ['**/*.{js,jsx,ts,tsx}'],

--- a/lib/hooks/useOnlineStatus.ts
+++ b/lib/hooks/useOnlineStatus.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(() => {
+    if (typeof navigator === 'undefined') {
+      return true;
+    }
+
+    return navigator.onLine;
+  });
+  const [wasOffline, setWasOffline] = useState(false);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsOnline(true);
+      setWasOffline(true);
+    };
+
+    const handleOffline = () => {
+      setIsOnline(false);
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return {
+    isOnline,
+    wasOffline,
+    clearRecoveredState: () => setWasOffline(false),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "jest --config jest.config.cjs",
     "test:watch": "jest --config jest.config.cjs --watch",
     "test:coverage": "jest --config jest.config.cjs --coverage"

--- a/tests/components/navigation/ConnectivityBanner.test.tsx
+++ b/tests/components/navigation/ConnectivityBanner.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import ConnectivityBanner from '@/app/components/navigation/ConnectivityBanner';
+
+describe('ConnectivityBanner', () => {
+  const setOnlineStatus = (isOnline: boolean) => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      configurable: true,
+      value: isOnline,
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setOnlineStatus(true);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not render while online by default', () => {
+    render(<ConnectivityBanner />);
+
+    expect(screen.queryByText(/Text communication and browser speech still work/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Connection restored/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the offline banner when the browser is offline', () => {
+    setOnlineStatus(false);
+
+    render(<ConnectivityBanner />);
+
+    expect(
+      screen.getByText(/Text communication and browser speech still work/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows a temporary recovery message after reconnecting', () => {
+    render(<ConnectivityBanner />);
+
+    act(() => {
+      setOnlineStatus(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(
+      screen.getByText(/Text communication and browser speech still work/i)
+    ).toBeInTheDocument();
+
+    act(() => {
+      setOnlineStatus(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(screen.getByText(/Connection restored/i)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.queryByText(/Connection restored/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a global online/offline banner so connectivity state is explicit in the app shell
- update the offline, support, and privacy copy to match the current text-communication-offline behavior
- fix the lint script and flat ESLint ignores so CI can run lint successfully again
- add test coverage for the connectivity banner state transitions

## Verification
- npm.cmd run lint
- npm.cmd test
- npm.cmd run build

Refs #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sticky connectivity banner that displays your connection status and notifies when connection is restored after being offline.
  * Enhanced offline page with clearer navigation options and descriptions of offline-available features.

* **Documentation**
  * Updated privacy policy and support FAQ to clarify which features require internet access and which work offline after initial app load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->