### PR TITLE
Chore: consolidate duplicate Add Phrase actions (#378)

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -403,7 +403,6 @@ export default function PhrasesInterface() {
         onBoardChange={handleBoardIndexChange}
         onOpenBoardPicker={() => setIsBoardPickerOpen(true)}
         onAddBoard={isOnline ? handleAddBoard : undefined}
-        onAddPhrase={isOnline ? handleAddPhrase : undefined}
         onEdit={handleEdit}
         isEditMode={isEditMode}
         canEditBoard={canEditCurrentBoard}
@@ -426,7 +425,6 @@ export default function PhrasesInterface() {
             router.push(`/phrases/boards/edit/${boardId}`);
           }}
           onAddBoard={isOnline ? handleAddBoard : undefined}
-          onAddPhrase={isOnline ? handleAddPhrase : undefined}
           onEdit={handleEdit}
           embedded={true}
         />

--- a/app/components/phrases/BoardActionButtons.tsx
+++ b/app/components/phrases/BoardActionButtons.tsx
@@ -1,17 +1,14 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
 import {
   PlusIcon,
   PencilIcon,
   CheckIcon,
   Squares2X2Icon,
-  ChatBubbleLeftIcon,
 } from '@heroicons/react/24/outline';
 
 interface BoardActionButtonsProps {
   onAddBoard?: () => void;
-  onAddPhrase?: () => void;
   onEdit?: () => void;
   isEditMode?: boolean;
   canEditBoard?: boolean;
@@ -19,90 +16,30 @@ interface BoardActionButtonsProps {
 
 export default function BoardActionButtons({
   onAddBoard,
-  onAddPhrase,
   onEdit,
   isEditMode = false,
   canEditBoard = true,
 }: BoardActionButtonsProps) {
-  const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
-  const addMenuRef = useRef<HTMLDivElement>(null);
-
-  // Close add menu when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (addMenuRef.current && !addMenuRef.current.contains(event.target as Node)) {
-        setIsAddMenuOpen(false);
-      }
-    };
-
-    if (isAddMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isAddMenuOpen]);
-
-  const showAddButton = onAddBoard || (onAddPhrase && canEditBoard);
+  const showAddBoard = !!onAddBoard;
   const showEditButton = canEditBoard && onEdit;
 
-  if (!showAddButton && !showEditButton) {
+  if (!showAddBoard && !showEditButton) {
     return null;
   }
 
   return (
     <div className="flex items-center justify-center gap-2 py-2 bg-surface">
-      {/* Add Dropdown */}
-      {showAddButton && (
-        <div ref={addMenuRef} className="relative">
-          <button
-            onClick={() => setIsAddMenuOpen(!isAddMenuOpen)}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors ${
-              isAddMenuOpen
-                ? 'bg-surface-hover text-foreground'
-                : 'hover:bg-surface-hover text-text-secondary'
-            }`}
-            aria-label="Add new"
-            aria-expanded={isAddMenuOpen}
-          >
-            <PlusIcon className="w-4 h-4" />
-            <span>Add</span>
-          </button>
-
-          {/* Dropdown Menu */}
-          {isAddMenuOpen && (
-            <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 bg-surface border border-border rounded-lg shadow-lg py-1 min-w-[140px] z-50">
-              {onAddPhrase && canEditBoard && (
-                <button
-                  onClick={() => {
-                    onAddPhrase();
-                    setIsAddMenuOpen(false);
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-text-primary hover:bg-surface-hover"
-                >
-                  <ChatBubbleLeftIcon className="w-4 h-4" />
-                  <span>New Phrase</span>
-                </button>
-              )}
-              {onAddBoard && (
-                <button
-                  onClick={() => {
-                    onAddBoard();
-                    setIsAddMenuOpen(false);
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-text-primary hover:bg-surface-hover"
-                >
-                  <Squares2X2Icon className="w-4 h-4" />
-                  <span>New Board</span>
-                </button>
-              )}
-            </div>
-          )}
-        </div>
+      {showAddBoard && (
+        <button
+          onClick={onAddBoard}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm hover:bg-surface-hover text-text-secondary transition-colors"
+          aria-label="Add board"
+        >
+          <Squares2X2Icon className="w-4 h-4" />
+          <span>Add Board</span>
+        </button>
       )}
 
-      {/* Edit/Done - only if can edit */}
       {showEditButton && (
         <button
           onClick={onEdit}

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -13,7 +13,6 @@ interface BoardSelectorProps {
   onEditBoard: (boardId: string) => void;
   // Action button props
   onAddBoard?: () => void;
-  onAddPhrase?: () => void;
   onEdit?: () => void;
   embedded?: boolean;
 }
@@ -25,7 +24,6 @@ export default function BoardSelector({
   onSelectBoard,
   onEditBoard,
   onAddBoard,
-  onAddPhrase,
   onEdit,
   embedded = false,
 }: BoardSelectorProps) {
@@ -95,7 +93,6 @@ export default function BoardSelector({
         </div>
         <BoardActionButtons
           onAddBoard={onAddBoard}
-          onAddPhrase={onAddPhrase}
           onEdit={onEdit}
           isEditMode={isEditMode}
           canEditBoard={canEditSelected}
@@ -147,7 +144,6 @@ export default function BoardSelector({
         </div>
         <BoardActionButtons
           onAddBoard={onAddBoard}
-          onAddPhrase={onAddPhrase}
           onEdit={onEdit}
           isEditMode={isEditMode}
           canEditBoard={canEditSelected}

--- a/app/components/phrases/SwipeableBoardNavigator.tsx
+++ b/app/components/phrases/SwipeableBoardNavigator.tsx
@@ -14,7 +14,6 @@ interface SwipeableBoardNavigatorProps {
   children: React.ReactNode;
   // Action button props
   onAddBoard?: () => void;
-  onAddPhrase?: () => void;
   onEdit?: () => void;
   isEditMode?: boolean;
   canEditBoard?: boolean;
@@ -27,7 +26,6 @@ export default function SwipeableBoardNavigator({
   onOpenBoardPicker,
   children,
   onAddBoard,
-  onAddPhrase,
   onEdit,
   isEditMode = false,
   canEditBoard = true,
@@ -134,7 +132,6 @@ export default function SwipeableBoardNavigator({
       {/* Action Buttons Row */}
       <BoardActionButtons
         onAddBoard={onAddBoard}
-        onAddPhrase={onAddPhrase}
         onEdit={onEdit}
         isEditMode={isEditMode}
         canEditBoard={canEditBoard}


### PR DESCRIPTION
## Summary

- Removed `onAddPhrase` from `BoardActionButtons`, `BoardSelector`, `SwipeableBoardNavigator`, and `PhrasesInterface`
- The inline `ActionTile` in the phrase grid remains as the single Add Phrase affordance (contextual, edit-mode only)
- The Add dropdown in `BoardActionButtons` is replaced with a plain "Add Board" button — no dropdown needed for a single action
- 236 tests pass

Closes #378