### PR TITLE
Chore: remove dead frequency field from phrases (#377)

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -137,7 +137,6 @@ export default function PhrasesInterface() {
       // Create the phrase
       const phraseId = await addPhrase({
         text: typingText,
-        frequency: 0,
         position,
       });
 
@@ -179,7 +178,6 @@ export default function PhrasesInterface() {
       .map((phrase: any) => ({
         id: String(phrase._id),
         text: phrase.text,
-        frequency: phrase.frequency,
       })) || [];
 
   // Transform boards to match the expected format (PhraseBoard type)

--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -7,7 +7,6 @@ interface PhraseTileProps {
   phrase: {
     id?: string;
     text: string;
-    frequency?: number;
   };
   onPress: () => void;
   onEdit?: () => void;

--- a/app/components/phrases/types.ts
+++ b/app/components/phrases/types.ts
@@ -1,7 +1,6 @@
 export interface PhraseSummary {
   id: string;
   text: string;
-  frequency?: number;
 }
 
 export interface BoardSummary {

--- a/app/phrases/add/page.tsx
+++ b/app/phrases/add/page.tsx
@@ -55,7 +55,6 @@ function AddPhraseForm() {
       // Create the phrase
       const phraseId = await addPhrase({
         text,
-        frequency: 0,
         position: 0, // Will be adjusted by backend based on board
       });
 

--- a/convex/phrases.ts
+++ b/convex/phrases.ts
@@ -39,7 +39,6 @@ export const getPhrase = query({
 export const addPhrase = mutation({
   args: {
     text: v.string(),
-    frequency: v.number(),
     position: v.number(),
   },
   handler: async (ctx, args) => {
@@ -51,7 +50,6 @@ export const addPhrase = mutation({
     const phraseId = await ctx.db.insert('phrases', {
       userId: identity.subject,
       text: args.text,
-      frequency: args.frequency,
       position: args.position,
     });
 
@@ -64,7 +62,6 @@ export const updatePhrase = mutation({
   args: {
     id: v.id('phrases'),
     text: v.optional(v.string()),
-    frequency: v.optional(v.number()),
     position: v.optional(v.number()),
   },
   handler: async (ctx, args) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -32,7 +32,7 @@ export default defineSchema({
   phrases: defineTable({
     userId: v.string(), // Clerk user ID
     text: v.string(),
-    frequency: v.number(),
+    frequency: v.optional(v.number()),
     position: v.number(),
   }).index('by_user_id', ['userId']),
 


### PR DESCRIPTION
## Summary

- `frequency` was written on every phrase insert but never read or shown in the UI
- Schema changed to `v.optional(v.number())` — backwards-compatible, no migration needed, existing data preserved
- Removed from `addPhrase`/`updatePhrase` mutation args, `PhraseSummary` type, and `PhraseTile` props
- All 236 tests pass

Closes #377