### PR TITLE
Fix: Live Typing modal doesn't open on first click (#361)

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -285,8 +285,8 @@ export default function Composer({
       else setShowLiveTypingModal(true);
       return;
     }
-    await createSession();
-    if (isSharing) {
+    const created = await createSession();
+    if (created) {
       updateContent(currentText);
       if (isMobile) setShowLiveTypingSheet(true);
       else setShowLiveTypingModal(true);
@@ -468,7 +468,7 @@ export default function Composer({
           isSharing={isSharing}
           isCreating={isCreating}
           shareableLink={shareableLink}
-          onStartSharing={async () => { await createSession(); if (isSharing) updateContent(currentText); }}
+          onStartSharing={async () => { const created = await createSession(); if (created) updateContent(currentText); }}
           onEndSession={async () => { await endSession(); }}
         />
       )}

--- a/lib/hooks/useLiveTyping.ts
+++ b/lib/hooks/useLiveTyping.ts
@@ -74,7 +74,7 @@ export function useLiveTyping() {
     }
   }, [sessionFromConvex, sessionKey]);
 
-  const createSession = useCallback(async () => {
+  const createSession = useCallback(async (): Promise<boolean> => {
     setIsCreating(true);
     setError(null);
 
@@ -99,9 +99,11 @@ export function useLiveTyping() {
         expiresAt: created.expiresAt,
         _creationTime: created._creationTime,
       });
+      return true;
     } catch (err) {
       console.error('Error creating live typing session:', err);
       setError(err instanceof Error ? err.message : 'Failed to create session');
+      return false;
     } finally {
       setIsCreating(false);
     }


### PR DESCRIPTION
## Summary

- `createSession` returned `void`, so `handleShare` checked the stale `isSharing` closure value after awaiting — always `false` at that point
- `createSession` now returns `boolean`; `handleShare` and the sheet's `onStartSharing` both use the return value to decide whether to open the modal/sheet
- Same stale-state bug fixed in `onStartSharing` on the `LiveTypingBottomSheet`

## Test plan

- [ ] Tap Share button for the first time — Live Typing modal/sheet should open immediately after session creates
- [ ] Tap Share while already sharing — modal/sheet opens immediately
- [ ] Session creation failure shows no modal

Closes #361