### PR TITLE
Persist offline typing state locally

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -47,6 +47,8 @@ export default function TypingArea({
   const [showTabManagementDialog, setShowTabManagementDialog] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const prevActiveTabIdRef = useRef<string | null>(null);
+  const hasProcessedInitialExternalTextRef = useRef(false);
+  const hasInitializedActiveTabRef = useRef(false);
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
   const { speak, stop, isSpeaking, isAvailable } = tts;
@@ -82,20 +84,43 @@ export default function TypingArea({
 
   // Sync external text prop with active tab
   useEffect(() => {
-    if (externalText !== undefined && externalText !== activeTab.text) {
+    if (externalText === undefined) {
+      return;
+    }
+
+    if (!hasProcessedInitialExternalTextRef.current) {
+      hasProcessedInitialExternalTextRef.current = true;
+
+      if (!externalText.trim() && activeTab.text.trim()) {
+        onChange?.(activeTab.text);
+        return;
+      }
+    }
+
+    if (externalText !== activeTab.text) {
       updateActiveTabText(externalText);
     }
-  }, [externalText, activeTab.text, updateActiveTabText]);
+  }, [activeTab.text, externalText, onChange, updateActiveTabText]);
 
   useEffect(() => {
     if (!activeTabId) return;
+
+    if (!hasInitializedActiveTabRef.current) {
+      hasInitializedActiveTabRef.current = true;
+      prevActiveTabIdRef.current = activeTabId;
+
+      if (externalText === undefined && activeTab.text.trim()) {
+        onChange?.(activeTab.text);
+      }
+      return;
+    }
 
     if (prevActiveTabIdRef.current && prevActiveTabIdRef.current !== activeTabId) {
       onChange?.(activeTab.text);
     }
 
     prevActiveTabIdRef.current = activeTabId;
-  }, [activeTabId, activeTab.text, onChange]);
+  }, [activeTabId, activeTab.text, externalText, onChange]);
 
   // Keyboard shortcuts for tabs
   useEffect(() => {

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -74,6 +74,8 @@ export default function TypingDock({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const prevTextRef = useRef(text); // Track previous text to detect external changes
   const prevActiveTabIdRef = useRef<string | null>(null);
+  const hasProcessedInitialTextRef = useRef(false);
+  const hasInitializedActiveTabRef = useRef(false);
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
 
@@ -129,13 +131,27 @@ export default function TypingDock({
   // Sync tabs text with external text prop when tabs are enabled
   // Only sync when text prop changes externally, not when activeTab.text changes
   useEffect(() => {
-    if (enableTabs && text !== prevTextRef.current) {
+    if (!enableTabs) {
+      return;
+    }
+
+    if (!hasProcessedInitialTextRef.current) {
+      hasProcessedInitialTextRef.current = true;
+      prevTextRef.current = text;
+
+      if (!text.trim() && activeTab.text.trim()) {
+        onChange(activeTab.text);
+        return;
+      }
+    }
+
+    if (text !== prevTextRef.current) {
       prevTextRef.current = text;
       if (text !== activeTab.text) {
         updateActiveTabText(text);
       }
     }
-  }, [enableTabs, text, activeTab.text, updateActiveTabText]);
+  }, [activeTab.text, enableTabs, onChange, text, updateActiveTabText]);
 
   useEffect(() => {
     if (dockMode === 'expanded' || dockMode === 'fullscreen') {
@@ -145,6 +161,12 @@ export default function TypingDock({
 
   useEffect(() => {
     if (!enableTabs || !activeTabId) return;
+
+    if (!hasInitializedActiveTabRef.current) {
+      hasInitializedActiveTabRef.current = true;
+      prevActiveTabIdRef.current = activeTabId;
+      return;
+    }
 
     if (prevActiveTabIdRef.current && prevActiveTabIdRef.current !== activeTabId) {
       onChange(activeTab.text);

--- a/app/components/home/GuestCommunication.tsx
+++ b/app/components/home/GuestCommunication.tsx
@@ -6,12 +6,18 @@ import TypingArea from '@/app/components/TypingArea';
 import TypingDock from '@/app/components/TypingDock';
 import { MobileDockPortal } from '@/app/contexts/MobileBottomContext';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
+import { useLocalMessageHistory } from '@/lib/hooks/useLocalMessageHistory';
 import { useTTS } from '@/lib/hooks/useTTS';
 
 export default function GuestCommunication() {
   const [text, setText] = useState('');
   const isMobile = useIsMobile();
   const tts = useTTS();
+  const { messages, recordMessage } = useLocalMessageHistory();
+
+  const handleRestoreMessage = (message: string) => {
+    setText(message);
+  };
 
   return (
     <section className="w-full max-w-5xl mx-auto px-4 pt-6 pb-4">
@@ -40,12 +46,38 @@ export default function GuestCommunication() {
               text={text}
               tts={tts}
               onChange={setText}
+              onMessageCompleted={recordMessage}
               enableFixText={false}
               enableLiveTyping={false}
             />
           </div>
         )}
       </div>
+
+      {messages.length > 0 && (
+        <div className="mt-4 rounded-3xl border border-border bg-surface px-5 py-4 shadow-lg">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Recent on this device</h3>
+              <p className="mt-1 text-xs text-text-secondary">
+                Tap a recent message to bring it back into the typing area.
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {messages.slice(0, 5).map((message) => (
+              <button
+                key={message.id}
+                type="button"
+                onClick={() => handleRestoreMessage(message.text)}
+                className="max-w-full rounded-full bg-surface-hover px-3 py-2 text-left text-sm text-foreground transition-colors hover:bg-primary-950 hover:text-primary-500"
+              >
+                {message.text}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {isMobile && (
         <MobileDockPortal>
@@ -58,6 +90,10 @@ export default function GuestCommunication() {
               }
 
               tts.speak(text);
+              recordMessage({
+                text,
+                source,
+              });
 
               if (source === 'speakAndClear') {
                 setTimeout(() => {
@@ -65,6 +101,7 @@ export default function GuestCommunication() {
                 }, 100);
               }
             }}
+            onMessageCompleted={recordMessage}
             onStop={tts.stop}
             isSpeaking={tts.isSpeaking}
             isAvailable={tts.isAvailable}

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useSettings } from '../../contexts/SettingsContext';
 import AnimatedLoading from '../phrases/AnimatedLoading';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
+import { useLocalMessageHistory } from '@/lib/hooks/useLocalMessageHistory';
 import ReplySuggestions from '../typing/ReplySuggestions';
 
 export default function PhrasesInterface() {
@@ -28,6 +29,7 @@ export default function PhrasesInterface() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [captureError, setCaptureError] = useState(false);
   const [isBoardPickerOpen, setIsBoardPickerOpen] = useState(false);
+  const { messages: localRecentMessages, recordMessage: recordLocalMessage } = useLocalMessageHistory();
   const selectedBoardId = uiPreferences.selectedBoardId;
   const activeTabId = uiPreferences.activeTypingTabId;
   const isMobile = useIsMobile();
@@ -215,6 +217,12 @@ export default function PhrasesInterface() {
       return;
     }
 
+    recordLocalMessage({
+      text: trimmedText,
+      source,
+      tabId,
+    });
+
     try {
       await recordMessage({
         text: trimmedText,
@@ -254,7 +262,13 @@ export default function PhrasesInterface() {
   };
 
   const suggestionContext = useMemo(() => {
-    const allMessages = recentMessages ?? [];
+    const fallbackLocalMessages = localRecentMessages.map((entry) => ({
+      text: entry.text,
+      tabId: entry.tabId ?? undefined,
+    }));
+    const allMessages = recentMessages && recentMessages.length > 0
+      ? recentMessages
+      : fallbackLocalMessages;
     const sameTabMessages = activeTabId
       ? allMessages.filter((entry) => entry.tabId === activeTabId)
       : [];
@@ -272,7 +286,7 @@ export default function PhrasesInterface() {
         ? 'Using recent completed messages across tabs until this tab has more history'
         : 'Based on your recent completed messages',
     };
-  }, [activeTabId, recentMessages]);
+  }, [activeTabId, localRecentMessages, recentMessages]);
 
   return (
     <>

--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -59,6 +59,11 @@ export function useTypingTabs(initialText?: string) {
     if (hasAutoCreated.current) return;
     hasAutoCreated.current = true;
 
+    // Only auto-create a follow-up tab when the hook was seeded with initial text.
+    if (!initialText?.trim()) {
+      return;
+    }
+
     // Check if active tab has text - auto-create a new empty tab
     if (activeTab.text.trim().length > 0) {
       const newTab = createDefaultTab(tabsState.nextTabNumber);
@@ -68,7 +73,7 @@ export function useTypingTabs(initialText?: string) {
         nextTabNumber: prev.nextTabNumber + 1,
       }));
     }
-  }, [activeTab.text, tabsState.tabs.length, tabsState.nextTabNumber]);
+  }, [activeTab.text, initialText, tabsState.nextTabNumber]);
 
   // Persist tabs to localStorage and Convex (debounced)
   const persistTabs = useCallback((state: TypingTabsState) => {

--- a/docs/offline-text-persistence.md
+++ b/docs/offline-text-persistence.md
@@ -1,0 +1,21 @@
+# Offline Text Persistence
+
+The offline text communication milestone uses `localStorage` for device-local persistence of typing drafts, typing tabs, the active tab id, and a short recent-message history.
+
+## Why `localStorage`
+
+- The current offline scope is small: one active typing experience plus a short history.
+- Draft restore has to work immediately on app startup without waiting for network or a larger client-side sync layer.
+- The app already stores typing tabs in `localStorage`, so extending that path keeps the release small and consistent.
+
+## Tradeoffs
+
+- Pros: simple, synchronous startup restore, no schema migration layer, no new dependency surface.
+- Cons: storage is smaller than IndexedDB, writes are synchronous, and the data remains device-local with no background sync.
+
+## Boundaries
+
+- This is intentionally not a Convex replacement.
+- App shell assets still belong in the service worker cache.
+- Cloud data such as boards, phrases, and account state remain server-backed.
+- If offline board editing or queued sync becomes a requirement later, IndexedDB becomes the more appropriate store for that larger workload.

--- a/lib/hooks/useLocalMessageHistory.ts
+++ b/lib/hooks/useLocalMessageHistory.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'localTypingHistory';
+const MAX_HISTORY_ENTRIES = 10;
+
+export interface LocalMessageHistoryEntry {
+  id: string;
+  text: string;
+  source: 'speak' | 'speakAndClear' | 'clear';
+  tabId?: string | null;
+  completedAt: number;
+}
+
+interface RecordLocalMessagePayload {
+  text: string;
+  source: 'speak' | 'speakAndClear' | 'clear';
+  tabId?: string | null;
+}
+
+function parseStoredHistory(value: string | null): LocalMessageHistoryEntry[] {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value) as LocalMessageHistoryEntry[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter((entry): entry is LocalMessageHistoryEntry => (
+        !!entry
+        && typeof entry.id === 'string'
+        && typeof entry.text === 'string'
+        && typeof entry.source === 'string'
+        && typeof entry.completedAt === 'number'
+      ))
+      .slice(0, MAX_HISTORY_ENTRIES);
+  } catch (error) {
+    console.error('Failed to parse local typing history:', error);
+    return [];
+  }
+}
+
+export function useLocalMessageHistory() {
+  const [messages, setMessages] = useState<LocalMessageHistoryEntry[]>(() => {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    return parseStoredHistory(window.localStorage.getItem(STORAGE_KEY));
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+  }, [messages]);
+
+  const recordMessage = useCallback((payload: RecordLocalMessagePayload) => {
+    const trimmedText = payload.text.trim();
+    if (!trimmedText) {
+      return;
+    }
+
+    setMessages((current) => {
+      const nextEntry: LocalMessageHistoryEntry = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        text: trimmedText,
+        source: payload.source,
+        tabId: payload.tabId,
+        completedAt: Date.now(),
+      };
+
+      const deduped = current.filter((entry) => (
+        entry.text !== trimmedText
+        || entry.tabId !== payload.tabId
+      ));
+
+      return [nextEntry, ...deduped].slice(0, MAX_HISTORY_ENTRIES);
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setMessages([]);
+  }, []);
+
+  return {
+    messages,
+    recordMessage,
+    clearHistory,
+  };
+}

--- a/tests/components/TypingArea.test.tsx
+++ b/tests/components/TypingArea.test.tsx
@@ -22,8 +22,11 @@ const mockUpdateUIPreference = jest.fn();
 jest.mock('@/app/contexts/SettingsContext', () => ({
   useSettings: jest.fn(() => ({
     settings: {
-      textSize: 'medium',
+      textSize: 18,
+      doubleEnterEnabled: false,
+      doubleEnterTimeoutMs: 600,
       enterKeyBehavior: 'newline',
+      doubleEnterAction: 'speak',
     },
     uiPreferences: {
       typingAreaVisible: true,
@@ -60,12 +63,34 @@ const mockTTS = {
   isAvailable: true,
 };
 
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
 // Mock scrollTo for TabBar component
 Element.prototype.scrollTo = jest.fn();
 
 describe('TypingArea', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorageMock.clear();
   });
 
   describe('external text prop synchronization', () => {
@@ -150,6 +175,29 @@ describe('TypingArea', () => {
 
       // onChange should not be called again if text hasn't changed
       expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('restores a persisted draft instead of overwriting it with an empty text prop', () => {
+      localStorageMock.setItem('typingTabs', JSON.stringify({
+        tabs: [
+          {
+            id: 'stored-tab-1',
+            label: 'Stored Draft',
+            text: 'Restored draft',
+            createdAt: Date.now(),
+            lastModified: Date.now(),
+            isCustomLabel: false,
+          },
+        ],
+        activeTabId: 'stored-tab-1',
+        nextTabNumber: 2,
+      }));
+
+      const onChange = jest.fn();
+      render(<TypingArea text="" tts={mockTTS} onChange={onChange} />);
+
+      expect(screen.getByRole('textbox')).toHaveValue('Restored draft');
+      expect(onChange).toHaveBeenCalledWith('Restored draft');
     });
 
     it('replaces existing text when phrase is selected', () => {

--- a/tests/components/TypingDock.test.tsx
+++ b/tests/components/TypingDock.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TypingDock from '@/app/components/TypingDock';
+
+jest.mock('nanoid', () => {
+  let idCounter = 0;
+  return {
+    nanoid: jest.fn(() => `test-id-${++idCounter}`),
+  };
+});
+
+const mockUpdateSettingsMutation = jest.fn();
+jest.mock('convex/react', () => ({
+  useMutation: jest.fn(() => mockUpdateSettingsMutation),
+}));
+
+const mockUpdateUIPreference = jest.fn();
+jest.mock('@/app/contexts/SettingsContext', () => ({
+  useSettings: jest.fn(() => ({
+    settings: {
+      textSize: 18,
+      doubleEnterEnabled: false,
+      doubleEnterTimeoutMs: 600,
+      enterKeyBehavior: 'newline',
+      doubleEnterAction: 'speak',
+    },
+    uiPreferences: {
+      typingDockMode: 'expanded',
+      activeTypingTabId: null,
+    },
+    updateUIPreference: mockUpdateUIPreference,
+  })),
+}));
+
+jest.mock('@/app/contexts/AuthContext', () => ({
+  useAuth: jest.fn(() => ({
+    user: null,
+  })),
+}));
+
+jest.mock('@/lib/hooks/useLiveTyping', () => ({
+  useLiveTyping: jest.fn(() => ({
+    isSharing: false,
+    isCreating: false,
+    createSession: jest.fn(),
+    endSession: jest.fn(),
+    updateContent: jest.fn(),
+    getShareableLink: jest.fn(() => null),
+  })),
+}));
+
+jest.mock('@/lib/hooks/useVisualViewport', () => ({
+  useVisualViewport: jest.fn(() => ({
+    top: 0,
+    height: 0,
+  })),
+}));
+
+jest.mock('@/app/components/live-typing/LiveTypingBottomSheet', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/app/components/typing-tabs/MobileTabList', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { whileTap?: unknown }) => {
+      const buttonProps = { ...props };
+      delete buttonProps.whileTap;
+      return <button {...buttonProps}>{children}</button>;
+    },
+  },
+}));
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('TypingDock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorageMock.clear();
+  });
+
+  it('restores the active tab draft into the parent text state on mount', async () => {
+    localStorageMock.setItem('typingTabs', JSON.stringify({
+      tabs: [
+        {
+          id: 'stored-tab-1',
+          label: 'Stored Draft',
+          text: 'Restored mobile draft',
+          createdAt: Date.now(),
+          lastModified: Date.now(),
+          isCustomLabel: false,
+        },
+      ],
+      activeTabId: 'stored-tab-1',
+      nextTabNumber: 2,
+    }));
+
+    const onChange = jest.fn();
+    render(
+      <TypingDock
+        text=""
+        onChange={onChange}
+        onSpeak={jest.fn()}
+        enableTabs={true}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('Restored mobile draft');
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('Restored mobile draft');
+    });
+  });
+
+  it('speaks the restored draft after mount when the parent adopts it', async () => {
+    localStorageMock.setItem('typingTabs', JSON.stringify({
+      tabs: [
+        {
+          id: 'stored-tab-1',
+          label: 'Stored Draft',
+          text: 'Restored mobile draft',
+          createdAt: Date.now(),
+          lastModified: Date.now(),
+          isCustomLabel: false,
+        },
+      ],
+      activeTabId: 'stored-tab-1',
+      nextTabNumber: 2,
+    }));
+
+    const user = userEvent.setup();
+    const onSpeak = jest.fn();
+
+    function Harness() {
+      const [text, setText] = React.useState('');
+
+      return (
+        <TypingDock
+          text={text}
+          onChange={setText}
+          onSpeak={onSpeak}
+          enableTabs={true}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('Restored mobile draft');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Speak' }));
+
+    expect(onSpeak).toHaveBeenCalledWith('speak');
+  });
+});

--- a/tests/components/typing-tabs/useTypingTabs.test.ts
+++ b/tests/components/typing-tabs/useTypingTabs.test.ts
@@ -92,7 +92,7 @@ describe('useTypingTabs', () => {
           {
             id: 'stored-tab-1',
             label: 'Stored Tab',
-            text: '', // Use empty text to avoid auto-creation
+            text: 'Restored draft',
             createdAt: Date.now(),
             lastModified: Date.now(),
             isCustomLabel: false,
@@ -107,8 +107,33 @@ describe('useTypingTabs', () => {
 
       expect(result.current.tabs).toHaveLength(1);
       expect(result.current.tabs[0].id).toBe('stored-tab-1');
+      expect(result.current.tabs[0].text).toBe('Restored draft');
       expect(result.current.tabs[0].label).toBe('Stored Tab');
       expect(result.current.activeTabId).toBe('stored-tab-1');
+    });
+
+    it('does not auto-create a new tab when restoring non-empty stored content', () => {
+      const storedState = {
+        tabs: [
+          {
+            id: 'stored-tab-1',
+            label: 'Stored Tab',
+            text: 'Restored draft',
+            createdAt: Date.now(),
+            lastModified: Date.now(),
+            isCustomLabel: false,
+          },
+        ],
+        activeTabId: 'stored-tab-1',
+        nextTabNumber: 2,
+      };
+      localStorageMock.setItem('typingTabs', JSON.stringify(storedState));
+
+      const { result } = renderHook(() => useTypingTabs());
+
+      expect(result.current.tabs).toHaveLength(1);
+      expect(result.current.activeTabId).toBe('stored-tab-1');
+      expect(result.current.activeTab.text).toBe('Restored draft');
     });
 
     it('migrates tabs without isCustomLabel field', () => {

--- a/tests/lib/hooks/useLocalMessageHistory.test.ts
+++ b/tests/lib/hooks/useLocalMessageHistory.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react';
+import { useLocalMessageHistory } from '@/lib/hooks/useLocalMessageHistory';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('useLocalMessageHistory', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    jest.clearAllMocks();
+  });
+
+  it('records recent messages to localStorage', () => {
+    const { result } = renderHook(() => useLocalMessageHistory());
+
+    act(() => {
+      result.current.recordMessage({
+        text: 'Need water',
+        source: 'speak',
+      });
+    });
+
+    expect(result.current.messages[0].text).toBe('Need water');
+
+    const stored = localStorageMock.getItem('localTypingHistory');
+    expect(stored).toContain('Need water');
+  });
+
+  it('moves duplicate messages to the front instead of duplicating them', () => {
+    const { result } = renderHook(() => useLocalMessageHistory());
+
+    act(() => {
+      result.current.recordMessage({
+        text: 'Need water',
+        source: 'speak',
+      });
+      result.current.recordMessage({
+        text: 'Need help',
+        source: 'speak',
+      });
+      result.current.recordMessage({
+        text: 'Need water',
+        source: 'clear',
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0].text).toBe('Need water');
+  });
+});


### PR DESCRIPTION
## Summary\n- fix draft/tab restore so persisted typing state is not overwritten on startup\n- add device-local recent message history for offline typing flows\n- document the localStorage persistence approach and add regression coverage\n\nCloses #319\n\n## Verification\n- npm.cmd test -- --runInBand\n- npm.cmd run lint\n- npm.cmd run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added local device message history—recent messages are automatically saved and persist across app sessions for quick recall
  * Introduced "Recent on this device" panel displaying up to 5 saved messages as quick-restore buttons for faster typing

* **Improvements**
  * Enhanced text synchronization and tab restoration from saved drafts
  * Improved handling of empty and whitespace text scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->