### PR TITLE
Reduce redundant offline warnings

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -84,8 +84,6 @@ export default function TypingArea({
   } = useTypingTabs(externalText === undefined ? initialText : undefined);
 
   const text = activeTab.text;
-  const showOfflineCloudNotice = !isOnline && (enableFixText || (enableLiveTyping && !!user));
-
   // Sync external text prop with active tab
   useEffect(() => {
     if (externalText === undefined) {
@@ -181,7 +179,7 @@ export default function TypingArea({
 
   const handleShare = async () => {
     if (!isOnline) {
-      setError('Live Typing requires an internet connection.');
+      setError('Live Typing is unavailable offline.');
       return;
     }
 
@@ -266,7 +264,7 @@ export default function TypingArea({
   const handleFixText = async () => {
     if (!text.trim() || isFixingText) return;
     if (!isOnline) {
-      setError('Fix Text requires an internet connection.');
+      setError('Fix Text is unavailable offline.');
       return;
     }
 
@@ -540,13 +538,6 @@ export default function TypingArea({
                   </>
                 )}
               </button>
-            </div>
-          )}
-          {showOfflineCloudNotice && (
-            <div className="px-4 pb-4 bg-surface-hover">
-              <p className="text-xs text-amber-500">
-                Offline: browser speech still works, but Fix Text and Live Typing require internet.
-              </p>
             </div>
           )}
         </div>

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -180,8 +180,6 @@ export default function TypingDock({
   // Text size from settings (now a number in px)
   const textSizePx = settings.textSize;
   const currentText = enableTabs ? activeTab.text : text;
-  const showOfflineCloudNotice = !isOnline && (enableFixText || (enableLiveTyping && !!user) || !!replySuggestions?.enabled);
-
   const showUndoHint = canUndo
     && entry?.tabId === (activeTabId || 'default')
     && currentText.trim().length === 0;
@@ -303,7 +301,7 @@ export default function TypingDock({
   const handleFixText = async () => {
     if (!currentText.trim() || isFixingText) return;
     if (!isOnline) {
-      setError('Fix Text requires an internet connection.');
+      setError('Fix Text is unavailable offline.');
       return;
     }
 
@@ -533,14 +531,6 @@ export default function TypingDock({
                 variant="inline"
               />
             )}
-            {showOfflineCloudNotice && (
-              <div className="px-1">
-                <span className="text-xs text-amber-500">
-                  Offline: browser speech still works, but AI tools and Live Typing need internet.
-                </span>
-              </div>
-            )}
-
             {/* Row 1: AI Features (when text exists) */}
             {currentText.trim() && enableFixText && (
               <div className="flex items-center gap-2">

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -337,15 +337,7 @@ export default function PhrasesInterface() {
         </div>
       ) : showOfflineBoardsState ? (
         <div className="flex-1 flex items-center justify-center">
-          <div className="max-w-md text-center">
-            <h2 className="text-xl font-medium text-foreground mb-4">Boards need internet</h2>
-            <p className="text-text-secondary mb-2">
-              Text communication and browser speech are still available, but saved boards and cloud updates are unavailable while offline.
-            </p>
-            <p className="text-sm text-amber-500">
-              Reconnect to load boards, edit phrases, and sync changes.
-            </p>
-          </div>
+          <p className="text-text-secondary">Boards are unavailable offline.</p>
         </div>
       ) : loading ? (
         <div className="flex-1 flex items-center justify-center">
@@ -496,11 +488,6 @@ export default function PhrasesInterface() {
           />
           {captureError && settings.aiReplySuggestionsEnabled && (
             <p className="px-3 pb-2 text-xs text-amber-500">Message history capture is temporarily unavailable.</p>
-          )}
-          {!isOnline && user && (
-            <p className="px-3 pb-2 text-xs text-amber-500">
-              Offline: boards, reply suggestions, and cloud sync will reconnect automatically when internet returns.
-            </p>
           )}
         </MobileDockPortal>
       )}

--- a/app/components/navigation/ConnectivityBanner.tsx
+++ b/app/components/navigation/ConnectivityBanner.tsx
@@ -48,7 +48,7 @@ export default function ConnectivityBanner() {
         )}
         <p>
           {isOfflineBanner
-            ? 'You are offline. Text communication and browser speech still work, but boards, Fix Text, reply suggestions, Live Typing, ElevenLabs, and cloud sync are unavailable.'
+            ? "You're offline. Text communication and browser speech still work."
             : 'Connection restored. Online features are available again.'}
         </p>
       </div>

--- a/app/components/typing/ReplySuggestions.tsx
+++ b/app/components/typing/ReplySuggestions.tsx
@@ -42,25 +42,7 @@ export default function ReplySuggestions({
   }
 
   if (!isOnline) {
-    if (variant === 'inline') {
-      return (
-        <p className={`text-xs text-amber-500 ${className}`}>
-          Reply suggestions require internet and will return when you reconnect.
-        </p>
-      );
-    }
-
-    return (
-      <div className={`rounded-2xl border border-border bg-surface px-3 py-2.5 shadow-sm ${className}`}>
-        <div className="mb-1 flex items-center gap-1.5">
-          <SparklesIcon className="h-4 w-4 text-primary-500" />
-          <p className="text-xs font-semibold text-foreground">Reply suggestions</p>
-        </div>
-        <p className="text-sm text-amber-500">
-          Reply suggestions require internet and will return when you reconnect.
-        </p>
-      </div>
-    );
+    return null;
   }
 
   const hasEnoughHistory = history.length >= MIN_HISTORY_ENTRIES;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
           <div className="mx-auto max-w-5xl">
             {isOnline
               ? 'Loading your account is taking longer than expected. Text communication is available below while SayIt! keeps trying to reconnect.'
-              : 'You appear to be offline. Text communication is available below while account and board features wait for internet access.'}
+              : 'You appear to be offline. Text communication is available below.'}
           </div>
         </div>
         <GuestCommunication />

--- a/tests/components/typing/ReplySuggestions.test.tsx
+++ b/tests/components/typing/ReplySuggestions.test.tsx
@@ -40,14 +40,14 @@ describe('ReplySuggestions', () => {
     });
   });
 
-  it('shows an explicit offline message instead of hiding suggestions state', () => {
+  it('renders nothing when offline instead of showing a redundant message', () => {
     mockUseOnlineStatus.mockReturnValue({
       isOnline: false,
       wasOffline: false,
       clearRecoveredState: jest.fn(),
     });
 
-    render(
+    const { container } = render(
       <ReplySuggestions
         history={['One', 'Two', 'Three']}
         enabled={true}
@@ -55,8 +55,6 @@ describe('ReplySuggestions', () => {
       />
     );
 
-    expect(
-      screen.getByText(/Reply suggestions require internet and will return when you reconnect/i)
-    ).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
## Summary
- Consolidate 5+ simultaneous offline messages down to one concise global `ConnectivityBanner` ("You're offline. Text communication and browser speech still work.")
- Remove redundant inline offline notices from `TypingDock`, `TypingArea`, `PhrasesInterface` mobile dock, and `ReplySuggestions`
- Condense the boards-offline placeholder from a 3-line block to a single line ("Boards are unavailable offline.")
- Shorten action-triggered error messages (e.g. "Fix Text is unavailable offline.")
- `ReplySuggestions` now returns `null` when offline instead of rendering an amber message — disappearance is self-explanatory

## Test plan
- [ ] Go offline on mobile as a logged-in Pro user — verify only the global ConnectivityBanner and short boards placeholder appear (no duplicate warnings)
- [ ] Go offline on desktop — verify TypingArea no longer shows its own offline notice
- [ ] Tap Fix Text or Live Typing while offline — verify the shortened error messages appear
- [ ] Come back online — verify the "Connection restored" banner appears and auto-dismisses
- [ ] Verify reply suggestions silently disappear offline and reappear on reconnect

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Simplified offline messaging across the app for clearer communication when features are unavailable without internet.
  * Updated error messages for Live Typing, Fix Text, Boards, and Reply Suggestions to be more concise and consistent.
  * Removed redundant offline notification prompts to reduce UI clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->