### PR TITLE
Fix PWA install banner — add left border to delineate from sidebar

### DIFF
--- a/app/components/navigation/InstallBanner.tsx
+++ b/app/components/navigation/InstallBanner.tsx
@@ -22,7 +22,7 @@ export default function InstallBanner() {
 
   return (
     <div
-      className="sticky top-0 z-30 border-b border-primary-900 bg-surface px-4 py-3 text-sm text-primary-100"
+      className="sticky top-0 z-30 border-b border-l border-primary-900 bg-surface px-4 py-3 text-sm text-primary-100"
       role="status"
       aria-live="polite"
     >


### PR DESCRIPTION
Closes #408

The banner background and sidebar use the same `bg-surface` colour so the bottom border appeared to span the full viewport. Added `border-l border-primary-900` to give the banner a clear left visual edge aligned with the sidebar/content boundary.