### PR TITLE
feat: extend audio tags with categories, full screen sheet, and v3 sounds (#459)

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -32,7 +32,7 @@ interface ComposerProps {
   text: string;
   onChange: (text: string) => void;
   onSpeak: (source?: 'speak' | 'speakAndClear') => void;
-  onSpeakWithTone?: (toneTag: string) => void;
+  onSpeakWithTone?: (toneTag: string, options?: { modelId?: string }) => void;
   onMessageCompleted?: (payload: { text: string; source: 'clear'; tabId?: string | null }) => void;
   onStop?: () => void;
   isSpeaking?: boolean;
@@ -231,7 +231,8 @@ export default function Composer({
 
   const handleToneSelected = useCallback((tone: TonePreset) => {
     if (!currentText.trim()) return;
-    onSpeakWithTone?.(applyToneTag(tone, currentText));
+    const options = tone.v3Only ? { modelId: 'eleven_v3' } : undefined;
+    onSpeakWithTone?.(applyToneTag(tone, currentText), options);
   }, [currentText, onSpeakWithTone]);
 
   // Auto-dismiss errors after 4 s; also dismiss when user starts typing

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -319,8 +319,8 @@ export default function PhrasesInterface() {
       text={typingText}
       onChange={setTypingText}
       onSpeak={handleSpeakFromDock}
-      onSpeakWithTone={(taggedText) => {
-        tts.speak(taggedText);
+      onSpeakWithTone={(taggedText, options) => {
+        tts.speak(taggedText, options);
         void handleCaptureCompletedMessage({
           text: typingText,
           source: 'speak',

--- a/app/components/typing/ToneSheet.tsx
+++ b/app/components/typing/ToneSheet.tsx
@@ -13,6 +13,13 @@ export interface TonePreset {
   /** Where to place the tag relative to the text (default 'before') */
   position?: 'before' | 'after';
   description: string;
+  /** Requires eleven_v3 model to work properly */
+  v3Only?: boolean;
+}
+
+export interface ToneCategory {
+  label: string;
+  presets: TonePreset[];
 }
 
 /** Apply a tone preset tag to text, respecting the tag position. */
@@ -23,16 +30,44 @@ export function applyToneTag(tone: TonePreset, text: string): string {
   return `${tone.tag} ${text}`;
 }
 
-export const TONE_PRESETS: TonePreset[] = [
-  { id: 'calm', label: 'Calm', tag: '[calmly]', description: 'Relaxed and gentle' },
-  { id: 'excited', label: 'Excited', tag: '[excited]', description: 'Energetic and enthusiastic' },
-  { id: 'whisper', label: 'Whisper', tag: '[whispers]', description: 'Soft and quiet' },
-  { id: 'sad', label: 'Sad', tag: '[sadly]', description: 'Somber and low' },
-  { id: 'angry', label: 'Angry', tag: '[angrily]', description: 'Forceful and intense' },
-  { id: 'cheerful', label: 'Cheerful', tag: '[cheerfully]', description: 'Bright and happy' },
-  { id: 'sigh-before', label: 'Sigh (before)', tag: '[sighs]', position: 'before', description: 'Sigh, then speak' },
-  { id: 'sigh-after', label: 'Sigh (after)', tag: '[sighs]', position: 'after', description: 'Speak, then sigh' },
+export const TONE_CATEGORIES: ToneCategory[] = [
+  {
+    label: 'Delivery',
+    presets: [
+      { id: 'calm', label: 'Calm', tag: '[calmly]', description: 'Relaxed and gentle' },
+      { id: 'excited', label: 'Excited', tag: '[excited]', description: 'Energetic and enthusiastic' },
+      { id: 'cheerful', label: 'Cheerful', tag: '[cheerfully]', description: 'Bright and happy' },
+      { id: 'whisper', label: 'Whisper', tag: '[whispers]', description: 'Soft and quiet' },
+      { id: 'shout', label: 'Shout', tag: '[shouts]', description: 'Loud and forceful' },
+    ],
+  },
+  {
+    label: 'Emotions',
+    presets: [
+      { id: 'sad', label: 'Sad', tag: '[sadly]', description: 'Somber and low' },
+      { id: 'angry', label: 'Angry', tag: '[angrily]', description: 'Forceful and intense' },
+      { id: 'scared', label: 'Scared', tag: '[scared]', description: 'Anxious and fearful' },
+      { id: 'frustrated', label: 'Frustrated', tag: '[frustrated]', description: 'Tense and strained' },
+      { id: 'surprised', label: 'Surprised', tag: '[surprised]', description: 'Startled and wide-eyed' },
+      { id: 'sarcastic', label: 'Sarcastic', tag: '[sarcastic]', description: 'Dry and ironic' },
+    ],
+  },
+  {
+    label: 'Sounds',
+    presets: [
+      { id: 'sigh', label: 'Sigh', tag: '[sighs]', description: 'Sigh before speaking', v3Only: true },
+      { id: 'laugh', label: 'Laugh', tag: '[laughs]', description: 'Laugh before speaking', v3Only: true },
+      { id: 'giggle', label: 'Giggle', tag: '[giggles]', description: 'Giggle before speaking', v3Only: true },
+      { id: 'yawn', label: 'Yawn', tag: '[yawns]', description: 'Yawn before speaking', v3Only: true },
+      { id: 'cry', label: 'Cry', tag: '[cries]', description: 'Cry before speaking', v3Only: true },
+      { id: 'clear-throat', label: 'Clear throat', tag: '[clears throat]', description: 'Clear throat before speaking', v3Only: true },
+      { id: 'cough', label: 'Cough', tag: '[coughs]', description: 'Cough before speaking', v3Only: true },
+    ],
+  },
 ];
+
+/** Flat list of all presets, for backwards compatibility */
+export const TONE_PRESETS: TonePreset[] = TONE_CATEGORIES.flatMap(c => c.presets);
 
 interface ToneSheetProps {
   isOpen: boolean;
@@ -43,7 +78,7 @@ interface ToneSheetProps {
 
 function ToneOptions({ onSelectTone, onSpeakWithoutTone, onClose }: Omit<ToneSheetProps, 'isOpen'>) {
   return (
-    <div className="p-4 space-y-3">
+    <div className="p-4 space-y-4">
       <button
         type="button"
         onClick={() => {
@@ -59,22 +94,34 @@ function ToneOptions({ onSelectTone, onSpeakWithoutTone, onClose }: Omit<ToneShe
         </div>
       </button>
 
-      <div className="grid grid-cols-2 gap-2">
-        {TONE_PRESETS.map((tone) => (
-          <button
-            key={tone.id}
-            type="button"
-            onClick={() => {
-              onSelectTone(tone);
-              onClose();
-            }}
-            className="flex flex-col items-start px-4 py-3 rounded-2xl bg-surface-hover hover:bg-surface text-left transition-colors border border-border hover:border-primary-500"
-          >
-            <span className="text-sm font-medium text-foreground">{tone.label}</span>
-            <span className="text-xs text-text-secondary">{tone.description}</span>
-          </button>
-        ))}
-      </div>
+      {TONE_CATEGORIES.map((category) => (
+        <div key={category.label}>
+          <div className="flex items-center gap-2 mb-2">
+            <h3 className="text-xs font-semibold text-text-secondary uppercase tracking-wider">
+              {category.label}
+            </h3>
+            {category.presets.some(p => p.v3Only) && (
+              <span className="text-xs text-primary-400 font-medium">v3</span>
+            )}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {category.presets.map((tone) => (
+              <button
+                key={tone.id}
+                type="button"
+                onClick={() => {
+                  onSelectTone(tone);
+                  onClose();
+                }}
+                className="flex flex-col items-start px-4 py-3 rounded-2xl bg-surface-hover hover:bg-surface text-left transition-colors border border-border hover:border-primary-500"
+              >
+                <span className="text-sm font-medium text-foreground">{tone.label}</span>
+                <span className="text-xs text-text-secondary">{tone.description}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -88,7 +135,7 @@ export default function ToneSheet({ isOpen, onClose, onSelectTone, onSpeakWithou
         isOpen={isOpen}
         onClose={onClose}
         title="How should this sound?"
-        snapPoints={[55]}
+        snapPoints={[100]}
         showHandle={true}
         showCloseButton={true}
       >
@@ -128,7 +175,7 @@ export default function ToneSheet({ isOpen, onClose, onSelectTone, onSpeakWithou
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-sm rounded-3xl bg-surface shadow-2xl">
+              <Dialog.Panel className="w-full max-w-sm rounded-3xl bg-surface shadow-2xl max-h-[90vh] overflow-y-auto">
                 <Dialog.Title className="text-lg font-semibold text-foreground px-4 pt-4 pb-2">
                   How should this sound?
                 </Dialog.Title>

--- a/app/components/ui/BottomSheet.tsx
+++ b/app/components/ui/BottomSheet.tsx
@@ -189,7 +189,7 @@ export default function BottomSheet({
             ref={sheetRef}
             className={`fixed bottom-0 left-0 right-0 z-[60] rounded-t-3xl shadow-2xl flex flex-col bg-surface ${className}`}
             style={{
-              maxHeight: '95vh',
+              maxHeight: '100vh',
               paddingBottom: keyboardHeight > 0 ? keyboardHeight : 'env(safe-area-inset-bottom)',
             }}
             initial={{ y: '100%' }}


### PR DESCRIPTION
## Summary

- Reorganises tone presets into 3 labelled categories: **Delivery**, **Emotions**, **Sounds**
- Adds new presets: Shout, Scared, Frustrated, Surprised, Sarcastic, Laugh, Giggle, Yawn, Cry, Clear throat, Cough
- Sounds category is tagged `v3Only` — selecting one automatically uses `eleven_v3` for that speak call regardless of the user's saved model preference
- Tone sheet opens full screen on mobile (`snapPoints={[100]}`)
- `BottomSheet` max height bumped to `100vh`

## Test plan

- [x] Build passes
- [x] All 236 tests pass
- [ ] Verify tone sheet opens full screen on mobile
- [ ] Verify Sounds presets use v3 even when Fast model is selected in settings
- [ ] Verify Delivery/Emotions presets use the user's saved model preference

Closes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v3 model support for voice synthesis options
  * Expanded tone library with new sound effects and delivery presets

* **UI/UX Improvements**
  * Reorganized tone selection into logical categories with visual markers
  * Enhanced interface layout with improved spacing and organization
  * Optimized mobile bottom sheet display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->