### PR TITLE
Soften app logo against dark background

### DIFF
--- a/app/components/home/HomeFeatures.tsx
+++ b/app/components/home/HomeFeatures.tsx
@@ -18,13 +18,13 @@ export default function HomeFeatures() {
         transition={{ duration: 0.5, ease: 'easeOut' }}
       >
         {/* App Icon */}
-        <div className="mb-6">
+        <div className="mb-6 rounded-2xl ring-1 ring-white/10 shadow-xl">
           <Image
             src="/icons/app-icon.png"
             alt="SayIt! App Icon"
             width={96}
             height={96}
-            className="rounded-2xl shadow-lg"
+            className="rounded-2xl"
             priority
           />
         </div>


### PR DESCRIPTION
Closes #407

Wraps the app icon in a container with `ring-1 ring-white/10 shadow-xl` to create a soft visual boundary between the white app icon and the warm dark background. The white background is baked into the PNG so this is the cleanest CSS-only fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual styling of app icon containers with updated shadow and border effects for improved visual hierarchy and polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->