### PR TITLE
Fix production home hydration mismatch

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -47,6 +47,7 @@ export default function TypingArea({
   const [showLiveTypingModal, setShowLiveTypingModal] = useState(false);
   const [showTabManagementDialog, setShowTabManagementDialog] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const prevExternalTextRef = useRef(externalText);
   const prevActiveTabIdRef = useRef<string | null>(null);
   const hasProcessedInitialExternalTextRef = useRef(false);
   const hasInitializedActiveTabRef = useRef(false);
@@ -80,7 +81,7 @@ export default function TypingArea({
     switchToTabByIndex,
     switchToPreviousTab,
     switchToNextTab,
-  } = useTypingTabs(initialText);
+  } = useTypingTabs(externalText === undefined ? initialText : undefined);
 
   const text = activeTab.text;
   const showOfflineCloudNotice = !isOnline && (enableFixText || (enableLiveTyping && !!user));
@@ -93,15 +94,25 @@ export default function TypingArea({
 
     if (!hasProcessedInitialExternalTextRef.current) {
       hasProcessedInitialExternalTextRef.current = true;
+      prevExternalTextRef.current = externalText;
 
       if (!externalText.trim() && activeTab.text.trim()) {
         onChange?.(activeTab.text);
         return;
       }
+
+      if (externalText !== activeTab.text) {
+        updateActiveTabText(externalText);
+        return;
+      }
     }
 
-    if (externalText !== activeTab.text) {
-      updateActiveTabText(externalText);
+    if (externalText !== prevExternalTextRef.current) {
+      prevExternalTextRef.current = externalText;
+
+      if (externalText !== activeTab.text) {
+        updateActiveTabText(externalText);
+      }
     }
   }, [activeTab.text, externalText, onChange, updateActiveTabText]);
 

--- a/app/components/typing-tabs/useTypingTabs.ts
+++ b/app/components/typing-tabs/useTypingTabs.ts
@@ -9,6 +9,15 @@ import { createDefaultTab, validateTabLabel, generateLabelFromText } from './uti
 const STORAGE_KEY = 'typingTabs';
 const DEBOUNCE_DELAY = 300;
 
+function createInitialTabsState(initialText?: string): TypingTabsState {
+  const firstTab = createDefaultTab(1, initialText || '');
+  return {
+    tabs: [firstTab],
+    activeTabId: firstTab.id,
+    nextTabNumber: 2,
+  };
+}
+
 export function useTypingTabs(initialText?: string) {
   const { uiPreferences, updateUIPreference } = useSettings();
   const { user } = useAuth();
@@ -16,38 +25,35 @@ export function useTypingTabs(initialText?: string) {
   const persistTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Initialize tabs state
-  const [tabsState, setTabsState] = useState<TypingTabsState>(() => {
-    // Try to load from localStorage first
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored) as TypingTabsState;
-          if (parsed.tabs.length > 0) {
-            // Migration: Add isCustomLabel field to existing tabs
-            const migratedTabs = parsed.tabs.map(tab => ({
-              ...tab,
-              isCustomLabel: tab.isCustomLabel ?? false,
-            }));
-            return {
-              ...parsed,
-              tabs: migratedTabs,
-            };
-          }
-        } catch (error) {
-          console.error('Failed to parse stored tabs:', error);
+  const [tabsState, setTabsState] = useState<TypingTabsState>(() => createInitialTabsState(initialText));
+  const [hasHydratedStorage, setHasHydratedStorage] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as TypingTabsState;
+        if (parsed.tabs.length > 0) {
+          const migratedTabs = parsed.tabs.map(tab => ({
+            ...tab,
+            isCustomLabel: tab.isCustomLabel ?? false,
+          }));
+          setTabsState({
+            ...parsed,
+            tabs: migratedTabs,
+          });
         }
+      } catch (error) {
+        console.error('Failed to parse stored tabs:', error);
       }
     }
 
-    // Migration: If no tabs exist but initialText exists, create first tab with that text
-    const firstTab = createDefaultTab(1, initialText || '');
-    return {
-      tabs: [firstTab],
-      activeTabId: firstTab.id,
-      nextTabNumber: 2,
-    };
-  });
+    setHasHydratedStorage(true);
+  }, []);
 
   // Get active tab
   const activeTab = tabsState.tabs.find(tab => tab.id === tabsState.activeTabId) || tabsState.tabs[0];
@@ -55,6 +61,8 @@ export function useTypingTabs(initialText?: string) {
   // Auto-create new empty tab on mount if active tab has text
   const hasAutoCreated = useRef(false);
   useEffect(() => {
+    if (!hasHydratedStorage) return;
+
     // Only run once on mount
     if (hasAutoCreated.current) return;
     hasAutoCreated.current = true;
@@ -73,7 +81,7 @@ export function useTypingTabs(initialText?: string) {
         nextTabNumber: prev.nextTabNumber + 1,
       }));
     }
