### PR TITLE
Lazy-load ElevenLabs voices

### DIFF
--- a/app/api/elevenlabs/voices/route.ts
+++ b/app/api/elevenlabs/voices/route.ts
@@ -15,10 +15,7 @@ export async function GET() {
     const apiKey = process.env.ELEVENLABS_API_KEY?.replace(/^\uFEFF/, '').trim();
 
     if (!apiKey) {
-      return NextResponse.json(
-        { error: 'API configuration error' },
-        { status: 500 },
-      );
+      return NextResponse.json({ voices: [], available: false });
     }
 
     const response = await fetch('https://api.elevenlabs.io/v1/voices', {
@@ -28,10 +25,7 @@ export async function GET() {
     });
 
     if (!response.ok) {
-      return NextResponse.json(
-        { error: 'Failed to load voices' },
-        { status: response.status },
-      );
+      return NextResponse.json({ voices: [], available: false });
     }
 
     const data = await response.json();
@@ -42,12 +36,9 @@ export async function GET() {
       description: voice.description || '',
     }));
 
-    return NextResponse.json({ voices });
+    return NextResponse.json({ voices, available: voices.length > 0 });
   } catch (error) {
     console.error('Error loading ElevenLabs voices:', error);
-    return NextResponse.json(
-      { error: 'Server error', details: error instanceof Error ? error.message : 'Unknown error' },
-      { status: 500 },
-    );
+    return NextResponse.json({ voices: [], available: false });
   }
 }

--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -28,6 +28,7 @@ export default function TTSSettings() {
     status,
     getVoicesByProvider,
     refreshVoices,
+    loadElevenLabsVoices,
     hasSubscription
   } = useTTS();
 
@@ -46,6 +47,14 @@ export default function TTSSettings() {
       refreshVoices();
     }
   }, [refreshVoices, settings.ttsProvider]);
