### PR TITLE
Add custom PWA install banner

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -9,6 +9,7 @@ import { AuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { MobileBottomProvider } from './contexts/MobileBottomContext';
 import ConnectivityBanner from './components/navigation/ConnectivityBanner';
+import InstallBanner from './components/navigation/InstallBanner';
 import Sidebar from './components/Sidebar';
 import MobileBottomStack from './components/navigation/MobileBottomStack';
 
@@ -55,6 +56,7 @@ export default function ClientLayout({
                 {/* Main content area */}
                 <div className="flex-1 md:pl-16 lg:pl-16">
                   <ConnectivityBanner />
+                  <InstallBanner />
                   <main className="min-h-dvh pb-32 md:pb-0">
                     {children}
                   </main>

--- a/app/components/navigation/InstallBanner.tsx
+++ b/app/components/navigation/InstallBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { ArrowDownTrayIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useInstallPrompt } from '@/lib/hooks/useInstallPrompt';
+
+export default function InstallBanner() {
+  const { mode, isVisible, dismiss, promptInstall } = useInstallPrompt();
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const isIOS = mode === 'ios';
+
+  return (
+    <div
+      className="sticky top-0 z-30 border-b border-primary-900 bg-primary-500/10 px-4 py-3 text-sm text-primary-100"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="mx-auto flex max-w-4xl items-start gap-3">
+        <ArrowDownTrayIcon className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-foreground">
+            Install SayIt! for faster offline access.
+          </p>
+          <p className="mt-1 text-xs text-text-secondary">
+            {isIOS
+              ? 'On iPhone or iPad, tap Share and choose Add to Home Screen.'
+              : 'Install the app to open it from your home screen and keep text communication close at hand.'}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {!isIOS && (
+            <button
+              type="button"
+              onClick={() => void promptInstall()}
+              className="rounded-full bg-primary-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-primary-600"
+            >
+              Install
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={dismiss}
+            className="rounded-full p-1.5 text-text-secondary transition-colors hover:bg-surface hover:text-foreground"
+            aria-label="Dismiss install banner"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/hooks/useInstallPrompt.ts
+++ b/lib/hooks/useInstallPrompt.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'pwaInstallBannerDismissed';
+
+declare global {
+  interface Navigator {
+    standalone?: boolean;
+  }
+}
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+}
+
+function isStandaloneMode() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+}
+
+function isIOSDevice() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /iPad|iPhone|iPod/.test(navigator.userAgent);
+}
+
+export function useInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isInstalled, setIsInstalled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    setIsDismissed(window.localStorage.getItem(STORAGE_KEY) === 'true');
+    setIsInstalled(isStandaloneMode());
+
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      const promptEvent = event as BeforeInstallPromptEvent;
+      promptEvent.preventDefault();
+      setDeferredPrompt(promptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      setDeferredPrompt(null);
+      setIsInstalled(true);
+      window.localStorage.setItem(STORAGE_KEY, 'true');
+      setIsDismissed(true);
+    };
+
+    const handleDisplayModeChange = () => {
+      setIsInstalled(isStandaloneMode());
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+    mediaQuery.addEventListener('change', handleDisplayModeChange);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+      mediaQuery.removeEventListener('change', handleDisplayModeChange);
+    };
+  }, []);
+
+  const dismiss = () => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, 'true');
+    }
+    setIsDismissed(true);
+    setDeferredPrompt(null);
+  };
+
+  const promptInstall = async () => {
+    if (!deferredPrompt) {
+      return null;
+    }
+
+    await deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+
+    if (choice.outcome === 'accepted') {
+      setIsInstalled(true);
+    } else {
+      setIsDismissed(true);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, 'true');
+      }
+    }
+
+    setDeferredPrompt(null);
+    return choice;
+  };
+
+  const mode = useMemo(() => {
+    if (isInstalled || isDismissed) {
+      return 'hidden' as const;
+    }
+
+    if (deferredPrompt) {
+      return 'prompt' as const;
+    }
+
+    if (isIOSDevice()) {
+      return 'ios' as const;
+    }
+
+    return 'hidden' as const;
+  }, [deferredPrompt, isDismissed, isInstalled]);
+
+  return {
+    mode,
+    dismiss,
+    promptInstall,
+    isVisible: mode !== 'hidden',
+  };
+}

--- a/tests/components/navigation/InstallBanner.test.tsx
+++ b/tests/components/navigation/InstallBanner.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import InstallBanner from '@/app/components/navigation/InstallBanner';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('InstallBanner', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    jest.clearAllMocks();
+    Object.defineProperty(window.navigator, 'standalone', {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(window.navigator, 'userAgent', {
+      configurable: true,
+      value: originalUserAgent,
+    });
+    (window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+  });
+
+  it('shows a custom install banner when beforeinstallprompt fires', async () => {
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const userChoice = Promise.resolve({ outcome: 'accepted', platform: 'web' });
+
+    render(<InstallBanner />);
+
+    const event = new Event('beforeinstallprompt') as Event & {
+      prompt: typeof prompt;
+      userChoice: typeof userChoice;
+      preventDefault: jest.Mock;
+    };
+    event.prompt = prompt;
+    event.userChoice = userChoice;
+    event.preventDefault = jest.fn();
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    expect(screen.getByText(/Install SayIt! for faster offline access/i)).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+      await userChoice;
+    });
+
+    expect(prompt).toHaveBeenCalled();
+  });
+
+  it('shows iOS guidance when install prompt is unavailable', () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+    });
+
+    render(<InstallBanner />);
+
+    expect(
+      screen.getByText(/tap Share and choose Add to Home Screen/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Install' })).not.toBeInTheDocument();
+  });
+
+  it('does not render when already installed in standalone mode', () => {
+    (window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+      matches: query === '(display-mode: standalone)',
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    render(<InstallBanner />);
+
+    expect(screen.queryByText(/Install SayIt!/i)).not.toBeInTheDocument();
+  });
+
+  it('stays hidden after explicit dismissal', () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+    });
+
+    const { rerender } = render(<InstallBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Dismiss install banner/i }));
+
+    rerender(<InstallBanner />);
+
+    expect(screen.queryByText(/Install SayIt!/i)).not.toBeInTheDocument();
+    expect(localStorageMock.getItem('pwaInstallBannerDismissed')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary\n- add a global custom install banner powered by the deferred eforeinstallprompt event\n- show Add to Home Screen guidance on iOS where the browser prompt is unavailable\n- hide the banner once dismissed or when the app is already installed, with regression tests\n\nCloses #329\n\n## Verification\n- npm.cmd test -- --runInBand\n- npm.cmd run lint\n- npm.cmd run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an install banner that prompts users to add the app to their home screen.
  * Install prompt displays platform-specific guidance tailored to iOS and other devices.
  * Users can dismiss the banner, with their preference persisted across sessions.

* **Tests**
  * Added comprehensive test coverage for the install banner functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->