### PR TITLE
Fix Stop button — replace gradient with flat error colour

### DIFF
--- a/app/components/typing/SpeakButton.tsx
+++ b/app/components/typing/SpeakButton.tsx
@@ -31,7 +31,7 @@ export default function SpeakButton({
     return (
       <motion.button
         onClick={onStop}
-        className="flex items-center gap-2 px-6 py-3 rounded-2xl font-bold transition-all duration-200 shadow-lg bg-gradient-to-r from-red-500 to-red-600 text-white text-base"
+        className="flex items-center gap-2 px-6 py-3 rounded-2xl font-bold transition-all duration-200 shadow-lg bg-error hover:bg-error-hover text-white text-base"
         whileTap={{ scale: 0.95 }}
         aria-label="Stop"
       >


### PR DESCRIPTION
Closes #403

Stop button was using `bg-gradient-to-r from-red-500 to-red-600`. Replaced with flat `bg-error hover:bg-error-hover` consistent with v3 flat button direction.