### PR TITLE
Theme Clerk sign-in/sign-up cards to match dark design

### DIFF
--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,9 +1,10 @@
 import { SignIn } from '@clerk/nextjs';
+import { clerkDarkAppearance } from '@/lib/clerkAppearance';
 
 export default function SignInPage() {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <SignIn />
+      <SignIn appearance={clerkDarkAppearance} />
     </div>
   );
 }

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,10 @@
 import { SignUp } from '@clerk/nextjs';
+import { clerkDarkAppearance } from '@/lib/clerkAppearance';
 
 export default function SignUpPage() {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <SignUp />
+      <SignUp appearance={clerkDarkAppearance} />
     </div>
   );
 }

--- a/lib/clerkAppearance.ts
+++ b/lib/clerkAppearance.ts
@@ -1,0 +1,29 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const clerkDarkAppearance: any = {
+  variables: {
+    colorBackground: '#232220',
+    colorInputBackground: '#1a1917',
+    colorInputText: '#f5f4f2',
+    colorText: '#f5f4f2',
+    colorTextSecondary: '#b8b5b0',
+    colorPrimary: '#14b8a6',
+    colorDanger: '#ef4444',
+    colorNeutral: '#3a3835',
+    borderRadius: '1rem',
+    fontFamily: 'inherit',
+  },
+  elements: {
+    card: 'bg-surface shadow-2xl border border-primary-900',
+    headerTitle: 'text-foreground',
+    headerSubtitle: 'text-text-secondary',
+    socialButtonsBlockButton: 'border-border bg-surface-hover hover:bg-surface text-foreground',
+    socialButtonsBlockButtonText: 'text-foreground font-medium',
+    dividerLine: 'bg-border',
+    dividerText: 'text-text-tertiary',
+    formFieldLabel: 'text-text-secondary',
+    formFieldInput: 'bg-background border-border text-foreground focus:border-primary-500',
+    footerActionLink: 'text-primary-400 hover:text-primary-300',
+    identityPreviewText: 'text-foreground',
+    identityPreviewEditButton: 'text-primary-400',
+  },
+};


### PR DESCRIPTION
Closes #401

Adds `lib/clerkAppearance.ts` with Clerk `appearance` config using v3 design tokens:
- Card background: `#232220` (surface)
- Input background: `#1a1917` (background)
- Primary: `#14b8a6` (teal)
- Text, borders, radius all match app tokens

Applied to both `/sign-in` and `/sign-up` pages.