### PR TITLE
Fix: MobileTabList never opens in Composer (#360)

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -312,7 +312,7 @@ export default function Composer({
               onTabClose={closeTab}
               onTabCreate={createTab}
               onTabRename={renameTab}
-              onManage={() => setShowTabManagement(true)}
+              onManage={() => isMobile ? setShowTabList(true) : setShowTabManagement(true)}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary

- `onManage` in `TabBar` was always calling `setShowTabManagement(true)`, routing to the desktop `TabManagementDialog` and leaving `showTabList` permanently `false`
- On mobile, it now calls `setShowTabList(true)` to open `MobileTabList` instead

## Test plan

- [ ] On mobile, tap the manage tabs (list) icon in the tab bar — `MobileTabList` should open
- [ ] Tab switching, closing, renaming, and creating all work from the mobile list
- [ ] On desktop, the manage icon still opens `TabManagementDialog`

Closes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab management experience with platform-specific behavior: mobile users now see an optimized tab list interface, while desktop users access the standard management dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->