### PR TITLE
release: v3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.49",
         "@clerk/nextjs": "^7.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to v3.2.0 (minor release)
- Extended audio tags: Delivery, Emotions, and Sounds categories with 18 presets
- Sounds presets auto-upgrade to `eleven_v3` for that speak call
- Tone sheet opens full screen on mobile

## Test plan

- [x] All 236 tests pass
- [x] Lint passes with no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 3.2.0 released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->