### PR TITLE
release: v3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.49",
         "@clerk/nextjs": "^7.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to v3.1.1 (patch release)
- Fixes ElevenLabs stopping midway through large text by falling back to `eleven_flash_v2_5` when text exceeds `eleven_v3`'s 5,000 character limit

## Test plan

- [x] All 236 tests pass
- [x] Lint passes with no issues