-  }, [activeTab.text, initialText, tabsState.nextTabNumber]);
+  }, [activeTab.text, hasHydratedStorage, initialText, tabsState.nextTabNumber]);
 
   // Persist tabs to localStorage and Convex (debounced)
   const persistTabs = useCallback((state: TypingTabsState) => {
@@ -103,15 +111,23 @@ export function useTypingTabs(initialText?: string) {
 
   // Sync active tab ID to UIPreferences
   useEffect(() => {
+    if (!hasHydratedStorage) {
+      return;
+    }
+
     if (uiPreferences.activeTypingTabId !== tabsState.activeTabId) {
       updateUIPreference('activeTypingTabId', tabsState.activeTabId);
     }
-  }, [tabsState.activeTabId, uiPreferences.activeTypingTabId, updateUIPreference]);
+  }, [hasHydratedStorage, tabsState.activeTabId, uiPreferences.activeTypingTabId, updateUIPreference]);
 
   // Persist tabs whenever they change
   useEffect(() => {
+    if (!hasHydratedStorage) {
+      return;
+    }
+
     persistTabs(tabsState);
-  }, [tabsState, persistTabs]);
+  }, [hasHydratedStorage, tabsState, persistTabs]);
 
   // Create a new tab
   const createTab = useCallback(() => {

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -213,10 +213,17 @@ function saveToLocalStorage(allSettings: AllSettings) {
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
-  const [allSettings, setAllSettings] = useState<AllSettings>(() => loadFromLocalStorage());
+  const [allSettings, setAllSettings] = useState<AllSettings>({
+    ...defaultSettings,
+    ...defaultUIPreferences,
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
   const [hasMigrated, setHasMigrated] = useState(false);
+
+  useEffect(() => {
+    setAllSettings(loadFromLocalStorage());
+  }, []);
 
   // Convex hooks - only query when authenticated
   const convexSettings = useQuery(api.userSettings.getUserSettings, user ? {} : 'skip');

--- a/lib/hooks/useLocalMessageHistory.ts
+++ b/lib/hooks/useLocalMessageHistory.ts
@@ -46,21 +46,25 @@ function parseStoredHistory(value: string | null): LocalMessageHistoryEntry[] {
 }
 
 export function useLocalMessageHistory() {
-  const [messages, setMessages] = useState<LocalMessageHistoryEntry[]>(() => {
-    if (typeof window === 'undefined') {
-      return [];
-    }
-
-    return parseStoredHistory(window.localStorage.getItem(STORAGE_KEY));
-  });
+  const [messages, setMessages] = useState<LocalMessageHistoryEntry[]>([]);
+  const [hasHydratedStorage, setHasHydratedStorage] = useState(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
 
+    setMessages(parseStoredHistory(window.localStorage.getItem(STORAGE_KEY)));
+    setHasHydratedStorage(true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !hasHydratedStorage) {
+      return;
+    }
+
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
-  }, [messages]);
+  }, [hasHydratedStorage, messages]);
 
   const recordMessage = useCallback((payload: RecordLocalMessagePayload) => {
     const trimmedText = payload.text.trim();

--- a/lib/hooks/useOnlineStatus.ts
+++ b/lib/hooks/useOnlineStatus.ts
@@ -3,16 +3,12 @@
 import { useEffect, useState } from 'react';
 
 export function useOnlineStatus() {
-  const [isOnline, setIsOnline] = useState(() => {
-    if (typeof navigator === 'undefined') {
-      return true;
-    }
-
-    return navigator.onLine;
-  });
+  const [isOnline, setIsOnline] = useState(true);
   const [wasOffline, setWasOffline] = useState(false);
 
   useEffect(() => {
+    setIsOnline(window.navigator.onLine);
+
     const handleOnline = () => {
       setIsOnline(true);
       setWasOffline(true);

--- a/tests/components/TypingArea.test.tsx
+++ b/tests/components/TypingArea.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TypingArea from '@/app/components/TypingArea';
 
@@ -185,7 +185,7 @@ describe('TypingArea', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
-    it('restores a persisted draft instead of overwriting it with an empty text prop', () => {
+    it('restores a persisted draft instead of overwriting it with an empty text prop', async () => {
       localStorageMock.setItem('typingTabs', JSON.stringify({
         tabs: [
           {
@@ -204,7 +204,9 @@ describe('TypingArea', () => {
       const onChange = jest.fn();
       render(<TypingArea text="" tts={mockTTS} onChange={onChange} />);
 
-      expect(screen.getByRole('textbox')).toHaveValue('Restored draft');
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toHaveValue('Restored draft');
+      });
       expect(onChange).toHaveBeenCalledWith('Restored draft');
     });
 


### PR DESCRIPTION
## Summary
- move browser-only state hydration for settings, online status, tabs, and local message history into effects so SSR and the first client render match
- keep restored drafts working by tightening TypingArea's controlled text sync logic
- update the persisted-draft test to assert the post-hydration result

## Testing
- npm.cmd test -- --runInBand
- npm.cmd run lint
- npm.cmd run build
- Lighthouse best-practices on http://127.0.0.1:3600/ improved from 54 to 73 and no longer reports the React hydration mismatch in console errors

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state initialization timing to prevent displaying stale or incorrect data on app startup
  * Improved handling of external text input to prevent unintended overwrites
  * Corrected localStorage hydration sequence across components to ensure proper data restoration

* **Tests**
  * Updated test to properly handle asynchronous draft restoration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->