### PR TITLE
Fix ElevenLabs speech before opening settings

### DIFF
--- a/lib/hooks/useTTS.ts
+++ b/lib/hooks/useTTS.ts
@@ -53,6 +53,8 @@ export function useTTS() {
       ttsRef.current = TTSProvider.getInstance();
       
       const tts = ttsRef.current;
+
+      tts.setProvider(settingsRef.current.ttsProvider);
       
       // Set initial state
       setIsAvailable(tts.isAvailable());

--- a/tests/lib/hooks/useTTS.test.ts
+++ b/tests/lib/hooks/useTTS.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTTS } from '@/lib/hooks/useTTS';
+
+const mockSettings = {
+  ttsProvider: 'elevenlabs',
+  ttsVoiceId: 'voice-1',
+  speechRate: 1,
+  speechPitch: 1,
+  speechVolume: 1,
+  ttsStability: 0.5,
+  ttsSimilarityBoost: 0.5,
+};
+
+let mockCurrentProvider: 'browser' | 'elevenlabs' = 'browser';
+
+const mockTTSProvider = {
+  isAvailable: jest.fn(() => true),
+  getCurrentProvider: jest.fn(() => mockCurrentProvider),
+  getStatus: jest.fn(() => ({
+    isSpeaking: false,
+    activeProvider: mockCurrentProvider,
+    elevenLabsAvailable: mockCurrentProvider === 'elevenlabs',
+    browserTTSAvailable: true,
+  })),
+  getAllVoices: jest.fn(() => []),
+  setCallbacks: jest.fn(),
+  setProvider: jest.fn((provider: 'browser' | 'elevenlabs') => {
+    mockCurrentProvider = provider;
+  }),
+  speak: jest.fn(),
+  stop: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  getVoicesByProvider: jest.fn(() => []),
+  refreshVoices: jest.fn(),
+  loadElevenLabsVoices: jest.fn(),
+};
+
+jest.mock('@/app/hooks/useSubscription', () => ({
+  useSubscription: jest.fn(() => ({
+    isActive: true,
+  })),
+}));
+
+jest.mock('@/app/contexts/SettingsContext', () => ({
+  useSettings: jest.fn(() => ({
+    settings: mockSettings,
+  })),
+}));
+
+jest.mock('@/lib/tts-provider', () => ({
+  TTSProvider: {
+    getInstance: jest.fn(() => mockTTSProvider),
+  },
+}));
+
+describe('useTTS', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentProvider = 'browser';
+  });
+
+  it('applies the saved provider during initialization', async () => {
+    const { result } = renderHook(() => useTTS());
+
+    await waitFor(() => {
+      expect(mockTTSProvider.setProvider).toHaveBeenCalledWith('elevenlabs');
+      expect(result.current.provider).toBe('elevenlabs');
+      expect(result.current.status.activeProvider).toBe('elevenlabs');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- apply the saved TTS provider during useTTS() initialization so the runtime does not stay on browser TTS until another page loads voices
- keep the lazy ElevenLabs voice loading behavior introduced in v2.7.0
- add a regression test for the saved-provider initialization path

## Testing
- npm.cmd test -- --runInBand tests/lib/hooks/useTTS.test.ts
- npm.cmd test -- --runInBand
- npm.cmd run lint
- npm.cmd run build

Closes #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed TTS provider initialization to ensure the configured provider setting is properly applied immediately upon startup, resolving potential timing issues.

* **Tests**
  * Added test coverage for TTS provider initialization behavior to validate correct provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->