### PR TITLE
UX: Add 'Create board' button to empty boards state (#362)

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -377,6 +377,14 @@ export default function PhrasesInterface() {
       <div className="text-center">
         <h2 className="text-xl font-medium text-foreground mb-4">No boards yet</h2>
         <p className="text-text-secondary mb-6">Create your first board to start adding phrases</p>
+        {isOnline && (
+          <button
+            onClick={handleAddBoard}
+            className="px-5 py-2.5 rounded-xl bg-primary-500 hover:bg-primary-600 text-white font-semibold transition-colors"
+          >
+            Create board
+          </button>
+        )}
       </div>
     </div>
   ) : isMobile ? (


### PR DESCRIPTION
## Summary

- Empty boards state had copy "Create your first board" but no action
- Added a "Create board" button wired to the existing `handleAddBoard` handler, guarded behind `isOnline`

## Test plan

- [ ] Log in with no boards — "Create board" button is visible
- [ ] Clicking it navigates to the add board page
- [ ] Button is hidden when offline

Closes #362