### PR TITLE
Visual: Fade transition when switching AACTabs content (#365)

### DIFF
--- a/app/components/home/AACTabs.tsx
+++ b/app/components/home/AACTabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { ChatBubbleBottomCenterTextIcon } from '@heroicons/react/24/outline';
 import { Squares2X2Icon } from '@heroicons/react/24/solid';
 
@@ -54,8 +54,19 @@ export default function AACTabs({ phrasesContent, typeContent }: AACTabsProps) {
       </div>
 
       {/* Tab content */}
-      <div className="flex-1 min-h-0">
-        {activeTab === 'phrases' ? phrasesContent : typeContent}
+      <div className="flex-1 min-h-0 relative">
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={activeTab}
+            className="absolute inset-0"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.12 }}
+          >
+            {activeTab === 'phrases' ? phrasesContent : typeContent}
+          </motion.div>
+        </AnimatePresence>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Tab content switched instantly while the pill indicator had a spring animation
- Added `AnimatePresence` with a 120ms opacity fade — fast enough not to delay AAC interaction

## Test plan

- [ ] Switch between Phrases and Type tabs — content fades smoothly
- [ ] Animation feels quick and not sluggish

Closes #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tab switching experience with smooth animated transitions between content areas, featuring crossfade effects for a more polished interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->