### PR TITLE
Add optional ElevenLabs v3 high-quality voice mode

### DIFF
--- a/app/api/text-to-speech/route.ts
+++ b/app/api/text-to-speech/route.ts
@@ -19,7 +19,10 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { text, voiceId, stability, similarityBoost, streaming } = body;
+    const { text, voiceId, stability, similarityBoost, streaming, modelId: requestedModelId } = body;
+
+    const ALLOWED_MODELS = ['eleven_flash_v2_5', 'eleven_v3'];
+    const modelId = ALLOWED_MODELS.includes(requestedModelId) ? requestedModelId : 'eleven_flash_v2_5';
 
     if (!text) {
       return NextResponse.json(
@@ -43,7 +46,7 @@ export async function POST(request: Request) {
     if (streaming) {
       const audioStream = await client.textToSpeech.stream(voiceId, {
         text: text,
-        modelId: 'eleven_flash_v2_5',
+        modelId,
         voiceSettings: {
           stability: stability ?? 0.5,
           similarityBoost: similarityBoost ?? 0.5,

--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -256,6 +256,75 @@ export default function TTSSettings() {
         )}
       </div>
 
+      {/* Voice Quality Card (ElevenLabs only) */}
+      {settings.ttsProvider === 'elevenlabs' && hasSubscription && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium text-foreground">Voice Quality</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={() => updateSetting('ttsModelPreference', 'fast')}
+              className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
+                settings.ttsModelPreference === 'fast'
+                  ? 'border-primary-500 bg-primary-900'
+                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <div className={`w-4 h-4 mt-0.5 rounded-full border-2 flex-shrink-0 ${
+                  settings.ttsModelPreference === 'fast'
+                    ? 'border-primary-500 bg-primary-500'
+                    : 'border-text-tertiary'
+                }`}>
+                  {settings.ttsModelPreference === 'fast' && (
+                    <div className="w-full h-full flex items-center justify-center">
+                      <div className="w-1.5 h-1.5 bg-white rounded-full" />
+                    </div>
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <span className="block font-medium text-foreground text-sm">Fast</span>
+                  <span className="block text-xs text-text-secondary mt-0.5">Low latency</span>
+                </div>
+              </div>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => updateSetting('ttsModelPreference', 'high_quality')}
+              className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
+                settings.ttsModelPreference === 'high_quality'
+                  ? 'border-primary-500 bg-primary-900'
+                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <div className={`w-4 h-4 mt-0.5 rounded-full border-2 flex-shrink-0 ${
+                  settings.ttsModelPreference === 'high_quality'
+                    ? 'border-primary-500 bg-primary-500'
+                    : 'border-text-tertiary'
+                }`}>
+                  {settings.ttsModelPreference === 'high_quality' && (
+                    <div className="w-full h-full flex items-center justify-center">
+                      <div className="w-1.5 h-1.5 bg-white rounded-full" />
+                    </div>
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <span className="block font-medium text-foreground text-sm">High Quality</span>
+                  <span className="block text-xs text-text-secondary mt-0.5">More expressive</span>
+                </div>
+              </div>
+            </button>
+          </div>
+          <p className="text-xs text-text-tertiary px-1">
+            {settings.ttsModelPreference === 'high_quality'
+              ? 'Using ElevenLabs v3 for richer, more expressive speech. Latency will be higher.'
+              : 'Using ElevenLabs Flash for fastest response time.'}
+          </p>
+        </div>
+      )}
+
       {/* Voice Settings Card */}
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-foreground">Voice Settings</h3>

--- a/app/components/navigation/ConnectivityBanner.tsx
+++ b/app/components/navigation/ConnectivityBanner.tsx
@@ -48,7 +48,7 @@ export default function ConnectivityBanner() {
         )}
         <p>
           {isOfflineBanner
-            ? "You're offline. Text communication and browser speech still work."
+            ? 'You\'re offline. Text communication and browser speech still work.'
             : 'Connection restored. Online features are available again.'}
         </p>
       </div>

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -10,6 +10,7 @@ type TextSize = number;
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
 type TypingDockMode = 'expanded' | 'fullscreen' | 'minimized';
 type MessageCaptureMode = 'disabled' | 'clearOnly' | 'speakOnly' | 'speakAndClearOnly' | 'speakAny';
+type TTSModelPreference = 'fast' | 'high_quality';
 
 const DOUBLE_ENTER_TIMEOUT_MIN_MS = 1000;
 const DOUBLE_ENTER_TIMEOUT_MAX_MS = 10000;
@@ -28,6 +29,7 @@ interface Settings {
   ttsVoiceId: string;
   ttsStability: number;
   ttsSimilarityBoost: number;
+  ttsModelPreference: TTSModelPreference;
   aiReplySuggestionsEnabled: boolean;
   messageCaptureMode: MessageCaptureMode;
 }
@@ -66,6 +68,7 @@ const defaultSettings: Settings = {
   ttsVoiceId: '',
   ttsStability: 0.5,
   ttsSimilarityBoost: 0.5,
+  ttsModelPreference: 'fast',
   aiReplySuggestionsEnabled: true,
   messageCaptureMode: 'speakOnly',
 };
@@ -189,6 +192,7 @@ function saveToLocalStorage(allSettings: AllSettings) {
     ttsVoiceId: allSettings.ttsVoiceId,
     ttsStability: allSettings.ttsStability,
     ttsSimilarityBoost: allSettings.ttsSimilarityBoost,
+    ttsModelPreference: allSettings.ttsModelPreference,
     aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
     messageCaptureMode: allSettings.messageCaptureMode,
   };
@@ -264,6 +268,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         ttsVoiceId: localSettings.ttsVoiceId,
         ttsStability: localSettings.ttsStability,
         ttsSimilarityBoost: localSettings.ttsSimilarityBoost,
+        ttsModelPreference: localSettings.ttsModelPreference,
         aiReplySuggestionsEnabled: localSettings.aiReplySuggestionsEnabled,
         messageCaptureMode: localSettings.messageCaptureMode,
         typingAreaVisible: localSettings.typingAreaVisible,
@@ -299,6 +304,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         ttsVoiceId: convexSettings.ttsVoiceId,
         ttsStability: convexSettings.ttsStability,
         ttsSimilarityBoost: convexSettings.ttsSimilarityBoost,
+        ttsModelPreference: (convexSettings.ttsModelPreference as TTSModelPreference) ?? defaultSettings.ttsModelPreference,
         aiReplySuggestionsEnabled: convexSettings.aiReplySuggestionsEnabled ?? defaultSettings.aiReplySuggestionsEnabled,
         messageCaptureMode: convexSettings.messageCaptureMode ?? defaultSettings.messageCaptureMode,
         typingAreaVisible: convexSettings.typingAreaVisible,
@@ -396,6 +402,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     ttsVoiceId: allSettings.ttsVoiceId,
     ttsStability: allSettings.ttsStability,
     ttsSimilarityBoost: allSettings.ttsSimilarityBoost,
+    ttsModelPreference: allSettings.ttsModelPreference,
     aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
     messageCaptureMode: allSettings.messageCaptureMode,
   };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -86,6 +86,7 @@ export default defineSchema({
     ttsVoiceId: v.string(),
     ttsStability: v.number(),
     ttsSimilarityBoost: v.number(),
+    ttsModelPreference: v.optional(v.union(v.literal('fast'), v.literal('high_quality'))),
     aiReplySuggestionsEnabled: v.optional(v.boolean()),
     messageCaptureMode: v.optional(
       v.union(

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -36,6 +36,7 @@ export const initializeSettings = mutation({
     ttsVoiceId: v.string(),
     ttsStability: v.number(),
     ttsSimilarityBoost: v.number(),
+    ttsModelPreference: v.optional(v.union(v.literal('fast'), v.literal('high_quality'))),
     aiReplySuggestionsEnabled: v.boolean(),
     messageCaptureMode: v.union(v.literal('disabled'), v.literal('clearOnly'), v.literal('speakOnly'), v.literal('speakAndClearOnly'), v.literal('speakAny')),
     typingAreaVisible: v.boolean(),
@@ -104,6 +105,7 @@ export const initializeSettings = mutation({
       ttsVoiceId: args.ttsVoiceId,
       ttsStability: args.ttsStability,
       ttsSimilarityBoost: args.ttsSimilarityBoost,
+      ttsModelPreference: args.ttsModelPreference,
       aiReplySuggestionsEnabled: args.aiReplySuggestionsEnabled,
       messageCaptureMode: args.messageCaptureMode,
       typingAreaVisible: args.typingAreaVisible,
@@ -135,6 +137,7 @@ export const updateSettings = mutation({
     ttsVoiceId: v.optional(v.string()),
     ttsStability: v.optional(v.number()),
     ttsSimilarityBoost: v.optional(v.number()),
+    ttsModelPreference: v.optional(v.union(v.literal('fast'), v.literal('high_quality'))),
     aiReplySuggestionsEnabled: v.optional(v.boolean()),
     messageCaptureMode: v.optional(v.union(v.literal('disabled'), v.literal('clearOnly'), v.literal('speakOnly'), v.literal('speakAndClearOnly'), v.literal('speakAny'))),
     typingAreaVisible: v.optional(v.boolean()),
@@ -230,6 +233,7 @@ export const updateSettings = mutation({
     if (updates.ttsVoiceId !== undefined) updateData.ttsVoiceId = updates.ttsVoiceId;
     if (updates.ttsStability !== undefined) updateData.ttsStability = updates.ttsStability;
     if (updates.ttsSimilarityBoost !== undefined) updateData.ttsSimilarityBoost = updates.ttsSimilarityBoost;
+    if (updates.ttsModelPreference !== undefined) updateData.ttsModelPreference = updates.ttsModelPreference;
     if (updates.aiReplySuggestionsEnabled !== undefined) updateData.aiReplySuggestionsEnabled = updates.aiReplySuggestionsEnabled;
     if (updates.messageCaptureMode !== undefined) updateData.messageCaptureMode = updates.messageCaptureMode;
     if (updates.typingAreaVisible !== undefined) updateData.typingAreaVisible = updates.typingAreaVisible;

--- a/lib/elevenlabs-tts.ts
+++ b/lib/elevenlabs-tts.ts
@@ -184,6 +184,7 @@ export class ElevenLabsTTS {
     stability?: number;
     similarityBoost?: number;
     streaming?: boolean;
+    modelId?: string;
   }) {
     if (!this.isAvailableFlag) {
       if (!this.voicesLoaded) {
@@ -241,7 +242,7 @@ export class ElevenLabsTTS {
         return;
       }
 
-      // Call our Next.js API route with Flash v2.5 model
+      // Call our Next.js API route
       const response = await fetch('/api/text-to-speech', {
         method: 'POST',
         headers: {
@@ -253,6 +254,7 @@ export class ElevenLabsTTS {
           stability: stability,
           similarityBoost: similarityBoost,
           streaming: useStreaming,
+          modelId: options?.modelId,
         }),
         signal: this.abortController.signal,
       });

--- a/lib/hooks/useTTS.ts
+++ b/lib/hooks/useTTS.ts
@@ -85,6 +85,7 @@ export function useTTS() {
     volume?: number;
     stability?: number;
     similarityBoost?: number;
+    modelId?: string;
   }) => {
     if (!ttsRef.current || !isAvailable) {
       console.warn('TTS is not available');
@@ -93,13 +94,18 @@ export function useTTS() {
 
     // Merge settings with custom options, with custom options taking precedence
     const currentSettings = settingsRef.current;
+    const modelId = currentSettings.ttsModelPreference === 'high_quality'
+      ? 'eleven_v3'
+      : 'eleven_flash_v2_5';
+
     const options = {
       voiceId: customOptions?.voiceId || currentSettings.ttsVoiceId,
       rate: customOptions?.rate || currentSettings.speechRate,
       pitch: customOptions?.pitch || currentSettings.speechPitch,
       volume: customOptions?.volume || currentSettings.speechVolume,
       stability: customOptions?.stability || currentSettings.ttsStability,
-      similarityBoost: customOptions?.similarityBoost || currentSettings.ttsSimilarityBoost
+      similarityBoost: customOptions?.similarityBoost || currentSettings.ttsSimilarityBoost,
+      modelId: customOptions?.modelId || modelId,
     };
 
     // Check if current provider is ElevenLabs or the voice is an ElevenLabs voice

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -165,6 +165,7 @@ export class TTSProvider {
     volume?: number;
     stability?: number;
     similarityBoost?: number;
+    modelId?: string;
   }) {
     // Determine which provider to use based on the selected voice
     let provider = this.activeProvider;
@@ -200,7 +201,8 @@ export class TTSProvider {
       this.elevenlabsTTS.speak(text, {
         voiceId: voiceToUse,
         stability: options?.stability,
-        similarityBoost: options?.similarityBoost
+        similarityBoost: options?.similarityBoost,
+        modelId: options?.modelId,
       });
     } else {
       this.webSpeechTTS.speak(text, {


### PR DESCRIPTION
## Summary
- Add a **Voice Quality** selector in TTS settings for ElevenLabs Pro users: **Fast** (Flash v2.5, ~75ms latency) or **High Quality** (v3, more expressive)
- Fast remains the default — AAC users need low latency
- New `ttsModelPreference` setting flows through the full chain: SettingsContext → useTTS → TTSProvider → ElevenLabsTTS → API route
- API route validates `modelId` against an allowlist, defaulting to Flash if invalid

## Changes
| File | What |
|------|------|
| `convex/schema.ts` | Add `ttsModelPreference` field |
| `convex/userSettings.ts` | Add to init + update mutations |
| `app/contexts/SettingsContext.tsx` | Add to Settings type, defaults, localStorage, Convex sync |
| `app/api/text-to-speech/route.ts` | Accept `modelId`, validate against allowlist |
| `lib/elevenlabs-tts.ts` | Accept + pass `modelId` in speak options |
| `lib/tts-provider.ts` | Pass `modelId` through to ElevenLabs provider |
| `lib/hooks/useTTS.ts` | Resolve preference to model ID, pass to speak |
| `app/components/TTSSettings.tsx` | Voice Quality radio selector (ElevenLabs Pro only) |
| `app/components/navigation/ConnectivityBanner.tsx` | Fix pre-existing lint quote style |

## Test plan
- [ ] As a Pro user with ElevenLabs provider, open Settings → TTS → verify "Voice Quality" section appears with Fast/High Quality options
- [ ] Select "High Quality", speak text — verify it uses v3 (richer output, slightly higher latency)
- [ ] Switch back to "Fast", speak text — verify low-latency Flash response
- [ ] As a non-Pro user — verify Voice Quality section does not appear
- [ ] As a browser TTS user — verify Voice Quality section does not appear
- [ ] Verify setting persists across page reloads (localStorage) and across devices (Convex sync)
- [ ] All 251 tests pass, lint clean, build succeeds

Closes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice quality preference option for ElevenLabs text-to-speech, allowing users to choose between fast mode for lower latency and high quality mode for improved audio fidelity
  * Voice quality selection is now persisted in user settings across sessions

* **Style**
  * Updated text formatting in offline connectivity banner

<!-- end of auto-generated comment: release notes by coderabbit.ai -->