### PR TITLE
v3 design language: calm + warm rebrand

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -147,7 +147,7 @@ function SidebarItem({ href, icon, title, isActive, isExpanded }: SidebarItemPro
         isExpanded ? 'justify-start gap-3 px-3' : 'justify-center hover:scale-110'
       } ${
         isActive
-          ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white shadow-lg'
+          ? 'bg-primary-500 text-white shadow-lg'
           : 'bg-surface-hover text-text-secondary hover:bg-primary-950 hover:text-primary-500'
       }`}
       data-tooltip-id={!isExpanded ? `sidebar-tooltip-${title}` : undefined}

--- a/app/components/typing-tabs/Tab.tsx
+++ b/app/components/typing-tabs/Tab.tsx
@@ -59,7 +59,7 @@ export default function Tab({ tab, isActive, onSelect, onClose, onRename }: TabP
         whitespace-nowrap transition-all duration-200 group
         ${
     isActive
-      ? 'bg-gradient-to-r from-primary-500 to-primary-600 text-white shadow-lg'
+      ? 'bg-primary-500 text-white shadow-lg'
       : 'bg-surface hover:bg-surface-hover text-text-secondary hover:text-foreground opacity-50 hover:opacity-100'
     }
       `}

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          'bg-gradient-to-r from-primary-500 to-primary-600 text-white hover:from-primary-600 hover:to-primary-700',
+          'bg-primary-500 text-white hover:bg-primary-600 active:bg-primary-700',
         destructive:
           'bg-gradient-to-r from-red-500 to-red-600 text-white hover:from-red-600 hover:to-red-700',
         outline:

--- a/app/components/ui/Dropdown.tsx
+++ b/app/components/ui/Dropdown.tsx
@@ -126,7 +126,7 @@ export function Dropdown<T = string>({
                           className={cn(
                             'w-full cursor-default select-none relative py-3 pl-6 pr-10 rounded-2xl transition-all duration-200 text-left',
                             isSelected
-                              ? 'text-white bg-gradient-to-r from-primary-500 to-primary-600'
+                              ? 'text-white bg-primary-500'
                               : 'text-foreground hover:bg-surface-hover',
                             option.disabled && 'opacity-50 cursor-not-allowed text-text-tertiary'
                           )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,26 @@
 @import "tailwindcss";
 
 :root {
-  /* Accessible dark theme colors */
-  --background: #1a1a1a;
-  --foreground: #f5f5f5;
-  --surface: #242424;
-  --surface-hover: #2e2e2e;
-  --border: #3a3a3a;
+  /* Accessible dark theme colors — v3: calm + warm */
+  --background: #1a1917;
+  --foreground: #f5f4f2;
+  --surface: #232220;
+  --surface-hover: #2d2b29;
+  --border: #3a3835;
 
   /* Mobile bottom stack height (nav + dock + safe area) */
   --bottom-stack-height: calc(108px + env(safe-area-inset-bottom, 0px));
 
   /* Text colors with WCAG AAA compliance */
-  --text-primary: #f5f5f5;
-  --text-secondary: #b8b8b8;
-  --text-tertiary: #8a8a8a;
+  --text-primary: #f5f4f2;
+  --text-secondary: #b8b5b0;
+  --text-tertiary: #8a8782;
 
   /* Background gradients */
-  --background-gradient-1: #1a1a1a;
-  --background-gradient-2: #242424;
-  --background-gradient-3: #2e2e2e;
-  --background-gradient-4: #1a1a1a;
+  --background-gradient-1: #1a1917;
+  --background-gradient-2: #232220;
+  --background-gradient-3: #2d2b29;
+  --background-gradient-4: #1a1917;
 }
 
 @theme inline {
@@ -165,7 +165,7 @@ body {
 
 /* Focus visible styles for better keyboard navigation */
 :focus-visible {
-  outline: 2px solid var(--color-primary-500, #3b82f6);
+  outline: 2px solid var(--color-primary-500, #14b8a6);
   outline-offset: 2px;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,23 +68,19 @@ const config: Config = {
           secondary: 'var(--text-secondary)',
           tertiary: 'var(--text-tertiary)',
         },
-        // Accessible high-contrast accent colors
+        // v3: deep teal primary — calm + warm design language
         primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa', // Primary accent - 8:1 contrast on dark bg
-          500: '#3b82f6', // Primary hover - 6.5:1 contrast
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
-          950: '#172554',
-        },
-        accent: {
-          DEFAULT: '#06b6d4', // Cyan-500 - 7:1 contrast
-          hover: '#0891b2',
+          50: '#f0fdfa',
+          100: '#ccfbf1',
+          200: '#99f6e4',
+          300: '#5eead4',
+          400: '#2dd4bf', // Primary accent - 8:1 contrast on dark bg
+          500: '#14b8a6', // Primary action - 7:1 contrast
+          600: '#0d9488', // Hover state - 6:1 contrast
+          700: '#0f766e',
+          800: '#115e59',
+          900: '#134e4a',
+          950: '#042f2e',
         },
         success: {
           DEFAULT: '#10b981', // Emerald-500 - 5:1 contrast
@@ -97,12 +93,6 @@ const config: Config = {
         error: {
           DEFAULT: '#ef4444', // Red-500 - 5.5:1 contrast
           hover: '#dc2626',
-        },
-        orange: {
-          DEFAULT: '#ff9800', // Orange-500 - main accent for interactions
-          hover: '#f57c00', // Orange-700 - darker hover
-          active: '#e65100', // Orange-900 - darkest active/pressed
-          light: '#ffb74d', // Orange-300 - lighter variant
         },
         // Solid status backgrounds (replacing transparent versions)
         status: {

--- a/tests/components/typing-tabs/Tab.test.tsx
+++ b/tests/components/typing-tabs/Tab.test.tsx
@@ -52,8 +52,7 @@ describe('Tab', () => {
       );
 
       const tabElement = container.firstChild as HTMLElement;
-      expect(tabElement.className).toContain('from-primary-500');
-      expect(tabElement.className).toContain('to-primary-600');
+      expect(tabElement.className).toContain('bg-primary-500');
       expect(tabElement.className).toContain('text-white');
       expect(tabElement.className).toContain('shadow-lg');
     });


### PR DESCRIPTION
Closes #397

## Changes
- **Backgrounds:** Slightly warm neutrals (`#1a1917`, `#232220`, `#2d2b29`, `#3a3835`)
- **Text:** Barely warm tint (`#f5f4f2`, `#b8b5b0`, `#8a8782`)
- **Primary accent:** Full blue scale replaced with deep teal (`#14b8a6` as primary-500)
- **Buttons:** Gradient backgrounds replaced with flat teal
- **Focus ring:** Updated to teal via `primary-500` token
- **Removed:** `orange` color scale and `accent` (cyan) — both absorbed into teal or eliminated
- Test updated to match new flat active tab styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified primary color styling across UI components by replacing gradient backgrounds with solid primary colors
  * Updated sidebar, tab, button, and dropdown styling for a cleaner appearance
  * Refreshed dark theme color palette with new warm and calm color values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->