### PR TITLE
Add long-press Speak for tone control via v3 audio tags

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -12,7 +12,7 @@ import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { useLongPress } from '@/lib/hooks/useLongPress';
 import LiveTypingLinkModal from './live-typing/LiveTypingLinkModal';
-import ToneSheet from './typing/ToneSheet';
+import ToneSheet, { applyToneTag } from './typing/ToneSheet';
 import type { TonePreset } from './typing/ToneSheet';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import TabBar from './typing-tabs/TabBar';
@@ -269,7 +269,7 @@ export default function TypingArea({
 
   const handleSpeakWithTone = useCallback((tone: TonePreset) => {
     if (!text.trim()) return;
-    const taggedText = `${tone.tag} ${text}`;
+    const taggedText = applyToneTag(tone, text);
     speak(taggedText);
     onMessageCompleted?.({
       text,

--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -10,7 +10,10 @@ import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import { useLongPress } from '@/lib/hooks/useLongPress';
 import LiveTypingLinkModal from './live-typing/LiveTypingLinkModal';
+import ToneSheet from './typing/ToneSheet';
+import type { TonePreset } from './typing/ToneSheet';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import TabBar from './typing-tabs/TabBar';
 import TabManagementDialog from './typing-tabs/TabManagementDialog';
@@ -29,6 +32,7 @@ interface TypingAreaProps {
   onMessageCompleted?: (payload: { text: string; source: 'speak' | 'speakAndClear' | 'clear'; tabId?: string | null }) => void
   enableFixText?: boolean
   enableLiveTyping?: boolean
+  enableToneControl?: boolean
 }
 
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
@@ -41,11 +45,13 @@ export default function TypingArea({
   onMessageCompleted,
   enableFixText = true,
   enableLiveTyping = true,
+  enableToneControl = false,
 }: TypingAreaProps) {
   const [error, setError] = useState<string | null>(null);
   const [isFixingText, setIsFixingText] = useState(false);
   const [showLiveTypingModal, setShowLiveTypingModal] = useState(false);
   const [showTabManagementDialog, setShowTabManagementDialog] = useState(false);
+  const [showToneSheet, setShowToneSheet] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const prevExternalTextRef = useRef(externalText);
   const prevActiveTabIdRef = useRef<string | null>(null);
@@ -261,6 +267,29 @@ export default function TypingArea({
     }
   }, [activeTabId, isSpeaking, onMessageCompleted, speak, stop, text]);
 
+  const handleSpeakWithTone = useCallback((tone: TonePreset) => {
+    if (!text.trim()) return;
+    const taggedText = `${tone.tag} ${text}`;
+    speak(taggedText);
+    onMessageCompleted?.({
+      text,
+      source: 'speak',
+      tabId: activeTabId,
+    });
+    textareaRef.current?.focus();
+  }, [activeTabId, onMessageCompleted, speak, text]);
+
+  const speakLongPress = useLongPress({
+    delay: 500,
+    onPress: handleSpeak,
+    onLongPress: () => {
+      if (text.trim() && !isSpeaking) {
+        setShowToneSheet(true);
+      }
+    },
+    enabled: enableToneControl && !isSpeaking,
+  });
+
   const handleFixText = async () => {
     if (!text.trim() || isFixingText) return;
     if (!isOnline) {
@@ -422,14 +451,14 @@ export default function TypingArea({
           {text.trim() && (
             <div className="flex flex-wrap gap-2 p-4 bg-surface-hover transition-colors duration-200">
               <button
-                onClick={handleSpeak}
+                {...(enableToneControl ? speakLongPress : { onClick: handleSpeak })}
                 className={`flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 ${
                   isSpeaking
                     ? 'bg-gradient-to-r from-red-500 to-red-600 text-white'
                     : 'bg-surface hover:bg-surface-hover text-foreground hover:text-primary-500'
                 }`}
                 data-tooltip-id="speak-tooltip"
-                data-tooltip-content={isSpeaking ? 'Stop speaking' : 'Speak text'}
+                data-tooltip-content={isSpeaking ? 'Stop speaking' : enableToneControl ? 'Speak text (hold for tone)' : 'Speak text'}
                 disabled={!isAvailable || (!isSpeaking && !text.trim())}
               >
                 {isSpeaking ? (
@@ -606,6 +635,16 @@ export default function TypingArea({
             onChange?.('');
           }}
           onRenameTab={renameTab}
+        />
+      )}
+
+      {/* Tone Control Sheet */}
+      {enableToneControl && (
+        <ToneSheet
+          isOpen={showToneSheet}
+          onClose={() => setShowToneSheet(false)}
+          onSelectTone={handleSpeakWithTone}
+          onSpeakWithoutTone={handleSpeak}
         />
       )}
     </div>

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -23,7 +23,7 @@ import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { useLongPress } from '@/lib/hooks/useLongPress';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import ReplySuggestions from './typing/ReplySuggestions';
-import ToneSheet from './typing/ToneSheet';
+import ToneSheet, { applyToneTag } from './typing/ToneSheet';
 import type { TonePreset } from './typing/ToneSheet';
 import SubscriptionWrapper from './SubscriptionWrapper';
 import LiveTypingBottomSheet from './live-typing/LiveTypingBottomSheet';
@@ -259,7 +259,7 @@ export default function TypingDock({
 
   const handleToneSelected = useCallback((tone: TonePreset) => {
     if (!currentText.trim()) return;
-    onSpeakWithTone?.(`${tone.tag} ${currentText}`);
+    onSpeakWithTone?.(applyToneTag(tone, currentText));
   }, [currentText, onSpeakWithTone]);
 
   const speakLongPress = useLongPress({

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -20,8 +20,11 @@ import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import { useLongPress } from '@/lib/hooks/useLongPress';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import ReplySuggestions from './typing/ReplySuggestions';
+import ToneSheet from './typing/ToneSheet';
+import type { TonePreset } from './typing/ToneSheet';
 import SubscriptionWrapper from './SubscriptionWrapper';
 import LiveTypingBottomSheet from './live-typing/LiveTypingBottomSheet';
 import MobileTabIndicator from './typing-tabs/MobileTabIndicator';
@@ -38,6 +41,7 @@ interface TypingDockProps {
   text: string;
   onChange: (text: string) => void;
   onSpeak: (source?: 'speak' | 'speakAndClear') => void;
+  onSpeakWithTone?: (toneTag: string) => void;
   onMessageCompleted?: (payload: { text: string; source: 'clear'; tabId?: string | null }) => void;
   onStop?: () => void;
   isSpeaking?: boolean;
@@ -47,6 +51,7 @@ interface TypingDockProps {
   enableTabs?: boolean;
   enableLiveTyping?: boolean;
   enableFixText?: boolean;
+  enableToneControl?: boolean;
   replySuggestions?: ReplySuggestionsConfig;
 }
 
@@ -56,6 +61,7 @@ export default function TypingDock({
   text,
   onChange,
   onSpeak,
+  onSpeakWithTone,
   onMessageCompleted,
   onStop,
   isSpeaking = false,
@@ -64,12 +70,14 @@ export default function TypingDock({
   enableTabs = false,
   enableLiveTyping = false,
   enableFixText = false,
+  enableToneControl = false,
   replySuggestions,
 }: TypingDockProps) {
   const [isFixingText, setIsFixingText] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showLiveTypingSheet, setShowLiveTypingSheet] = useState(false);
   const [showTabList, setShowTabList] = useState(false);
+  const [showToneSheet, setShowToneSheet] = useState(false);
   const { top: viewportTop, height: viewportHeight } = useVisualViewport();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -247,6 +255,22 @@ export default function TypingDock({
     timeoutMs: settings.doubleEnterTimeoutMs,
     onSingleEnter: () => runEnterAction(settings.enterKeyBehavior),
     onDoubleEnter: () => runEnterAction(settings.doubleEnterAction),
+  });
+
+  const handleToneSelected = useCallback((tone: TonePreset) => {
+    if (!currentText.trim()) return;
+    onSpeakWithTone?.(`${tone.tag} ${currentText}`);
+  }, [currentText, onSpeakWithTone]);
+
+  const speakLongPress = useLongPress({
+    delay: 500,
+    onPress: isSpeaking ? onStop : () => onSpeak('speak'),
+    onLongPress: () => {
+      if (currentText.trim() && !isSpeaking) {
+        setShowToneSheet(true);
+      }
+    },
+    enabled: enableToneControl && !isSpeaking,
   });
 
   const showDoubleEnterHint = settings.doubleEnterEnabled && isPending;
@@ -624,7 +648,7 @@ export default function TypingDock({
 
               {/* Speak/Stop button - primary CTA */}
               <motion.button
-                onClick={isSpeaking ? onStop : () => onSpeak('speak')}
+                {...(enableToneControl ? speakLongPress : { onClick: isSpeaking ? onStop : () => onSpeak('speak') })}
                 disabled={!isAvailable || (!isSpeaking && !currentText.trim())}
                 className={`flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
                   isSpeaking
@@ -632,7 +656,7 @@ export default function TypingDock({
                     : 'bg-primary-500 hover:bg-primary-600 text-white'
                 }`}
                 whileTap={{ scale: 0.95 }}
-                aria-label={isSpeaking ? 'Stop' : 'Speak'}
+                aria-label={isSpeaking ? 'Stop' : enableToneControl ? 'Speak (hold for tone)' : 'Speak'}
               >
                 {isSpeaking ? (
                   <>
@@ -702,6 +726,16 @@ export default function TypingDock({
             onChange('');
           }}
           onRenameTab={renameTab}
+        />
+      )}
+
+      {/* Tone Control Sheet */}
+      {enableToneControl && (
+        <ToneSheet
+          isOpen={showToneSheet}
+          onClose={() => setShowToneSheet(false)}
+          onSelectTone={handleToneSelected}
+          onSpeakWithoutTone={() => onSpeak('speak')}
         />
       )}
     </>

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -301,6 +301,10 @@ export default function PhrasesInterface() {
     };
   }, [activeTabId, localRecentMessages, recentMessages]);
 
+  const enableToneControl = isOnline
+    && settings.ttsProvider === 'elevenlabs'
+    && settings.ttsModelPreference === 'high_quality';
+
   return (
     <>
       {/* Desktop: TypingArea at top */}
@@ -314,6 +318,7 @@ export default function PhrasesInterface() {
             onMessageCompleted={(payload) => {
               void handleCaptureCompletedMessage(payload);
             }}
+            enableToneControl={enableToneControl}
           />
           <div className="px-2 pb-2">
             {captureError && settings.aiReplySuggestionsEnabled && (
@@ -480,6 +485,15 @@ export default function PhrasesInterface() {
             enableTabs={true}
             enableLiveTyping={!!user}
             enableFixText={true}
+            enableToneControl={enableToneControl}
+            onSpeakWithTone={(taggedText) => {
+              tts.speak(taggedText);
+              void handleCaptureCompletedMessage({
+                text: typingText,
+                source: 'speak',
+                tabId: activeTabId,
+              });
+            }}
             replySuggestions={{
               history: suggestionContext.history,
               enabled: settings.aiReplySuggestionsEnabled,

--- a/app/components/typing/ToneSheet.tsx
+++ b/app/components/typing/ToneSheet.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { SpeakerWaveIcon } from '@heroicons/react/24/outline';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+import { useIsMobile } from '@/lib/hooks/useIsMobile';
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment } from 'react';
+
+export interface TonePreset {
+  id: string;
+  label: string;
+  tag: string;
+  description: string;
+}
+
+export const TONE_PRESETS: TonePreset[] = [
+  { id: 'calm', label: 'Calm', tag: '[calmly]', description: 'Relaxed and gentle' },
+  { id: 'excited', label: 'Excited', tag: '[excited]', description: 'Energetic and enthusiastic' },
+  { id: 'whisper', label: 'Whisper', tag: '[whispers]', description: 'Soft and quiet' },
+  { id: 'sad', label: 'Sad', tag: '[sadly]', description: 'Somber and low' },
+  { id: 'angry', label: 'Angry', tag: '[angrily]', description: 'Forceful and intense' },
+  { id: 'cheerful', label: 'Cheerful', tag: '[cheerfully]', description: 'Bright and happy' },
+];
+
+interface ToneSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectTone: (tone: TonePreset) => void;
+  onSpeakWithoutTone: () => void;
+}
+
+function ToneOptions({ onSelectTone, onSpeakWithoutTone, onClose }: Omit<ToneSheetProps, 'isOpen'>) {
+  return (
+    <div className="p-4 space-y-3">
+      <button
+        type="button"
+        onClick={() => {
+          onSpeakWithoutTone();
+          onClose();
+        }}
+        className="w-full flex items-center gap-3 px-4 py-3 rounded-2xl bg-primary-500 hover:bg-primary-600 text-white font-medium transition-colors"
+      >
+        <SpeakerWaveIcon className="w-5 h-5 shrink-0" />
+        <div className="text-left">
+          <span className="block text-sm font-medium">Speak normally</span>
+          <span className="block text-xs opacity-80">No tone applied</span>
+        </div>
+      </button>
+
+      <div className="grid grid-cols-2 gap-2">
+        {TONE_PRESETS.map((tone) => (
+          <button
+            key={tone.id}
+            type="button"
+            onClick={() => {
+              onSelectTone(tone);
+              onClose();
+            }}
+            className="flex flex-col items-start px-4 py-3 rounded-2xl bg-surface-hover hover:bg-surface text-left transition-colors border border-border hover:border-primary-500"
+          >
+            <span className="text-sm font-medium text-foreground">{tone.label}</span>
+            <span className="text-xs text-text-secondary">{tone.description}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function ToneSheet({ isOpen, onClose, onSelectTone, onSpeakWithoutTone }: ToneSheetProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        isOpen={isOpen}
+        onClose={onClose}
+        title="How should this sound?"
+        snapPoints={[45]}
+        showHandle={true}
+        showCloseButton={true}
+      >
+        <ToneOptions
+          onSelectTone={onSelectTone}
+          onSpeakWithoutTone={onSpeakWithoutTone}
+          onClose={onClose}
+        />
+      </BottomSheet>
+    );
+  }
+
+  // Desktop: centered dialog
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-sm rounded-3xl bg-surface shadow-2xl">
+                <Dialog.Title className="text-lg font-semibold text-foreground px-4 pt-4 pb-2">
+                  How should this sound?
+                </Dialog.Title>
+                <ToneOptions
+                  onSelectTone={onSelectTone}
+                  onSpeakWithoutTone={onSpeakWithoutTone}
+                  onClose={onClose}
+                />
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/app/components/typing/ToneSheet.tsx
+++ b/app/components/typing/ToneSheet.tsx
@@ -10,7 +10,17 @@ export interface TonePreset {
   id: string;
   label: string;
   tag: string;
+  /** Where to place the tag relative to the text (default 'before') */
+  position?: 'before' | 'after';
   description: string;
+}
+
+/** Apply a tone preset tag to text, respecting the tag position. */
+export function applyToneTag(tone: TonePreset, text: string): string {
+  if (tone.position === 'after') {
+    return `${text} ${tone.tag}`;
+  }
+  return `${tone.tag} ${text}`;
 }
 
 export const TONE_PRESETS: TonePreset[] = [
@@ -20,6 +30,8 @@ export const TONE_PRESETS: TonePreset[] = [
   { id: 'sad', label: 'Sad', tag: '[sadly]', description: 'Somber and low' },
   { id: 'angry', label: 'Angry', tag: '[angrily]', description: 'Forceful and intense' },
   { id: 'cheerful', label: 'Cheerful', tag: '[cheerfully]', description: 'Bright and happy' },
+  { id: 'sigh-before', label: 'Sigh (before)', tag: '[sighs]', position: 'before', description: 'Sigh, then speak' },
+  { id: 'sigh-after', label: 'Sigh (after)', tag: '[sighs]', position: 'after', description: 'Speak, then sigh' },
 ];
 
 interface ToneSheetProps {
@@ -76,7 +88,7 @@ export default function ToneSheet({ isOpen, onClose, onSelectTone, onSpeakWithou
         isOpen={isOpen}
         onClose={onClose}
         title="How should this sound?"
-        snapPoints={[45]}
+        snapPoints={[55]}
         showHandle={true}
         showCloseButton={true}
       >

--- a/lib/hooks/useLongPress.ts
+++ b/lib/hooks/useLongPress.ts
@@ -1,0 +1,75 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+interface UseLongPressOptions {
+  /** Delay in ms before long press fires (default 500) */
+  delay?: number;
+  /** Called on normal tap/click (short press) */
+  onPress?: () => void;
+  /** Called when a long press is detected */
+  onLongPress?: () => void;
+  /** Whether the long press is enabled (default true) */
+  enabled?: boolean;
+}
+
+/**
+ * Hook that distinguishes between short press (tap/click) and long press.
+ *
+ * Returns event handlers for touch and mouse events. When `enabled` is false,
+ * `onPress` fires immediately on click and long-press detection is skipped.
+ */
+export function useLongPress({
+  delay = 500,
+  onPress,
+  onLongPress,
+  enabled = true,
+}: UseLongPressOptions) {
+  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const isLongPress = useRef(false);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+      }
+    };
+  }, []);
+
+  const startPress = useCallback(() => {
+    if (!enabled || !onLongPress) return;
+
+    isLongPress.current = false;
+    longPressTimer.current = setTimeout(() => {
+      isLongPress.current = true;
+      if (navigator.vibrate) {
+        navigator.vibrate(50);
+      }
+      onLongPress();
+    }, delay);
+  }, [delay, enabled, onLongPress]);
+
+  const endPress = useCallback(() => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (isLongPress.current) {
+      isLongPress.current = false;
+      return;
+    }
+    onPress?.();
+  }, [onPress]);
+
+  return {
+    onTouchStart: startPress,
+    onTouchEnd: endPress,
+    onTouchCancel: endPress,
+    onMouseDown: startPress,
+    onMouseUp: endPress,
+    onMouseLeave: endPress,
+    onClick: handleClick,
+  };
+}


### PR DESCRIPTION
## Summary
- **Long-press the Speak button** to open a tone selection sheet before speaking
- **Normal tap** speaks immediately — zero friction change to the existing flow
- 6 tone presets: Calm, Excited, Whisper, Sad, Angry, Cheerful — mapped to ElevenLabs v3 audio tags
- Bottom sheet on mobile, centered dialog on desktop
- Audio tag is prepended at speak-time only — does NOT modify the text in the typing area
- Gated behind: ElevenLabs provider + High Quality (v3) model + online

## New files
| File | Purpose |
|------|---------|
| `lib/hooks/useLongPress.ts` | Reusable hook: distinguishes tap vs long-press with haptic feedback |
| `app/components/typing/ToneSheet.tsx` | Tone preset UI — uses existing BottomSheet (mobile) and Headless UI Dialog (desktop) |

## Changed files
| File | What |
|------|------|
| `TypingDock.tsx` | Long-press on Speak button, `enableToneControl` + `onSpeakWithTone` props, ToneSheet rendering |
| `TypingArea.tsx` | Long-press on Speak button, `enableToneControl` prop, inline tone-tagged speak, ToneSheet rendering |
| `PhrasesInterface.tsx` | Computes `enableToneControl` gate, passes to both TypingDock and TypingArea |

## Test plan
- [ ] As a Pro user with ElevenLabs + High Quality: long-press Speak → tone sheet opens with 6 presets + "Speak normally"
- [ ] Select a tone (e.g. Whisper) → text is spoken with `[whispers]` tag, typing area text unchanged
- [ ] Tap "Speak normally" → speaks without tone tag
- [ ] Normal short tap on Speak → speaks immediately, no sheet
- [ ] As browser TTS user or Fast model → long-press has no effect, normal tap works
- [ ] On desktop: tone dialog appears centered
- [ ] On mobile: tone bottom sheet slides up, drag-to-close works
- [ ] All 251 tests pass, lint clean, build succeeds

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tone selection for text-to-speech: long-press the Speak button to choose from multiple tone presets (or tap to speak normally).
  * Speak button tooltip/label updated to indicate "hold for tone" when tone control is available.
  * Tone selection UI available on desktop and mobile; includes "speak normally" fallback.
  * Tone control is enabled only when online and using the high-quality TTS provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->