### PR TITLE
Fix startup browser TTS activation hack

### DIFF
--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -27,6 +27,7 @@ export default function TTSSettings() {
     isSpeaking,
     status,
     getVoicesByProvider,
+    refreshVoices,
     hasSubscription
   } = useTTS();
 
@@ -40,6 +41,12 @@ export default function TTSSettings() {
   const SAMPLE_TEXT = 'Hello, this is a preview of how this voice sounds.';
 
   // Load provider voices only when voices or provider changes
+  useEffect(() => {
+    if (settings.ttsProvider === 'browser') {
+      refreshVoices();
+    }
+  }, [refreshVoices, settings.ttsProvider]);
+
   useEffect(() => {
     const voicesForProvider = getVoicesByProvider(settings.ttsProvider);
     setProviderVoices(voicesForProvider);

--- a/lib/hooks/useTTS.ts
+++ b/lib/hooks/useTTS.ts
@@ -166,6 +166,13 @@ export function useTTS() {
     return ttsRef.current.getVoicesByProvider(providerType);
   }, []);
 
+  const refreshVoices = useCallback(() => {
+    if (!ttsRef.current) return;
+    ttsRef.current.refreshVoices();
+    setVoices(ttsRef.current.getAllVoices());
+    setStatus(ttsRef.current.getStatus());
+  }, []);
+
   // Helper to check if a provider is actually available (considering subscription)
   const isProviderAvailable = useCallback((providerType: TTSProviderType) => {
     if (providerType === 'browser') return true;
@@ -184,6 +191,7 @@ export function useTTS() {
     provider,
     switchProvider,
     getVoicesByProvider,
+    refreshVoices,
     status,
     hasSubscription,
     isProviderAvailable

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -144,6 +144,11 @@ export class TTSProvider {
     return this.getAllVoices().find(voice => voice.id === id);
   }
 
+  public refreshVoices() {
+    this.webSpeechTTS.refreshVoices();
+    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+  }
+
   public speak(text: string, options?: {
     voiceId?: string;
     rate?: number;

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -34,18 +34,6 @@ export class TextToSpeech {
 
     // Set up event listener for when voices are loaded
     window.speechSynthesis.onvoiceschanged = () => this.updateVoices();
-
-    // For mobile devices, we need to trigger voice loading
-    // by making a small utterance
-    if (this.voices.length === 0) {
-      const utterance = new SpeechSynthesisUtterance('');
-      utterance.volume = 0;
-      utterance.onend = () => {
-        // After the utterance ends, try to get voices again
-        this.updateVoices();
-      };
-      window.speechSynthesis.speak(utterance);
-    }
   }
 
   private updateVoices() {
@@ -77,6 +65,10 @@ export class TextToSpeech {
     return this.voices.find(voice => voice.voiceURI === voiceURI);
   }
 
+  public refreshVoices() {
+    this.updateVoices();
+  }
+
   public speak(text: string, options?: {
     rate?: number;
     pitch?: number;
@@ -86,6 +78,8 @@ export class TextToSpeech {
     if (typeof window === 'undefined' || !window.speechSynthesis) {
       return;
     }
+
+    this.refreshVoices();
 
     // Stop any ongoing speech
     this.stop();

--- a/tests/lib/tts.test.ts
+++ b/tests/lib/tts.test.ts
@@ -1,0 +1,91 @@
+import { TextToSpeech } from '@/lib/tts';
+
+class MockSpeechSynthesisUtterance {
+  text: string;
+  rate = 1;
+  pitch = 1;
+  volume = 1;
+  voice?: SpeechSynthesisVoice;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: SpeechSynthesisErrorEvent) => void) | null = null;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+describe('TextToSpeech', () => {
+  const originalSpeechSynthesis = window.speechSynthesis;
+  const originalUtterance = global.SpeechSynthesisUtterance;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'SpeechSynthesisUtterance', {
+      configurable: true,
+      value: MockSpeechSynthesisUtterance,
+    });
+
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        getVoices: jest.fn(() => []),
+        speak: jest.fn(),
+        cancel: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        paused: false,
+        onvoiceschanged: null,
+      },
+    });
+
+    (TextToSpeech as unknown as { instance?: TextToSpeech }).instance = undefined;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: originalSpeechSynthesis,
+    });
+
+    Object.defineProperty(global, 'SpeechSynthesisUtterance', {
+      configurable: true,
+      value: originalUtterance,
+    });
+  });
+
+  it('does not trigger speech synthesis during initialization', () => {
+    const tts = TextToSpeech.getInstance();
+
+    expect(tts.isAvailable()).toBe(true);
+    expect(window.speechSynthesis.speak).not.toHaveBeenCalled();
+  });
+
+  it('refreshes voices and speaks only when requested by the user', () => {
+    const getVoices = jest.fn(() => [
+      {
+        name: 'Test Voice',
+        lang: 'en-US',
+        voiceURI: 'voice:test',
+      } as SpeechSynthesisVoice,
+    ]);
+
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        getVoices,
+        speak: jest.fn(),
+        cancel: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        paused: false,
+        onvoiceschanged: null,
+      },
+    });
+
+    const tts = TextToSpeech.getInstance();
+    tts.speak('Hello there', { voiceURI: 'voice:test' });
+
+    expect(getVoices).toHaveBeenCalled();
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the empty browser TTS startup utterance that Lighthouse flagged as a deprecation
- add an explicit voice refresh path for browser voices and use it from TTS settings and real speak actions
- add a regression test to ensure startup no longer calls speech synthesis automatically

## Testing
- npm.cmd test -- --runInBand tests/lib/tts.test.ts
- npm.cmd test -- --runInBand
- npm.cmd run lint
- npm.cmd run build

Closes #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice list refresh capability when switching text-to-speech providers.

* **Bug Fixes**
  * Enhanced voice data reliability through automatic refresh on each speak action.

* **Tests**
  * Added test suite for text-to-speech module with mocked audio APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->