### PR TITLE
Fix slider fill — default track colour to primary-500

### DIFF
--- a/app/components/ui/Slider.tsx
+++ b/app/components/ui/Slider.tsx
@@ -33,8 +33,8 @@ export function Slider({
   disabled = false,
   error,
   showTicks = false,
-  trackColor = 'bg-black',
-  thumbColor = 'bg-black'
+  trackColor = 'bg-primary-500',
+  thumbColor = 'bg-primary-500'
 }: SliderProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [isHovering, setIsHovering] = useState(false);


### PR DESCRIPTION
Closes #402

Slider active track and thumb defaulted to `bg-black`. Changed to `bg-primary-500` so sliders render teal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Sliders now use the primary brand color as the default styling for the active track and thumb, replacing the previous black appearance for improved visual consistency with the application's design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->