### PR TITLE
Fix Tailwind v4 color tokens — move custom colors to @theme CSS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,9 +23,49 @@
   --background-gradient-4: #1a1917;
 }
 
+/* Fixed color tokens */
+@theme {
+  /* v3 primary: deep teal */
+  --color-primary-50: #f0fdfa;
+  --color-primary-100: #ccfbf1;
+  --color-primary-200: #99f6e4;
+  --color-primary-300: #5eead4;
+  --color-primary-400: #2dd4bf;
+  --color-primary-500: #14b8a6;
+  --color-primary-600: #0d9488;
+  --color-primary-700: #0f766e;
+  --color-primary-800: #115e59;
+  --color-primary-900: #134e4a;
+  --color-primary-950: #042f2e;
+
+  /* Status */
+  --color-success: #10b981;
+  --color-success-hover: #059669;
+  --color-warning: #f59e0b;
+  --color-warning-hover: #d97706;
+  --color-error: #ef4444;
+  --color-error-hover: #dc2626;
+
+  /* Solid status backgrounds */
+  --color-status-error: #2a1215;
+  --color-status-warning: #2a1f0a;
+  --color-status-success: #0a2a1a;
+  --color-status-info: #0a1a2a;
+  --color-status-purple: #1a0a2a;
+
+  --color-overlay: #0a0a0a;
+}
+
+/* Semantic tokens — reference CSS variables so they update with theme changes */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-hover: var(--surface-hover);
+  --color-border: var(--border);
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-tertiary: var(--text-tertiary);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,62 +49,7 @@ const config: Config = {
         'screen-dvh': '100dvh',
         'screen-svh': '100svh',
       },
-      colors: {
-        background: {
-          DEFAULT: 'var(--background)',
-        },
-        foreground: {
-          DEFAULT: 'var(--foreground)',
-        },
-        surface: {
-          DEFAULT: 'var(--surface)',
-          hover: 'var(--surface-hover)',
-        },
-        border: {
-          DEFAULT: 'var(--border)',
-        },
-        text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          tertiary: 'var(--text-tertiary)',
-        },
-        // v3: deep teal primary — calm + warm design language
-        primary: {
-          50: '#f0fdfa',
-          100: '#ccfbf1',
-          200: '#99f6e4',
-          300: '#5eead4',
-          400: '#2dd4bf', // Primary accent - 8:1 contrast on dark bg
-          500: '#14b8a6', // Primary action - 7:1 contrast
-          600: '#0d9488', // Hover state - 6:1 contrast
-          700: '#0f766e',
-          800: '#115e59',
-          900: '#134e4a',
-          950: '#042f2e',
-        },
-        success: {
-          DEFAULT: '#10b981', // Emerald-500 - 5:1 contrast
-          hover: '#059669',
-        },
-        warning: {
-          DEFAULT: '#f59e0b', // Amber-500 - 6:1 contrast
-          hover: '#d97706',
-        },
-        error: {
-          DEFAULT: '#ef4444', // Red-500 - 5.5:1 contrast
-          hover: '#dc2626',
-        },
-        // Solid status backgrounds (replacing transparent versions)
-        status: {
-          error: '#2a1215',      // Dark red background
-          warning: '#2a1f0a',    // Dark amber background
-          success: '#0a2a1a',    // Dark green background
-          info: '#0a1a2a',       // Dark blue background
-          purple: '#1a0a2a',     // Dark purple background
-        },
-        // Overlay/backdrop solid color
-        overlay: '#0a0a0a',     // Near-black for modals
-      },
+      // Colors are defined in app/globals.css via @theme — Tailwind v4 CSS-first approach
     },
   },
   plugins: [


### PR DESCRIPTION
Closes #399

## Problem
Custom colors in `tailwind.config.ts` were silently ignored by Tailwind v4. Classes like `bg-primary-500`, `bg-surface`, `text-text-secondary`, `border-border` have never applied any styles.

## Fix
Move all color tokens to `@theme` / `@theme inline` blocks in `globals.css` — the correct CSS-first approach for Tailwind v4:

- **`@theme {}`** — fixed color tokens: full teal primary scale, success/warning/error, status backgrounds, overlay
- **`@theme inline {}`** — semantic tokens backed by CSS variables: surface, border, text-primary/secondary/tertiary

`tailwind.config.ts` colors section removed entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized color theme system to use Tailwind v4 `@theme` declarations. Expanded color palette includes primary color scales, status colors (success, warning, error), and semantic tokens for surfaces, borders, and text levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->