### PR TITLE
Replace long-press Speak with split button for tone control

### DIFF
--- a/app/components/TypingArea.tsx
+++ b/app/components/TypingArea.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { XMarkIcon, ChevronUpIcon, ChevronDownIcon, ArrowPathIcon, SparklesIcon, ArrowsPointingOutIcon, ArrowsPointingInIcon, ShareIcon, StopIcon, SpeakerWaveIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, ChevronUpIcon, ChevronDownIcon, ArrowPathIcon, SparklesIcon, ArrowsPointingOutIcon, ArrowsPointingInIcon, ShareIcon } from '@heroicons/react/24/outline';
 import { Tooltip } from 'react-tooltip';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -10,9 +10,9 @@ import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
 import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
-import { useLongPress } from '@/lib/hooks/useLongPress';
 import LiveTypingLinkModal from './live-typing/LiveTypingLinkModal';
-import ToneSheet, { applyToneTag } from './typing/ToneSheet';
+import SpeakButton from './typing/SpeakButton';
+import { applyToneTag } from './typing/ToneSheet';
 import type { TonePreset } from './typing/ToneSheet';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import TabBar from './typing-tabs/TabBar';
@@ -53,7 +53,6 @@ export default function TypingArea({
   const [isFixingText, setIsFixingText] = useState(false);
   const [showLiveTypingModal, setShowLiveTypingModal] = useState(false);
   const [showTabManagementDialog, setShowTabManagementDialog] = useState(false);
-  const [showToneSheet, setShowToneSheet] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const prevExternalTextRef = useRef(externalText);
   const prevActiveTabIdRef = useRef<string | null>(null);
@@ -281,17 +280,6 @@ export default function TypingArea({
     textareaRef.current?.focus();
   }, [activeTabId, onMessageCompleted, speak, text]);
 
-  const speakLongPress = useLongPress({
-    delay: 500,
-    onPress: handleSpeak,
-    onLongPress: () => {
-      if (text.trim() && !isSpeaking) {
-        setShowToneSheet(true);
-      }
-    },
-    enabled: enableToneControl && !isSpeaking,
-  });
-
   const handleFixText = async () => {
     if (!text.trim() || isFixingText) return;
     if (!isOnline) {
@@ -454,29 +442,15 @@ export default function TypingArea({
           </div>
           {text.trim() && (
             <div className="flex flex-wrap gap-2 p-4 bg-surface-hover transition-colors duration-200">
-              <button
-                {...(enableToneControl ? speakLongPress : { onClick: handleSpeak })}
-                className={`flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 ${
-                  isSpeaking
-                    ? 'bg-gradient-to-r from-red-500 to-red-600 text-white'
-                    : 'bg-surface hover:bg-surface-hover text-foreground hover:text-primary-500'
-                }`}
-                data-tooltip-id="speak-tooltip"
-                data-tooltip-content={isSpeaking ? 'Stop speaking' : enableToneControl ? 'Speak text (hold for tone)' : 'Speak text'}
-                disabled={!isAvailable || (!isSpeaking && !text.trim())}
-              >
-                {isSpeaking ? (
-                  <>
-                    <StopIcon className="w-5 h-5" />
-                    <span>Stop</span>
-                  </>
-                ) : (
-                  <>
-                    <SpeakerWaveIcon className="w-5 h-5" />
-                    <span>Speak</span>
-                  </>
-                )}
-              </button>
+              <SpeakButton
+                variant="area"
+                onSpeak={handleSpeak}
+                onStop={() => stop()}
+                onSelectTone={handleSpeakWithTone}
+                isSpeaking={isSpeaking}
+                disabled={!isAvailable || !text.trim()}
+                enableToneControl={enableToneControl}
+              />
               {enableFixText && (
                 !isOnline ? (
                   <button
@@ -642,15 +616,6 @@ export default function TypingArea({
         />
       )}
 
-      {/* Tone Control Sheet */}
-      {enableToneControl && (
-        <ToneSheet
-          isOpen={showToneSheet}
-          onClose={() => setShowToneSheet(false)}
-          onSelectTone={handleSpeakWithTone}
-          onSpeakWithoutTone={handleSpeak}
-        />
-      )}
     </div>
   );
 }

--- a/app/components/TypingDock.tsx
+++ b/app/components/TypingDock.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import {
-  SpeakerWaveIcon,
   SparklesIcon,
   XMarkIcon,
   ArrowPathIcon,
@@ -11,7 +10,6 @@ import {
   ArrowsPointingOutIcon,
   ArrowsPointingInIcon,
   MinusIcon,
-  StopIcon,
 } from '@heroicons/react/24/outline';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -20,10 +18,10 @@ import { useDoubleEnter } from '@/lib/hooks/useDoubleEnter';
 import { useUndoClear } from '@/lib/hooks/useUndoClear';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
-import { useLongPress } from '@/lib/hooks/useLongPress';
 import { useTypingTabs } from './typing-tabs/useTypingTabs';
 import ReplySuggestions from './typing/ReplySuggestions';
-import ToneSheet, { applyToneTag } from './typing/ToneSheet';
+import SpeakButton from './typing/SpeakButton';
+import { applyToneTag } from './typing/ToneSheet';
 import type { TonePreset } from './typing/ToneSheet';
 import SubscriptionWrapper from './SubscriptionWrapper';
 import LiveTypingBottomSheet from './live-typing/LiveTypingBottomSheet';
@@ -77,7 +75,6 @@ export default function TypingDock({
   const [error, setError] = useState<string | null>(null);
   const [showLiveTypingSheet, setShowLiveTypingSheet] = useState(false);
   const [showTabList, setShowTabList] = useState(false);
-  const [showToneSheet, setShowToneSheet] = useState(false);
   const { top: viewportTop, height: viewportHeight } = useVisualViewport();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -261,17 +258,6 @@ export default function TypingDock({
     if (!currentText.trim()) return;
     onSpeakWithTone?.(applyToneTag(tone, currentText));
   }, [currentText, onSpeakWithTone]);
-
-  const speakLongPress = useLongPress({
-    delay: 500,
-    onPress: isSpeaking ? onStop : () => onSpeak('speak'),
-    onLongPress: () => {
-      if (currentText.trim() && !isSpeaking) {
-        setShowToneSheet(true);
-      }
-    },
-    enabled: enableToneControl && !isSpeaking,
-  });
 
   const showDoubleEnterHint = settings.doubleEnterEnabled && isPending;
   const doubleEnterActionLabel: Record<EnterKeyBehavior, string> = {
@@ -646,29 +632,15 @@ export default function TypingDock({
               <div className="flex-1" />
 
               {/* Speak/Stop button - primary CTA */}
-              <motion.button
-                {...(enableToneControl ? speakLongPress : { onClick: isSpeaking ? onStop : () => onSpeak('speak') })}
-                disabled={!isAvailable || (!isSpeaking && !currentText.trim())}
-                className={`flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg ${
-                  isSpeaking
-                    ? 'bg-gradient-to-r from-red-500 to-red-600 text-white'
-                    : 'bg-primary-500 hover:bg-primary-600 text-white'
-                }`}
-                whileTap={{ scale: 0.95 }}
-                aria-label={isSpeaking ? 'Stop' : enableToneControl ? 'Speak (hold for tone)' : 'Speak'}
-              >
-                {isSpeaking ? (
-                  <>
-                    <StopIcon className="w-5 h-5" />
-                    <span>Stop</span>
-                  </>
-                ) : (
-                  <>
-                    <SpeakerWaveIcon className="w-5 h-5" />
-                    <span>Speak</span>
-                  </>
-                )}
-              </motion.button>
+              <SpeakButton
+                variant="dock"
+                onSpeak={() => onSpeak('speak')}
+                onStop={onStop}
+                onSelectTone={handleToneSelected}
+                isSpeaking={isSpeaking}
+                disabled={!isAvailable || !currentText.trim()}
+                enableToneControl={enableToneControl}
+              />
             </div>
           </motion.div>
         </div>
@@ -728,15 +700,6 @@ export default function TypingDock({
         />
       )}
 
-      {/* Tone Control Sheet */}
-      {enableToneControl && (
-        <ToneSheet
-          isOpen={showToneSheet}
-          onClose={() => setShowToneSheet(false)}
-          onSelectTone={handleToneSelected}
-          onSpeakWithoutTone={() => onSpeak('speak')}
-        />
-      )}
     </>
   );
 }

--- a/app/components/typing/SpeakButton.tsx
+++ b/app/components/typing/SpeakButton.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import { SpeakerWaveIcon, StopIcon } from '@heroicons/react/24/outline';
+import { AudioWaveform } from 'lucide-react';
+import { motion } from 'framer-motion';
+import ToneSheet from './ToneSheet';
+import type { TonePreset } from './ToneSheet';
+
+interface SpeakButtonProps {
+  onSpeak: () => void;
+  onStop?: () => void;
+  onSelectTone: (tone: TonePreset) => void;
+  isSpeaking: boolean;
+  disabled: boolean;
+  enableToneControl: boolean;
+  /** 'dock' for mobile TypingDock styling, 'area' for desktop TypingArea styling */
+  variant: 'dock' | 'area';
+}
+
+export default function SpeakButton({
+  onSpeak,
+  onStop,
+  onSelectTone,
+  isSpeaking,
+  disabled,
+  enableToneControl,
+  variant,
+}: SpeakButtonProps) {
+  const [showToneSheet, setShowToneSheet] = useState(false);
+
+  // Speaking state — full Stop button, no split
+  if (isSpeaking) {
+    if (variant === 'dock') {
+      return (
+        <motion.button
+          onClick={onStop}
+          className="flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 shadow-lg bg-gradient-to-r from-red-500 to-red-600 text-white"
+          whileTap={{ scale: 0.95 }}
+          aria-label="Stop"
+        >
+          <StopIcon className="w-5 h-5" />
+          <span>Stop</span>
+        </motion.button>
+      );
+    }
+
+    return (
+      <button
+        onClick={onStop}
+        className="flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md bg-gradient-to-r from-red-500 to-red-600 text-white"
+        aria-label="Stop"
+      >
+        <StopIcon className="w-5 h-5" />
+        <span>Stop</span>
+      </button>
+    );
+  }
+
+  // Not speaking, tone control enabled — split button
+  if (enableToneControl) {
+    if (variant === 'dock') {
+      return (
+        <>
+          <div className={`flex items-center rounded-full shadow-lg overflow-hidden ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}>
+            <motion.button
+              onClick={onSpeak}
+              disabled={disabled}
+              className="flex items-center gap-2 pl-6 pr-4 py-3 font-semibold transition-colors duration-200 bg-primary-500 hover:bg-primary-600 text-white disabled:cursor-not-allowed"
+              whileTap={disabled ? undefined : { scale: 0.97 }}
+              aria-label="Speak"
+            >
+              <SpeakerWaveIcon className="w-5 h-5" />
+              <span>Speak</span>
+            </motion.button>
+            <div className="w-px h-6 bg-white/20 shrink-0" />
+            <motion.button
+              onClick={() => setShowToneSheet(true)}
+              disabled={disabled}
+              className="flex items-center px-3 py-3 transition-colors duration-200 bg-primary-500 hover:bg-primary-600 text-white disabled:cursor-not-allowed"
+              whileTap={disabled ? undefined : { scale: 0.97 }}
+              aria-label="Choose tone"
+            >
+              <AudioWaveform className="w-4 h-4" />
+            </motion.button>
+          </div>
+          <ToneSheet
+            isOpen={showToneSheet}
+            onClose={() => setShowToneSheet(false)}
+            onSelectTone={onSelectTone}
+            onSpeakWithoutTone={() => {
+              onSpeak();
+              setShowToneSheet(false);
+            }}
+          />
+        </>
+      );
+    }
+
+    // Area variant — desktop split button
+    return (
+      <>
+        <div className={`flex items-center rounded-full shadow-md overflow-hidden flex-1 min-w-[140px] h-12 ${disabled ? 'opacity-40 cursor-not-allowed' : 'hover:shadow-lg hover:scale-105'} transition-all duration-200`}>
+          <button
+            onClick={onSpeak}
+            disabled={disabled}
+            className="flex-1 h-full flex items-center justify-center gap-2 font-medium bg-surface hover:bg-surface-hover text-foreground hover:text-primary-500 transition-colors duration-200 disabled:cursor-not-allowed"
+            aria-label="Speak"
+          >
+            <SpeakerWaveIcon className="w-5 h-5" />
+            <span>Speak</span>
+          </button>
+          <div className="w-px h-6 bg-border shrink-0" />
+          <button
+            onClick={() => setShowToneSheet(true)}
+            disabled={disabled}
+            className="h-full flex items-center px-3 bg-surface hover:bg-surface-hover text-foreground hover:text-primary-500 transition-colors duration-200 disabled:cursor-not-allowed"
+            aria-label="Choose tone"
+          >
+            <AudioWaveform className="w-4 h-4" />
+          </button>
+        </div>
+        <ToneSheet
+          isOpen={showToneSheet}
+          onClose={() => setShowToneSheet(false)}
+          onSelectTone={onSelectTone}
+          onSpeakWithoutTone={() => {
+            onSpeak();
+            setShowToneSheet(false);
+          }}
+        />
+      </>
+    );
+  }
+
+  // No tone control — plain button
+  if (variant === 'dock') {
+    return (
+      <motion.button
+        onClick={onSpeak}
+        disabled={disabled}
+        className="flex items-center gap-2 px-6 py-3 rounded-full font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed shadow-lg bg-primary-500 hover:bg-primary-600 text-white"
+        whileTap={{ scale: 0.95 }}
+        aria-label="Speak"
+      >
+        <SpeakerWaveIcon className="w-5 h-5" />
+        <span>Speak</span>
+      </motion.button>
+    );
+  }
+
+  return (
+    <button
+      onClick={onSpeak}
+      disabled={disabled}
+      className="flex-1 min-w-[140px] h-12 rounded-full transition-all duration-200 flex items-center justify-center gap-2 font-medium shadow-md hover:shadow-lg hover:scale-105 bg-surface hover:bg-surface-hover text-foreground hover:text-primary-500 disabled:opacity-40 disabled:cursor-not-allowed"
+      aria-label="Speak"
+    >
+      <SpeakerWaveIcon className="w-5 h-5" />
+      <span>Speak</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- **New `SpeakButton` component** — a split button with two joined sections:
  - Left: 🔊 Speak (taps to speak immediately)
  - Right: ∿ AudioWaveform icon (taps to open ToneSheet)
- When speaking → full-width Stop button (no split)
- When tone disabled → plain Speak button (no split)
- Two variants: `dock` (mobile styling) and `area` (desktop styling)
- Component manages its own ToneSheet state — consumers are simpler

## Before → After
```
Before: Long-press Speak → undiscoverable tone sheet
After:  ┌──────────┬─────┐
        │ 🔊 Speak │ ∿∿  │  ← visible, tappable
        └──────────┴─────┘
```

## Changes
| File | What |
|------|------|
| `app/components/typing/SpeakButton.tsx` | **New** — self-contained split button |
| `app/components/TypingDock.tsx` | Remove useLongPress, showToneSheet, ToneSheet → use SpeakButton |
| `app/components/TypingArea.tsx` | Same simplification |

## Test plan
- [ ] ElevenLabs v3 mode: split button visible with waveform icon; tap left speaks, tap right opens ToneSheet
- [ ] Select tone → speaks with audio tag applied
- [ ] While speaking: full Stop button, no split
- [ ] Browser TTS or Flash model: plain Speak button, no waveform icon
- [ ] All 251 tests pass, lint clean, build succeeds

Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated speech and tone control UI into a dedicated component for improved code organization and maintainability across the typing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->