### PR TITLE
Fix unused screen import lint warning

### DIFF
--- a/tests/components/typing/ReplySuggestions.test.tsx
+++ b/tests/components/typing/ReplySuggestions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import ReplySuggestions from '@/app/components/typing/ReplySuggestions';
 
 const mockUseOnlineStatus = jest.fn();


### PR DESCRIPTION
## Summary
- Remove unused `screen` import from ReplySuggestions test (leftover from #344)

## Test plan
- [x] `npx eslint .` passes with zero warnings
- [x] `npm test` — all 251 tests pass