### PR TITLE
Fix indefinite PWA startup loading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
@@ -8,19 +9,54 @@ import HomeFeatures from '@/app/components/home/HomeFeatures';
 import GuestCommunication from '@/app/components/home/GuestCommunication';
 import PhrasesInterface from '@/app/components/home/PhrasesInterface';
 import ConnectionRequestsBanner from '@/app/components/connection/ConnectionRequestsBanner';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+
+const STARTUP_FALLBACK_DELAY_MS = 4000;
 
 export default function Home() {
   const { user, loading: authLoading } = useAuth();
   const profile = useQuery(api.profiles.getProfile);
+  const { isOnline } = useOnlineStatus();
+  const [showStartupFallback, setShowStartupFallback] = useState(false);
+  const isProfileLoading = !!user && profile === undefined;
+  const isStartupPending = authLoading || isProfileLoading;
 
-  // Show loading while auth is loading
-  if (authLoading) {
+  useEffect(() => {
+    if (!isStartupPending) {
+      setShowStartupFallback(false);
+      return;
+    }
+
+    if (!isOnline) {
+      setShowStartupFallback(true);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setShowStartupFallback(true);
+    }, STARTUP_FALLBACK_DELAY_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isOnline, isStartupPending]);
+
+  if (isStartupPending && !showStartupFallback) {
     return <AnimatedLoading />;
   }
 
-  // Show loading while profile is being fetched for logged-in users
-  if (user && profile === undefined) {
-    return <AnimatedLoading />;
+  if (isStartupPending && showStartupFallback) {
+    return (
+      <div className="min-h-screen flex flex-col bg-background">
+        <div className="border-b border-amber-900 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+          <div className="mx-auto max-w-5xl">
+            {isOnline
+              ? 'Loading your account is taking longer than expected. Text communication is available below while SayIt! keeps trying to reconnect.'
+              : 'You appear to be offline. Text communication is available below while account and board features wait for internet access.'}
+          </div>
+        </div>
+        <GuestCommunication />
+        <HomeFeatures />
+      </div>
+    );
   }
 
   return (

--- a/tests/app/HomePage.test.tsx
+++ b/tests/app/HomePage.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import Home from '@/app/page';
+
+const mockUseAuth = jest.fn();
+const mockUseQuery = jest.fn();
+const mockUseOnlineStatus = jest.fn();
+
+jest.mock('@/app/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('convex/react', () => ({
+  useQuery: () => mockUseQuery(),
+}));
+
+jest.mock('@/lib/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => mockUseOnlineStatus(),
+}));
+
+jest.mock('@/convex/_generated/api', () => ({
+  api: {
+    profiles: {
+      getProfile: 'profiles.getProfile',
+    },
+  },
+}));
+
+jest.mock('@/app/components/phrases/AnimatedLoading', () => ({
+  __esModule: true,
+  default: () => <div>Loading Screen</div>,
+}));
+
+jest.mock('@/app/components/home/GuestCommunication', () => ({
+  __esModule: true,
+  default: () => <div>Guest Communication</div>,
+}));
+
+jest.mock('@/app/components/home/HomeFeatures', () => ({
+  __esModule: true,
+  default: () => <div>Home Features</div>,
+}));
+
+jest.mock('@/app/components/home/PhrasesInterface', () => ({
+  __esModule: true,
+  default: () => <div>Phrases Interface</div>,
+}));
+
+jest.mock('@/app/components/connection/ConnectionRequestsBanner', () => ({
+  __esModule: true,
+  default: () => <div>Connection Requests</div>,
+}));
+
+describe('Home startup loading fallback', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockUseOnlineStatus.mockReturnValue({ isOnline: true });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows the loading screen during a short auth load', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    mockUseQuery.mockReturnValue(undefined);
+
+    render(<Home />);
+
+    expect(screen.getByText('Loading Screen')).toBeInTheDocument();
+    expect(screen.queryByText('Guest Communication')).not.toBeInTheDocument();
+  });
+
+  it('falls back to guest communication immediately when offline during auth load', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    mockUseQuery.mockReturnValue(undefined);
+    mockUseOnlineStatus.mockReturnValue({ isOnline: false });
+
+    render(<Home />);
+
+    expect(screen.getByText('Guest Communication')).toBeInTheDocument();
+    expect(
+      screen.getByText(/You appear to be offline\. Text communication is available below/i)
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to guest communication after a prolonged online auth load', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    mockUseQuery.mockReturnValue(undefined);
+
+    render(<Home />);
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.getByText('Guest Communication')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Loading your account is taking longer than expected/i)
+    ).toBeInTheDocument();
+  });
+
+  it('falls back when a signed-in user profile load stalls', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'user_123', email: 'user@example.com' },
+      loading: false,
+    });
+    mockUseQuery.mockReturnValue(undefined);
+
+    render(<Home />);
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.getByText('Guest Communication')).toBeInTheDocument();
+    expect(screen.queryByText('Phrases Interface')).not.toBeInTheDocument();
+  });
+
+  it('shows the signed-in experience when startup data is available', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'user_123', email: 'user@example.com' },
+      loading: false,
+    });
+    mockUseQuery.mockReturnValue({ role: 'communicator' });
+
+    render(<Home />);
+
+    expect(screen.getByText('Connection Requests')).toBeInTheDocument();
+    expect(screen.getByText('Phrases Interface')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #341

## Summary
- stop the home route from waiting forever on auth or profile startup
- fall back to the offline text communication surface when startup loading stalls or the device is offline
- add regression tests for short loads, offline startup, and stalled signed-in startup

## Verification
- npm test -- --runInBand tests/app/HomePage.test.tsx
- npm run lint
- npm test -- --runInBand
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced home page with online/offline status awareness, displaying contextual messages based on your connectivity.
  * Added intelligent fallback UI that appears after 4 seconds if the page is taking longer than expected to load.

* **Tests**
  * Added comprehensive test coverage for home page behavior across connectivity and loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->