### PR TITLE
release: v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.49",
         "@clerk/nextjs": "^7.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/components/phrases/BoardSelector.test.tsx
+++ b/tests/components/phrases/BoardSelector.test.tsx
@@ -279,14 +279,12 @@ describe('BoardSelector', () => {
         />
       );
 
-      // Click edit button (pencil icon button)
-      const editButtons = screen.getAllByRole('button');
-      // Find the one that's the edit button (not the dropdown)
-      const editButton = editButtons.find(btn => btn.querySelector('svg'));
-      if (editButton) {
-        await userEvent.click(editButton);
-        expect(mockOnEditBoard).toHaveBeenCalledWith('board-1');
-      }
+      // Open the more options menu, then click "Edit Board"
+      const moreOptionsButton = screen.getByRole('button', { name: /more options/i });
+      await userEvent.click(moreOptionsButton);
+      const editBoardItem = screen.getByRole('button', { name: /edit board/i });
+      await userEvent.click(editBoardItem);
+      expect(mockOnEditBoard).toHaveBeenCalledWith('board-1');
     });
   });
 


### PR DESCRIPTION
## Summary

- Bumps version to v3.1.0 (minor release)
- Fixes failing `BoardSelector` test to match the dropdown menu-based edit board UI

## Test plan

- [x] All 236 tests pass
- [x] Lint passes with no issues