### PR TITLE
Add explicit offline fallbacks for network-only features

### DIFF
--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTTS } from '@/lib/hooks/useTTS';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { TTSVoice, TTSProviderType } from '@/lib/tts-provider';
 import { useSettings } from '../contexts/SettingsContext';
 import { Dropdown } from '@/app/components/ui/Dropdown';
@@ -30,6 +31,7 @@ export default function TTSSettings() {
   } = useTTS();
 
   const router = useRouter();
+  const { isOnline } = useOnlineStatus();
 
   const [providerVoices, setProviderVoices] = useState<ExtendedTTSVoice[]>([]);
   const [isPlayingPreview, setIsPlayingPreview] = useState(false);
@@ -56,14 +58,14 @@ export default function TTSSettings() {
 
   // Safe provider change
   const handleProviderChange = useCallback((newProvider: TTSProviderType) => {
-    if (newProvider === 'elevenlabs' && !status.elevenLabsAvailable) {
+    if (newProvider === 'elevenlabs' && (!status.elevenLabsAvailable || !isOnline)) {
       return;
     }
 
     if (settings.ttsProvider !== newProvider) {
       updateSetting('ttsProvider', newProvider);
     }
-  }, [settings.ttsProvider, status.elevenLabsAvailable, updateSetting]);
+  }, [isOnline, settings.ttsProvider, status.elevenLabsAvailable, updateSetting]);
 
   // Preview voice function
   const previewVoice = useCallback(() => {
@@ -75,7 +77,7 @@ export default function TTSSettings() {
 
     setIsPlayingPreview(true);
 
-    if (settings.ttsProvider === 'elevenlabs') {
+    if (settings.ttsProvider === 'elevenlabs' && isOnline) {
       const voice = providerVoices.find(v => v.id === settings.ttsVoiceId) as ExtendedTTSVoice;
 
       if (voice?.metadata?.preview_url) {
@@ -90,7 +92,7 @@ export default function TTSSettings() {
       speak(SAMPLE_TEXT);
       setTimeout(() => setIsPlayingPreview(false), 5000);
     }
-  }, [speak, stop, isSpeaking, settings.ttsProvider, settings.ttsVoiceId, providerVoices]);
+  }, [isOnline, speak, stop, isSpeaking, settings.ttsProvider, settings.ttsVoiceId, providerVoices]);
 
   // Get selected voice name for display
   const selectedVoiceName = providerVoices.find(v => v.id === settings.ttsVoiceId)?.name;
@@ -175,9 +177,9 @@ export default function TTSSettings() {
           <button
             type="button"
             onClick={() => handleProviderChange('elevenlabs')}
-            disabled={!status.elevenLabsAvailable}
+            disabled={!status.elevenLabsAvailable || !isOnline}
             className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
-              !status.elevenLabsAvailable
+              !status.elevenLabsAvailable || !isOnline
                 ? 'opacity-50 cursor-not-allowed border-border bg-surface'
                 : settings.ttsProvider === 'elevenlabs'
                   ? 'border-primary-500 bg-primary-900'
@@ -225,7 +227,13 @@ export default function TTSSettings() {
           </p>
         )}
 
-        {!status.elevenLabsAvailable && (
+        {!isOnline && (
+          <p className="text-xs text-amber-500 px-1">
+            Offline. Browser TTS still works, but ElevenLabs voices need internet.
+          </p>
+        )}
+
+        {!status.elevenLabsAvailable && isOnline && (
           <p className="text-xs text-text-tertiary px-1">
             ElevenLabs unavailable. API key not configured.
           </p>

--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -9,6 +9,7 @@ import SubscriptionWrapper from './SubscriptionWrapper';
 import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import LiveTypingLinkModal from './live-typing/LiveTypingLinkModal';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import TabBar from './typing-tabs/TabBar';
@@ -51,6 +52,7 @@ export default function TypingArea({
   const hasInitializedActiveTabRef = useRef(false);
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
+  const { isOnline } = useOnlineStatus();
   const { speak, stop, isSpeaking, isAvailable } = tts;
   const {
     isSharing,
@@ -81,6 +83,7 @@ export default function TypingArea({
   } = useTypingTabs(initialText);
 
   const text = activeTab.text;
+  const showOfflineCloudNotice = !isOnline && (enableFixText || (enableLiveTyping && !!user));
 
   // Sync external text prop with active tab
   useEffect(() => {
@@ -166,6 +169,11 @@ export default function TypingArea({
   }, [text, isSharing, updateContent]);
 
   const handleShare = async () => {
+    if (!isOnline) {
+      setError('Live Typing requires an internet connection.');
+      return;
+    }
+
     if (isSharing) {
       setShowLiveTypingModal(true);
       return;
@@ -246,6 +254,10 @@ export default function TypingArea({
 
   const handleFixText = async () => {
     if (!text.trim() || isFixingText) return;
+    if (!isOnline) {
+      setError('Fix Text requires an internet connection.');
+      return;
+    }
 
     setIsFixingText(true);
     setError(null);
@@ -424,43 +436,56 @@ export default function TypingArea({
                 )}
               </button>
               {enableFixText && (
-                <SubscriptionWrapper
-                  fallback={
-                    <button
-                      onClick={() => window.location.href = '/pricing'}
-                      className="flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 bg-surface hover:bg-status-warning text-foreground hover:text-amber-500"
-                      data-tooltip-id="fix-text-tooltip"
-                      data-tooltip-content="Fix Text (Pro feature)"
-                    >
-                      <SparklesIcon className="w-5 h-5" />
-                      <span>Fix Text</span>
-                    </button>
-                  }
-                >
+                !isOnline ? (
                   <button
-                    onClick={handleFixText}
-                    className={`flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 ${
-                      isFixingText
-                        ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
-                        : 'bg-surface hover:bg-status-purple text-foreground hover:text-purple-500'
-                    }`}
+                    type="button"
+                    disabled={true}
+                    className="flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md bg-surface text-text-tertiary opacity-60 cursor-not-allowed"
                     data-tooltip-id="fix-text-tooltip"
-                    data-tooltip-content="Fix grammar and spelling"
-                    disabled={!text.trim() || isFixingText}
+                    data-tooltip-content="Fix Text requires internet"
                   >
-                    {isFixingText ? (
-                      <>
-                        <ArrowPathIcon className="w-5 h-5 animate-spin" />
-                        <span>Fixing...</span>
-                      </>
-                    ) : (
-                      <>
+                    <SparklesIcon className="w-5 h-5" />
+                    <span>Fix Text</span>
+                  </button>
+                ) : (
+                  <SubscriptionWrapper
+                    fallback={
+                      <button
+                        onClick={() => window.location.href = '/pricing'}
+                        className="flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 bg-surface hover:bg-status-warning text-foreground hover:text-amber-500"
+                        data-tooltip-id="fix-text-tooltip"
+                        data-tooltip-content="Fix Text (Pro feature)"
+                      >
                         <SparklesIcon className="w-5 h-5" />
                         <span>Fix Text</span>
-                      </>
-                    )}
-                  </button>
-                </SubscriptionWrapper>
+                      </button>
+                    }
+                  >
+                    <button
+                      onClick={handleFixText}
+                      className={`flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 ${
+                        isFixingText
+                          ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
+                          : 'bg-surface hover:bg-status-purple text-foreground hover:text-purple-500'
+                      }`}
+                      data-tooltip-id="fix-text-tooltip"
+                      data-tooltip-content="Fix grammar and spelling"
+                      disabled={!text.trim() || isFixingText}
+                    >
+                      {isFixingText ? (
+                        <>
+                          <ArrowPathIcon className="w-5 h-5 animate-spin" />
+                          <span>Fixing...</span>
+                        </>
+                      ) : (
+                        <>
+                          <SparklesIcon className="w-5 h-5" />
+                          <span>Fix Text</span>
+                        </>
+                      )}
+                    </button>
+                  </SubscriptionWrapper>
+                )
               )}
               <button
                 onClick={() => handleClear('clear')}
@@ -478,13 +503,19 @@ export default function TypingArea({
               <button
                 onClick={handleShare}
                 className={`w-full h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 ${
-                  isSharing
-                    ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
-                    : 'bg-surface hover:bg-status-success text-foreground hover:text-green-500'
+                  !isOnline
+                    ? 'bg-surface text-text-tertiary'
+                    : isSharing
+                      ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
+                      : 'bg-surface hover:bg-status-success text-foreground hover:text-green-500'
                 }`}
-                data-tooltip-id="live-typing-tooltip"
-                data-tooltip-content={isSharing ? 'View live typing link' : 'Start live typing'}
-                disabled={isCreating}
+                data-tooltip-id={isOnline ? 'live-typing-tooltip' : 'offline-live-typing-tooltip'}
+                data-tooltip-content={
+                  isOnline
+                    ? (isSharing ? 'View live typing link' : 'Start live typing')
+                    : 'Live Typing requires internet'
+                }
+                disabled={isCreating || !isOnline}
               >
                 {isCreating ? (
                   <>
@@ -498,6 +529,13 @@ export default function TypingArea({
                   </>
                 )}
               </button>
+            </div>
+          )}
+          {showOfflineCloudNotice && (
+            <div className="px-4 pb-4 bg-surface-hover">
+              <p className="text-xs text-amber-500">
+                Offline: browser speech still works, but Fix Text and Live Typing require internet.
+              </p>
             </div>
           )}
         </div>
@@ -540,6 +578,7 @@ export default function TypingArea({
       <Tooltip id="expand-tooltip" />
       <Tooltip id="toggle-tooltip" />
       <Tooltip id="live-typing-tooltip" />
+      <Tooltip id="offline-live-typing-tooltip" />
 
       {showLiveTypingModal && shareableLink && (
         <LiveTypingLinkModal

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -19,6 +19,7 @@ import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import ReplySuggestions from './typing/ReplySuggestions';
 import SubscriptionWrapper from './SubscriptionWrapper';
@@ -78,6 +79,7 @@ export default function TypingDock({
   const hasInitializedActiveTabRef = useRef(false);
   const { settings, uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
+  const { isOnline } = useOnlineStatus();
 
   // Get current mode from settings
   const dockMode = uiPreferences.typingDockMode;
@@ -178,6 +180,7 @@ export default function TypingDock({
   // Text size from settings (now a number in px)
   const textSizePx = settings.textSize;
   const currentText = enableTabs ? activeTab.text : text;
+  const showOfflineCloudNotice = !isOnline && (enableFixText || (enableLiveTyping && !!user) || !!replySuggestions?.enabled);
 
   const showUndoHint = canUndo
     && entry?.tabId === (activeTabId || 'default')
@@ -299,6 +302,10 @@ export default function TypingDock({
   // Fix Text handler
   const handleFixText = async () => {
     if (!currentText.trim() || isFixingText) return;
+    if (!isOnline) {
+      setError('Fix Text requires an internet connection.');
+      return;
+    }
 
     setIsFixingText(true);
     setError(null);
@@ -526,46 +533,65 @@ export default function TypingDock({
                 variant="inline"
               />
             )}
+            {showOfflineCloudNotice && (
+              <div className="px-1">
+                <span className="text-xs text-amber-500">
+                  Offline: browser speech still works, but AI tools and Live Typing need internet.
+                </span>
+              </div>
+            )}
 
             {/* Row 1: AI Features (when text exists) */}
             {currentText.trim() && enableFixText && (
               <div className="flex items-center gap-2">
                 {/* Fix Text button (Pro) */}
-                <SubscriptionWrapper
-                  fallback={
-                    <button
-                      onClick={() => window.location.href = '/pricing'}
-                      className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-warning text-text-secondary hover:text-amber-500 transition-all duration-200"
-                      aria-label="Fix Text (Pro)"
-                    >
-                      <SparklesIcon className="w-4 h-4" />
-                      <span className="text-sm font-medium">Fix Text</span>
-                    </button>
-                  }
-                >
+                {!isOnline ? (
                   <button
-                    onClick={handleFixText}
-                    disabled={!currentText.trim() || isFixingText}
-                    className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed ${
-                      isFixingText
-                        ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
-                        : 'bg-surface-hover hover:bg-status-purple text-text-secondary hover:text-purple-500'
-                    }`}
+                    type="button"
+                    disabled={true}
+                    className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover text-text-tertiary transition-all duration-200 opacity-60 cursor-not-allowed"
                     aria-label="Fix Text"
                   >
-                    {isFixingText ? (
-                      <>
-                        <ArrowPathIcon className="w-4 h-4 animate-spin" />
-                        <span className="text-sm font-medium">Fixing...</span>
-                      </>
-                    ) : (
-                      <>
+                    <SparklesIcon className="w-4 h-4" />
+                    <span className="text-sm font-medium">Fix Text</span>
+                  </button>
+                ) : (
+                  <SubscriptionWrapper
+                    fallback={
+                      <button
+                        onClick={() => window.location.href = '/pricing'}
+                        className="flex items-center gap-1.5 px-3 py-2 rounded-full bg-surface-hover hover:bg-status-warning text-text-secondary hover:text-amber-500 transition-all duration-200"
+                        aria-label="Fix Text (Pro)"
+                      >
                         <SparklesIcon className="w-4 h-4" />
                         <span className="text-sm font-medium">Fix Text</span>
-                      </>
-                    )}
-                  </button>
-                </SubscriptionWrapper>
+                      </button>
+                    }
+                  >
+                    <button
+                      onClick={handleFixText}
+                      disabled={!currentText.trim() || isFixingText}
+                      className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed ${
+                        isFixingText
+                          ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white'
+                          : 'bg-surface-hover hover:bg-status-purple text-text-secondary hover:text-purple-500'
+                      }`}
+                      aria-label="Fix Text"
+                    >
+                      {isFixingText ? (
+                        <>
+                          <ArrowPathIcon className="w-4 h-4 animate-spin" />
+                          <span className="text-sm font-medium">Fixing...</span>
+                        </>
+                      ) : (
+                        <>
+                          <SparklesIcon className="w-4 h-4" />
+                          <span className="text-sm font-medium">Fix Text</span>
+                        </>
+                      )}
+                    </button>
+                  </SubscriptionWrapper>
+                )}
               </div>
             )}
 
@@ -587,11 +613,14 @@ export default function TypingDock({
                 <button
                   onClick={() => setShowLiveTypingSheet(true)}
                   className={`flex items-center gap-1.5 px-3 py-2 rounded-full transition-all duration-200 ${
-                    isSharing
-                      ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
-                      : 'bg-surface-hover hover:bg-status-success text-text-secondary hover:text-green-500'
+                    !isOnline
+                      ? 'bg-surface-hover text-text-tertiary'
+                      : isSharing
+                        ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
+                        : 'bg-surface-hover hover:bg-status-success text-text-secondary hover:text-green-500'
                   }`}
                   aria-label="Live Typing"
+                  disabled={!isOnline}
                 >
                   <ShareIcon className="w-4 h-4" />
                   <span className="text-sm font-medium">

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -18,6 +18,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import AnimatedLoading from '../phrases/AnimatedLoading';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useLocalMessageHistory } from '@/lib/hooks/useLocalMessageHistory';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import ReplySuggestions from '../typing/ReplySuggestions';
 
 export default function PhrasesInterface() {
@@ -25,6 +26,7 @@ export default function PhrasesInterface() {
   const tts = useTTS();
   const { user, loading: authLoading } = useAuth();
   const { settings, uiPreferences, updateUIPreference } = useSettings();
+  const { isOnline } = useOnlineStatus();
   const [typingText, setTypingText] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
   const [captureError, setCaptureError] = useState(false);
@@ -59,6 +61,7 @@ export default function PhrasesInterface() {
   );
 
   const loading = authLoading || (shouldLoadBoards && boards === undefined);
+  const showOfflineBoardsState = !isOnline && shouldLoadBoards && boards === undefined;
 
   // Auto-select first board on load or use saved board
   useEffect(() => {
@@ -95,6 +98,10 @@ export default function PhrasesInterface() {
   };
 
   const handleAddPhrase = async () => {
+    if (!isOnline) {
+      return;
+    }
+
     if (!selectedBoardId) {
       console.error('Cannot add phrase: no board selected');
       return;
@@ -103,6 +110,10 @@ export default function PhrasesInterface() {
   };
 
   const handleAddTypingAsPhrase = async () => {
+    if (!isOnline) {
+      return;
+    }
+
     if (!selectedBoardId || !typingText.trim()) {
       console.error('Cannot add phrase: no board selected or empty text');
       return;
@@ -133,11 +144,13 @@ export default function PhrasesInterface() {
   };
 
   const handleEditPhrase = (phrase: PhraseSummary) => {
+    if (!isOnline) return;
     if (!selectedBoardId) return;
     router.push(`/phrases/edit/${phrase.id}?boardId=${selectedBoardId}`);
   };
 
   const handleAddBoard = () => {
+    if (!isOnline) return;
     router.push('/phrases/boards/add');
   };
 
@@ -322,6 +335,18 @@ export default function PhrasesInterface() {
             <p className="text-text-secondary mb-6">Your saved boards appear after logging in.</p>
           </div>
         </div>
+      ) : showOfflineBoardsState ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="max-w-md text-center">
+            <h2 className="text-xl font-medium text-foreground mb-4">Boards need internet</h2>
+            <p className="text-text-secondary mb-2">
+              Text communication and browser speech are still available, but saved boards and cloud updates are unavailable while offline.
+            </p>
+            <p className="text-sm text-amber-500">
+              Reconnect to load boards, edit phrases, and sync changes.
+            </p>
+          </div>
+        </div>
       ) : loading ? (
         <div className="flex-1 flex items-center justify-center">
           <AnimatedLoading />
@@ -342,8 +367,8 @@ export default function PhrasesInterface() {
               currentBoardIndex={validBoardIndex}
               onBoardChange={handleBoardIndexChange}
               onOpenBoardPicker={() => setIsBoardPickerOpen(true)}
-              onAddBoard={handleAddBoard}
-              onAddPhrase={handleAddPhrase}
+              onAddBoard={isOnline ? handleAddBoard : undefined}
+              onAddPhrase={isOnline ? handleAddPhrase : undefined}
               onEdit={handleEdit}
               isEditMode={isEditMode}
               canEditBoard={canEditCurrentBoard}
@@ -360,14 +385,14 @@ export default function PhrasesInterface() {
                       className="aspect-square"
                     />
                   ))}
-                  {typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
+                  {isOnline && typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
                     <ActionTile
                       text="+ Add as Phrase"
                       onClick={handleAddTypingAsPhrase}
                       className="aspect-square"
                     />
                   )}
-                  {isEditMode && canEditCurrentBoard && (
+                  {isOnline && isEditMode && canEditCurrentBoard && (
                     <ActionTile
                       text="+ Add Phrase"
                       onClick={handleAddPhrase}
@@ -386,9 +411,12 @@ export default function PhrasesInterface() {
                   selectedBoard={selectedBoard}
                   isEditMode={isEditMode}
                   onSelectBoard={handleSelectBoard}
-                  onEditBoard={(boardId) => router.push(`/phrases/boards/edit/${boardId}`)}
-                  onAddBoard={handleAddBoard}
-                  onAddPhrase={handleAddPhrase}
+                  onEditBoard={(boardId) => {
+                    if (!isOnline) return;
+                    router.push(`/phrases/boards/edit/${boardId}`);
+                  }}
+                  onAddBoard={isOnline ? handleAddBoard : undefined}
+                  onAddPhrase={isOnline ? handleAddPhrase : undefined}
                   onEdit={handleEdit}
                 />
               </div>
@@ -408,14 +436,14 @@ export default function PhrasesInterface() {
                             className="aspect-square"
                           />
                         ))}
-                        {typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
+                        {isOnline && typingText.trim() && canEditCurrentBoard && !phrases.some(p => p.text === typingText.trim()) && (
                           <ActionTile
                             text="+ Add as Phrase"
                             onClick={handleAddTypingAsPhrase}
                             className="aspect-square"
                           />
                         )}
-                        {isEditMode && canEditCurrentBoard && (
+                        {isOnline && isEditMode && canEditCurrentBoard && (
                           <ActionTile
                             text="+ Add Phrase"
                             onClick={handleAddPhrase}
@@ -439,7 +467,10 @@ export default function PhrasesInterface() {
         isOpen={isBoardPickerOpen}
         onClose={() => setIsBoardPickerOpen(false)}
         onSelectBoard={handleSelectBoard}
-        onEditBoard={(boardId) => router.push(`/phrases/boards/edit/${boardId}`)}
+        onEditBoard={(boardId) => {
+          if (!isOnline) return;
+          router.push(`/phrases/boards/edit/${boardId}`);
+        }}
       />
       {/* Mobile: TypingDock portaled into bottom stack */}
       {isMobile && (
@@ -465,6 +496,11 @@ export default function PhrasesInterface() {
           />
           {captureError && settings.aiReplySuggestionsEnabled && (
             <p className="px-3 pb-2 text-xs text-amber-500">Message history capture is temporarily unavailable.</p>
+          )}
+          {!isOnline && user && (
+            <p className="px-3 pb-2 text-xs text-amber-500">
+              Offline: boards, reply suggestions, and cloud sync will reconnect automatically when internet returns.
+            </p>
           )}
         </MobileDockPortal>
       )}

--- a/app/components/navigation/ConnectivityBanner.tsx
+++ b/app/components/navigation/ConnectivityBanner.tsx
@@ -48,7 +48,7 @@ export default function ConnectivityBanner() {
         )}
         <p>
           {isOfflineBanner
-            ? 'You are offline. Text communication and browser speech still work, but boards, AI tools, and cloud sync may be unavailable.'
+            ? 'You are offline. Text communication and browser speech still work, but boards, Fix Text, reply suggestions, Live Typing, ElevenLabs, and cloud sync are unavailable.'
             : 'Connection restored. Online features are available again.'}
         </p>
       </div>

--- a/app/components/typing/ReplySuggestions.tsx
+++ b/app/components/typing/ReplySuggestions.tsx
@@ -4,6 +4,7 @@ import { ArrowPathIcon, SparklesIcon } from '@heroicons/react/24/outline';
 import { useReplySuggestions } from '@/lib/hooks/useReplySuggestions';
 import { useSubscription } from '@/app/hooks/useSubscription';
 import { useAuth } from '@/app/contexts/AuthContext';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { MIN_HISTORY_ENTRIES } from '@/lib/reply-suggestions-constants';
 
 interface ReplySuggestionsProps {
@@ -25,6 +26,7 @@ export default function ReplySuggestions({
 }: ReplySuggestionsProps) {
   const { user, loading: authLoading } = useAuth();
   const { isActive: hasSubscription, loading: subscriptionLoading } = useSubscription();
+  const { isOnline } = useOnlineStatus();
   const {
     suggestions,
     isLoading,
@@ -32,11 +34,33 @@ export default function ReplySuggestions({
     refresh,
   } = useReplySuggestions({
     history,
-    enabled: enabled && !authLoading && !!user && hasSubscription,
+    enabled: enabled && isOnline && !authLoading && !!user && hasSubscription,
   });
 
   if (authLoading || subscriptionLoading || !enabled || !user || !hasSubscription) {
     return null;
+  }
+
+  if (!isOnline) {
+    if (variant === 'inline') {
+      return (
+        <p className={`text-xs text-amber-500 ${className}`}>
+          Reply suggestions require internet and will return when you reconnect.
+        </p>
+      );
+    }
+
+    return (
+      <div className={`rounded-2xl border border-border bg-surface px-3 py-2.5 shadow-sm ${className}`}>
+        <div className="mb-1 flex items-center gap-1.5">
+          <SparklesIcon className="h-4 w-4 text-primary-500" />
+          <p className="text-xs font-semibold text-foreground">Reply suggestions</p>
+        </div>
+        <p className="text-sm text-amber-500">
+          Reply suggestions require internet and will return when you reconnect.
+        </p>
+      </div>
+    );
   }
 
   const hasEnoughHistory = history.length >= MIN_HISTORY_ENTRIES;

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -58,8 +58,8 @@ export default function SupportPage() {
               <h3 className="text-lg font-semibold text-foreground mb-2">Can I use SayIt! offline?</h3>
               <p className="text-text-secondary">
                 Yes. If you install SayIt! as a PWA, the app shell can open offline and you can continue typing
-                and using browser text-to-speech. Saved boards, AI features, account management, and cloud sync
-                still require an internet connection.
+                and using browser text-to-speech. Saved boards, Fix Text, reply suggestions, Live Typing,
+                ElevenLabs voices, account management, and cloud sync still require an internet connection.
               </p>
             </div>
 

--- a/tests/components/TypingArea.test.tsx
+++ b/tests/components/TypingArea.test.tsx
@@ -56,6 +56,14 @@ jest.mock('@/lib/hooks/useLiveTyping', () => ({
   })),
 }));
 
+jest.mock('@/lib/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: jest.fn(() => ({
+    isOnline: true,
+    wasOffline: false,
+    clearRecoveredState: jest.fn(),
+  })),
+}));
+
 const mockTTS = {
   speak: jest.fn(),
   stop: jest.fn(),

--- a/tests/components/TypingDock.test.tsx
+++ b/tests/components/TypingDock.test.tsx
@@ -57,6 +57,14 @@ jest.mock('@/lib/hooks/useVisualViewport', () => ({
   })),
 }));
 
+jest.mock('@/lib/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: jest.fn(() => ({
+    isOnline: true,
+    wasOffline: false,
+    clearRecoveredState: jest.fn(),
+  })),
+}));
+
 jest.mock('@/app/components/live-typing/LiveTypingBottomSheet', () => ({
   __esModule: true,
   default: () => null,

--- a/tests/components/typing/ReplySuggestions.test.tsx
+++ b/tests/components/typing/ReplySuggestions.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReplySuggestions from '@/app/components/typing/ReplySuggestions';
+
+const mockUseOnlineStatus = jest.fn();
+
+jest.mock('@/app/contexts/AuthContext', () => ({
+  useAuth: jest.fn(() => ({
+    user: { id: 'user-1' },
+    loading: false,
+  })),
+}));
+
+jest.mock('@/app/hooks/useSubscription', () => ({
+  useSubscription: jest.fn(() => ({
+    isActive: true,
+    loading: false,
+  })),
+}));
+
+jest.mock('@/lib/hooks/useReplySuggestions', () => ({
+  useReplySuggestions: jest.fn(() => ({
+    suggestions: [],
+    isLoading: false,
+    error: null,
+    refresh: jest.fn(),
+  })),
+}));
+
+jest.mock('@/lib/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => mockUseOnlineStatus(),
+}));
+
+describe('ReplySuggestions', () => {
+  beforeEach(() => {
+    mockUseOnlineStatus.mockReturnValue({
+      isOnline: true,
+      wasOffline: false,
+      clearRecoveredState: jest.fn(),
+    });
+  });
+
+  it('shows an explicit offline message instead of hiding suggestions state', () => {
+    mockUseOnlineStatus.mockReturnValue({
+      isOnline: false,
+      wasOffline: false,
+      clearRecoveredState: jest.fn(),
+    });
+
+    render(
+      <ReplySuggestions
+        history={['One', 'Two', 'Three']}
+        enabled={true}
+        onSelectSuggestion={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/Reply suggestions require internet and will return when you reconnect/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary\n- disable or message online-only typing features when the app is offline\n- show explicit offline states for reply suggestions, boards, and ElevenLabs settings\n- update product copy and regression tests around offline behavior\n\nCloses #322\n\n## Verification\n- npm.cmd test -- --runInBand\n- npm.cmd run lint\n- npm.cmd run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * App now detects your online/offline status and automatically disables internet-dependent features when offline
  * Added clear messaging indicating which features require an internet connection to function
  * Offline features reconnect automatically when connectivity is restored

* **Documentation**
  * Updated support resources to clarify which features require internet access

* **Tests**
  * Added test coverage for offline state handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->