### PR TITLE
Accessibility: Tooltip on tone control button (#367)

### DIFF
--- a/app/components/typing/SpeakButton.tsx
+++ b/app/components/typing/SpeakButton.tsx
@@ -63,6 +63,7 @@ export default function SpeakButton({
             className="flex items-center px-3.5 py-3 transition-colors duration-200 bg-primary-500 hover:bg-primary-600 text-white disabled:cursor-not-allowed"
             whileTap={disabled ? undefined : { scale: 0.97 }}
             aria-label="Choose tone"
+            title="Choose tone"
           >
             <AudioWaveform className="w-4 h-4" />
           </motion.button>


### PR DESCRIPTION
## Summary

- Icon-only waveform button had `aria-label` but no visible tooltip
- Added `title="Choose tone"` matching the pattern used in `TabBar`

## Test plan

- [ ] With ElevenLabs high-quality mode enabled, hover the waveform button — tooltip appears
- [ ] Focus the button via keyboard — tooltip appears

Closes #367