+
+  useEffect(() => {
+    if (!isOnline) {
+      return;
+    }
+
+    void loadElevenLabsVoices();
+  }, [isOnline, loadElevenLabsVoices]);
 
   useEffect(() => {
     const voicesForProvider = getVoicesByProvider(settings.ttsProvider);

--- a/lib/elevenlabs-tts.ts
+++ b/lib/elevenlabs-tts.ts
@@ -90,9 +90,6 @@ export class ElevenLabsTTS {
   private constructor() {
     // Private constructor to enforce singleton pattern
     this.fallbackTTS = WebSpeechTTS.getInstance();
-    if (typeof window !== 'undefined') {
-      this.loadVoices();
-    }
   }
 
   public static getInstance(): ElevenLabsTTS {
@@ -102,7 +99,7 @@ export class ElevenLabsTTS {
     return ElevenLabsTTS.instance;
   }
 
-  private async loadVoices() {
+  public async loadVoices() {
     if (typeof window === 'undefined') return;
 
     if (this.loadingVoices) {
@@ -113,13 +110,6 @@ export class ElevenLabsTTS {
       try {
         const response = await fetch('/api/elevenlabs/voices');
 
-        if (!response.ok) {
-          this.isAvailableFlag = false;
-          this.voices = [];
-          this.callbacks.onVoicesChanged?.(this.voices);
-          return;
-        }
-
         const data = await response.json();
 
         this.voices = (data?.voices ?? []).map((voice: Voice) => ({
@@ -129,7 +119,7 @@ export class ElevenLabsTTS {
           description: voice.description || ''
         }));
 
-        this.isAvailableFlag = true;
+        this.isAvailableFlag = data?.available ?? this.voices.length > 0;
         this.callbacks.onVoicesChanged?.(this.voices);
       } catch (error) {
         this.isAvailableFlag = false;
@@ -144,6 +134,10 @@ export class ElevenLabsTTS {
     })();
 
     return this.loadingVoices;
+  }
+
+  public hasLoadedVoices(): boolean {
+    return this.voicesLoaded;
   }
 
   public setCallbacks(callbacks: {

--- a/lib/hooks/useTTS.ts
+++ b/lib/hooks/useTTS.ts
@@ -38,6 +38,16 @@ export function useTTS() {
   }, [settings]);
 
   useEffect(() => {
+    if (!ttsRef.current) {
+      return;
+    }
+
+    ttsRef.current.setProvider(settings.ttsProvider);
+    setProvider(ttsRef.current.getCurrentProvider());
+    setStatus(ttsRef.current.getStatus());
+  }, [settings.ttsProvider]);
+
+  useEffect(() => {
     // Initialize only once
     if (!ttsRef.current) {
       ttsRef.current = TTSProvider.getInstance();
@@ -173,6 +183,13 @@ export function useTTS() {
     setStatus(ttsRef.current.getStatus());
   }, []);
 
+  const loadElevenLabsVoices = useCallback(async () => {
+    if (!ttsRef.current) return;
+    await ttsRef.current.loadElevenLabsVoices();
+    setVoices(ttsRef.current.getAllVoices());
+    setStatus(ttsRef.current.getStatus());
+  }, []);
+
   // Helper to check if a provider is actually available (considering subscription)
   const isProviderAvailable = useCallback((providerType: TTSProviderType) => {
     if (providerType === 'browser') return true;
@@ -192,6 +209,7 @@ export function useTTS() {
     switchProvider,
     getVoicesByProvider,
     refreshVoices,
+    loadElevenLabsVoices,
     status,
     hasSubscription,
     isProviderAvailable

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -102,7 +102,11 @@ export class TTSProvider {
       return;
     }
     
-    if (provider === 'elevenlabs' && !this.elevenlabsTTS.isAvailable()) {
+    if (
+      provider === 'elevenlabs'
+      && this.elevenlabsTTS.hasLoadedVoices()
+      && !this.elevenlabsTTS.isAvailable()
+    ) {
       console.warn('ElevenLabs is not available, staying with browser TTS');
       return;
     }
@@ -149,6 +153,11 @@ export class TTSProvider {
     this.callbacks.onVoicesChanged?.(this.getAllVoices());
   }
 
+  public async loadElevenLabsVoices() {
+    await this.elevenlabsTTS.loadVoices();
+    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+  }
+
   public speak(text: string, options?: {
     voiceId?: string;
     rate?: number;
@@ -169,7 +178,7 @@ export class TTSProvider {
     
     console.log(`Speaking with provider: ${provider}, requested voiceId: ${options?.voiceId}`);
     
-    if (provider === 'elevenlabs' && this.elevenlabsTTS.isAvailable()) {
+    if (provider === 'elevenlabs') {
       // Get all available voices
       const allVoices = this.getAllVoices();
       

--- a/tests/lib/elevenlabs-tts.test.ts
+++ b/tests/lib/elevenlabs-tts.test.ts
@@ -1,0 +1,43 @@
+import { ElevenLabsTTS } from '@/lib/elevenlabs-tts';
+
+describe('ElevenLabsTTS', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    (ElevenLabsTTS as unknown as { instance?: ElevenLabsTTS }).instance = undefined;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not fetch voices during initialization', () => {
+    ElevenLabsTTS.getInstance();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('loads voices only when requested', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: async () => ({
+        available: true,
+        voices: [
+          {
+            voice_id: 'voice-1',
+            name: 'Test Voice',
+            preview_url: 'https://example.com/voice.mp3',
+            description: 'Preview voice',
+          },
+        ],
+      }),
+    });
+
+    const tts = ElevenLabsTTS.getInstance();
+    await tts.loadVoices();
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/elevenlabs/voices');
+    expect(tts.isAvailable()).toBe(true);
+    expect(tts.getVoices()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- stop fetching ElevenLabs voices during startup and only load them when TTS settings needs them or ElevenLabs speech is attempted
- sync the runtime TTS provider from saved settings so lazy loading does not force users back to browser TTS
- soften the voices API to return an empty unavailable state instead of a 500 for missing/unavailable ElevenLabs config

## Testing
- npm.cmd test -- --runInBand
- npm.cmd run lint
- npm.cmd run build
- Lighthouse best-practices on http://127.0.0.1:3601/ improved from 73 to 77 and errors-in-console is now empty on the home route

Closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ElevenLabs voices now automatically reload when network connectivity is restored.
  * Enhanced reliability of voice availability detection.
  * Improved consistency of error handling in voice loading across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->