### PR TITLE
Fix outline button border contrast and destructive gradient

### DIFF
--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -12,9 +12,9 @@ const buttonVariants = cva(
         default:
           'bg-primary-500 text-white hover:bg-primary-600 active:bg-primary-700',
         destructive:
-          'bg-gradient-to-r from-red-500 to-red-600 text-white hover:from-red-600 hover:to-red-700',
+          'bg-error text-white hover:bg-error-hover',
         outline:
-          'border border-border bg-surface text-foreground hover:bg-surface-hover hover:border-primary-700',
+          'border border-primary-800 bg-surface text-foreground hover:bg-surface-hover hover:border-primary-600',
         secondary:
           'bg-surface-hover text-foreground hover:bg-primary-950 hover:text-primary-500',
         ghost: 'hover:bg-surface-hover text-foreground hover:text-primary-500',


### PR DESCRIPTION
Closes #406

- Outline variant: `border-border` → `border-primary-800` (visible teal-tinted border), hover to `border-primary-600`
- Destructive variant: remaining gradient replaced with flat `bg-error hover:bg-error-hover`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated destructive button colors with enhanced error state styling.
  * Improved outline button border and hover state colors for better visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->