### PR TITLE
Fix: useOnlineStatus initialises from navigator.onLine (#390)

### DIFF
--- a/lib/hooks/useOnlineStatus.ts
+++ b/lib/hooks/useOnlineStatus.ts
@@ -3,12 +3,12 @@
 import { useEffect, useState } from 'react';
 
 export function useOnlineStatus() {
-  const [isOnline, setIsOnline] = useState(true);
+  const [isOnline, setIsOnline] = useState(() =>
+    typeof window !== 'undefined' ? window.navigator.onLine : true
+  );
   const [wasOffline, setWasOffline] = useState(false);
 
   useEffect(() => {
-    setIsOnline(window.navigator.onLine);
-
     const handleOnline = () => {
       setIsOnline(true);
       setWasOffline(true);


### PR DESCRIPTION
Lazy `useState` initialiser reads `navigator.onLine` synchronously instead of defaulting to `true` and correcting in a `useEffect`. Offline users now see the fallback UI immediately on launch with no spinner delay.

Closes #390