### PR TITLE
Add Azure TTS provider

### DIFF
--- a/app/api/azure/tts/route.ts
+++ b/app/api/azure/tts/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { text, voiceId, rate, pitch, volume } = body;
+    const { text, voiceId } = body;
 
     if (!text) {
       return NextResponse.json({ error: 'Text is required' }, { status: 400 });
@@ -29,9 +29,6 @@ export async function POST(request: Request) {
 
     const { audioStream } = await client.synthToBytestream(text, {
       voice: voiceId,
-      rate,
-      pitch,
-      volume,
       format: 'mp3',
       useWordBoundary: false,
     });

--- a/app/api/azure/tts/route.ts
+++ b/app/api/azure/tts/route.ts
@@ -1,52 +1,8 @@
+import { AzureTTSClient } from 'js-tts-wrapper';
 import { NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
-
-type AzureRate = 'x-slow' | 'slow' | 'medium' | 'fast' | 'x-fast';
-type AzurePitch = 'x-low' | 'low' | 'medium' | 'high' | 'x-high';
-
-function rateToAzure(rate?: number): AzureRate {
-  if (rate === undefined || (rate > 0.85 && rate <= 1.15)) return 'medium';
-  if (rate <= 0.6) return 'x-slow';
-  if (rate <= 0.85) return 'slow';
-  if (rate <= 1.6) return 'fast';
-  return 'x-fast';
-}
-
-function pitchToAzure(pitch?: number): AzurePitch {
-  if (pitch === undefined || (pitch > 0.85 && pitch <= 1.15)) return 'medium';
-  if (pitch <= 0.6) return 'x-low';
-  if (pitch <= 0.85) return 'low';
-  if (pitch <= 1.6) return 'high';
-  return 'x-high';
-}
-
-function volumeToAzure(volume?: number): string {
-  if (volume === undefined) return 'medium';
-  // volume is 0-1; Azure accepts 0-100 or keywords
-  const pct = Math.round(volume * 100);
-  return `${pct}%`;
-}
-
-function escapeXml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
-function buildSsml(text: string, voiceId: string, rate: AzureRate, pitch: AzurePitch, volume: string): string {
-  // Extract language from voice ID (e.g. en-US-JennyNeural → en-US)
-  const lang = voiceId.split('-').slice(0, 2).join('-') || 'en-US';
-  return `<speak version='1.0' xml:lang='${lang}' xmlns='http://www.w3.org/2001/10/synthesis'>` +
-    `<voice name='${voiceId}'>` +
-    `<prosody rate='${rate}' pitch='${pitch}' volume='${volume}'>` +
-    `${escapeXml(text)}` +
-    `</prosody></voice></speak>`;
-}
 
 export async function POST(request: Request) {
   try {
@@ -69,36 +25,18 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Voice ID is required' }, { status: 400 });
     }
 
-    const ssml = buildSsml(
-      text,
-      voiceId,
-      rateToAzure(rate),
-      pitchToAzure(pitch),
-      volumeToAzure(volume),
-    );
+    const client = new AzureTTSClient({ subscriptionKey, region });
 
-    const endpoint = `https://${region}.tts.speech.microsoft.com/cognitiveservices/v1`;
-    const azureResponse = await fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        'Ocp-Apim-Subscription-Key': subscriptionKey,
-        'Content-Type': 'application/ssml+xml',
-        'X-Microsoft-OutputFormat': 'audio-24khz-48kbitrate-mono-mp3',
-        'User-Agent': 'sayit-web',
-      },
-      body: ssml,
+    const { audioStream } = await client.synthToBytestream(text, {
+      voice: voiceId,
+      rate,
+      pitch,
+      volume,
+      format: 'mp3',
+      useWordBoundary: false,
     });
 
-    if (!azureResponse.ok) {
-      const errorText = await azureResponse.text().catch(() => azureResponse.statusText);
-      console.error(`Azure TTS REST error: ${azureResponse.status} ${errorText}`);
-      return NextResponse.json(
-        { error: 'Azure TTS error', details: errorText },
-        { status: azureResponse.status },
-      );
-    }
-
-    return new Response(azureResponse.body, {
+    return new Response(audioStream, {
       status: 200,
       headers: {
         'Content-Type': 'audio/mpeg',

--- a/app/api/azure/tts/route.ts
+++ b/app/api/azure/tts/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { AzureTTSClient } from 'js-tts-wrapper';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type AzureRate = 'x-slow' | 'slow' | 'medium' | 'fast' | 'x-fast';
+type AzurePitch = 'x-low' | 'low' | 'medium' | 'high' | 'x-high';
+
+function rateToAzure(rate?: number): AzureRate | undefined {
+  if (rate === undefined) return undefined;
+  if (rate <= 0.6) return 'x-slow';
+  if (rate <= 0.85) return 'slow';
+  if (rate <= 1.15) return 'medium';
+  if (rate <= 1.6) return 'fast';
+  return 'x-fast';
+}
+
+function pitchToAzure(pitch?: number): AzurePitch | undefined {
+  if (pitch === undefined) return undefined;
+  if (pitch <= 0.6) return 'x-low';
+  if (pitch <= 0.85) return 'low';
+  if (pitch <= 1.15) return 'medium';
+  if (pitch <= 1.6) return 'high';
+  return 'x-high';
+}
+
+export async function POST(request: Request) {
+  try {
+    const subscriptionKey = process.env.AZURE_SUBSCRIPTION_KEY?.replace(/^\uFEFF/, '').trim();
+    const region = process.env.AZURE_REGION?.replace(/^\uFEFF/, '').trim();
+
+    if (!subscriptionKey || !region) {
+      console.error('AZURE_SUBSCRIPTION_KEY or AZURE_REGION is not set');
+      return NextResponse.json({ error: 'API configuration error' }, { status: 500 });
+    }
+
+    const body = await request.json();
+    const { text, voiceId, rate, pitch, volume } = body;
+
+    if (!text) {
+      return NextResponse.json({ error: 'Text is required' }, { status: 400 });
+    }
+
+    if (!voiceId) {
+      return NextResponse.json({ error: 'Voice ID is required' }, { status: 400 });
+    }
+
+    const client = new AzureTTSClient({ subscriptionKey, region });
+
+    const { audioStream } = await client.synthToBytestream(text, {
+      voice: voiceId,
+      rate: rateToAzure(rate),
+      pitch: pitchToAzure(pitch),
+      volume: volume !== undefined ? Math.round(volume * 100) : undefined,
+    });
+
+    return new Response(audioStream as unknown as ReadableStream, {
+      status: 200,
+      headers: {
+        'Content-Type': 'audio/mpeg',
+        'Transfer-Encoding': 'chunked',
+        'Cache-Control': 'no-cache',
+      },
+    });
+  } catch (error) {
+    console.error('Error in Azure TTS API:', error);
+    return NextResponse.json(
+      { error: 'Server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/azure/tts/route.ts
+++ b/app/api/azure/tts/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { AzureTTSClient } from 'js-tts-wrapper';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -7,22 +6,46 @@ export const dynamic = 'force-dynamic';
 type AzureRate = 'x-slow' | 'slow' | 'medium' | 'fast' | 'x-fast';
 type AzurePitch = 'x-low' | 'low' | 'medium' | 'high' | 'x-high';
 
-function rateToAzure(rate?: number): AzureRate | undefined {
-  if (rate === undefined) return undefined;
+function rateToAzure(rate?: number): AzureRate {
+  if (rate === undefined || (rate > 0.85 && rate <= 1.15)) return 'medium';
   if (rate <= 0.6) return 'x-slow';
   if (rate <= 0.85) return 'slow';
-  if (rate <= 1.15) return 'medium';
   if (rate <= 1.6) return 'fast';
   return 'x-fast';
 }
 
-function pitchToAzure(pitch?: number): AzurePitch | undefined {
-  if (pitch === undefined) return undefined;
+function pitchToAzure(pitch?: number): AzurePitch {
+  if (pitch === undefined || (pitch > 0.85 && pitch <= 1.15)) return 'medium';
   if (pitch <= 0.6) return 'x-low';
   if (pitch <= 0.85) return 'low';
-  if (pitch <= 1.15) return 'medium';
   if (pitch <= 1.6) return 'high';
   return 'x-high';
+}
+
+function volumeToAzure(volume?: number): string {
+  if (volume === undefined) return 'medium';
+  // volume is 0-1; Azure accepts 0-100 or keywords
+  const pct = Math.round(volume * 100);
+  return `${pct}%`;
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildSsml(text: string, voiceId: string, rate: AzureRate, pitch: AzurePitch, volume: string): string {
+  // Extract language from voice ID (e.g. en-US-JennyNeural → en-US)
+  const lang = voiceId.split('-').slice(0, 2).join('-') || 'en-US';
+  return `<speak version='1.0' xml:lang='${lang}' xmlns='http://www.w3.org/2001/10/synthesis'>` +
+    `<voice name='${voiceId}'>` +
+    `<prosody rate='${rate}' pitch='${pitch}' volume='${volume}'>` +
+    `${escapeXml(text)}` +
+    `</prosody></voice></speak>`;
 }
 
 export async function POST(request: Request) {
@@ -46,16 +69,36 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Voice ID is required' }, { status: 400 });
     }
 
-    const client = new AzureTTSClient({ subscriptionKey, region });
+    const ssml = buildSsml(
+      text,
+      voiceId,
+      rateToAzure(rate),
+      pitchToAzure(pitch),
+      volumeToAzure(volume),
+    );
 
-    const { audioStream } = await client.synthToBytestream(text, {
-      voice: voiceId,
-      rate: rateToAzure(rate),
-      pitch: pitchToAzure(pitch),
-      volume: volume !== undefined ? Math.round(volume * 100) : undefined,
+    const endpoint = `https://${region}.tts.speech.microsoft.com/cognitiveservices/v1`;
+    const azureResponse = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Ocp-Apim-Subscription-Key': subscriptionKey,
+        'Content-Type': 'application/ssml+xml',
+        'X-Microsoft-OutputFormat': 'audio-24khz-48kbitrate-mono-mp3',
+        'User-Agent': 'sayit-web',
+      },
+      body: ssml,
     });
 
-    return new Response(audioStream as unknown as ReadableStream, {
+    if (!azureResponse.ok) {
+      const errorText = await azureResponse.text().catch(() => azureResponse.statusText);
+      console.error(`Azure TTS REST error: ${azureResponse.status} ${errorText}`);
+      return NextResponse.json(
+        { error: 'Azure TTS error', details: errorText },
+        { status: azureResponse.status },
+      );
+    }
+
+    return new Response(azureResponse.body, {
       status: 200,
       headers: {
         'Content-Type': 'audio/mpeg',

--- a/app/api/azure/voices/route.ts
+++ b/app/api/azure/voices/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { AzureTTSClient } from 'js-tts-wrapper';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const subscriptionKey = process.env.AZURE_SUBSCRIPTION_KEY?.replace(/^\uFEFF/, '').trim();
+    const region = process.env.AZURE_REGION?.replace(/^\uFEFF/, '').trim();
+
+    if (!subscriptionKey || !region) {
+      return NextResponse.json({ voices: [], available: false });
+    }
+
+    const client = new AzureTTSClient({ subscriptionKey, region });
+    const unifiedVoices = await client.getVoices();
+
+    const voices = unifiedVoices.map(v => ({
+      voice_id: v.id,
+      name: v.name,
+    }));
+
+    return NextResponse.json({ voices, available: voices.length > 0 });
+  } catch (error) {
+    console.error('Error loading Azure voices:', error);
+    return NextResponse.json({ voices: [], available: false });
+  }
+}

--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -379,31 +379,6 @@ export default function TTSSettings() {
             </>
           )}
 
-          {/* Azure settings */}
-          {settings.ttsProvider === 'azure' && hasSubscription && (
-            <>
-              <Slider
-                value={settings.speechRate}
-                onChange={(value) => updateSetting('speechRate', value)}
-                min={0.5}
-                max={2}
-                step={0.1}
-                label="Speed"
-                valueLabel={(v) => `${v.toFixed(1)}x`}
-              />
-
-              <Slider
-                value={settings.speechPitch}
-                onChange={(value) => updateSetting('speechPitch', value)}
-                min={0.5}
-                max={2}
-                step={0.1}
-                label="Pitch"
-                valueLabel={(v) => v.toFixed(1)}
-              />
-            </>
-          )}
-
           {/* ElevenLabs-specific settings */}
           {settings.ttsProvider === 'elevenlabs' && hasSubscription && (
             <>
@@ -429,9 +404,15 @@ export default function TTSSettings() {
             </>
           )}
 
-          {(settings.ttsProvider === 'elevenlabs' || settings.ttsProvider === 'azure') && !hasSubscription && (
+          {settings.ttsProvider === 'elevenlabs' && !hasSubscription && (
             <p className="text-xs text-text-tertiary text-center py-2">
               Advanced voice controls available with Pro subscription
+            </p>
+          )}
+
+          {settings.ttsProvider === 'azure' && (
+            <p className="text-xs text-text-tertiary text-center py-2">
+              Voice speed and pitch are set by the selected Azure voice.
             </p>
           )}
         </div>

--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -10,6 +10,9 @@ import { Slider } from '@/app/components/ui/Slider';
 import { useRouter } from 'next/navigation';
 import { PlayCircleIcon, StopCircleIcon } from '@heroicons/react/24/solid';
 
+// Sample text used for voice preview
+const SAMPLE_TEXT = 'This is how I sound.';
+
 export default function TTSSettings() {
   const { settings, updateSetting } = useSettings();
   const {
@@ -21,59 +24,58 @@ export default function TTSSettings() {
     getVoicesByProvider,
     refreshVoices,
     loadElevenLabsVoices,
+    loadAzureVoices,
     hasSubscription
   } = useTTS();
 
   const router = useRouter();
   const { isOnline } = useOnlineStatus();
 
-  const [providerVoices, setProviderVoices] = useState<typeof voices>([]);
+  const [providerVoices, setProviderVoices] = useState(voices);
 
-  const SAMPLE_TEXT = 'This is how I sound.';
-
-  // Load provider voices only when voices or provider changes
+  // Refresh browser voices when switching to browser provider
   useEffect(() => {
     if (settings.ttsProvider === 'browser') {
       refreshVoices();
     }
   }, [refreshVoices, settings.ttsProvider]);
 
+  // Load ElevenLabs voices when online
   useEffect(() => {
-    if (!isOnline) {
-      return;
-    }
-
+    if (!isOnline) return;
     void loadElevenLabsVoices();
   }, [isOnline, loadElevenLabsVoices]);
 
+  // Load Azure voices when online
   useEffect(() => {
-    const voicesForProvider = getVoicesByProvider(settings.ttsProvider);
-    setProviderVoices(voicesForProvider);
+    if (!isOnline) return;
+    void loadAzureVoices();
+  }, [isOnline, loadAzureVoices]);
+
+  // Update visible voices when provider or voice list changes
+  useEffect(() => {
+    setProviderVoices(getVoicesByProvider(settings.ttsProvider));
   }, [voices, settings.ttsProvider, getVoicesByProvider]);
 
-  // Handle default voice selection if needed
+  // Auto-select first voice if current voice doesn't exist in this provider
   useEffect(() => {
     if (providerVoices.length > 0) {
       const currentVoiceExists = providerVoices.some(v => v.id === settings.ttsVoiceId);
-
       if (!currentVoiceExists) {
         updateSetting('ttsVoiceId', providerVoices[0].id);
       }
     }
   }, [providerVoices, settings.ttsVoiceId, updateSetting]);
 
-  // Safe provider change
   const handleProviderChange = useCallback((newProvider: TTSProviderType) => {
-    if (newProvider === 'elevenlabs' && (!status.elevenLabsAvailable || !isOnline)) {
-      return;
-    }
+    if (newProvider === 'elevenlabs' && (!status.elevenLabsAvailable || !isOnline)) return;
+    if (newProvider === 'azure' && (!status.azureAvailable || !isOnline)) return;
 
     if (settings.ttsProvider !== newProvider) {
       updateSetting('ttsProvider', newProvider);
     }
-  }, [isOnline, settings.ttsProvider, status.elevenLabsAvailable, updateSetting]);
+  }, [isOnline, settings.ttsProvider, status.elevenLabsAvailable, status.azureAvailable, updateSetting]);
 
-  // Preview voice function
   const previewVoice = useCallback(() => {
     if (isSpeaking) {
       stop();
@@ -82,8 +84,13 @@ export default function TTSSettings() {
     speak(SAMPLE_TEXT);
   }, [speak, stop, isSpeaking]);
 
-  // Get selected voice name for display
   const selectedVoiceName = providerVoices.find(v => v.id === settings.ttsVoiceId)?.name;
+
+  const providerLabel = settings.ttsProvider === 'elevenlabs'
+    ? 'ElevenLabs'
+    : settings.ttsProvider === 'azure'
+      ? 'Azure'
+      : 'Browser TTS';
 
   return (
     <div className="space-y-6">
@@ -102,6 +109,7 @@ export default function TTSSettings() {
                 onChange={(value) => updateSetting('ttsVoiceId', value)}
                 placeholder={providerVoices.length === 0 ? 'Loading voices...' : 'Select a voice'}
                 disabled={providerVoices.length === 0}
+                searchable
               />
             </div>
 
@@ -122,7 +130,7 @@ export default function TTSSettings() {
 
           {selectedVoiceName && (
             <p className="mt-2 text-xs text-text-tertiary">
-              Provider: {settings.ttsProvider === 'browser' ? 'Browser TTS' : 'ElevenLabs'}
+              Provider: {providerLabel}
             </p>
           )}
         </div>
@@ -131,8 +139,8 @@ export default function TTSSettings() {
       {/* Provider Selection Card */}
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-foreground">Provider</h3>
-        <div className="grid grid-cols-2 gap-3">
-          {/* Browser TTS Option */}
+        <div className="grid grid-cols-3 gap-3">
+          {/* Browser TTS */}
           <button
             type="button"
             onClick={() => handleProviderChange('browser')}
@@ -155,13 +163,13 @@ export default function TTSSettings() {
                 )}
               </div>
               <div className="min-w-0">
-                <span className="block font-medium text-foreground text-sm">Browser TTS</span>
+                <span className="block font-medium text-foreground text-sm">Browser</span>
                 <span className="block text-xs text-text-secondary mt-0.5">System voices</span>
               </div>
             </div>
           </button>
 
-          {/* ElevenLabs Option */}
+          {/* ElevenLabs */}
           <button
             type="button"
             onClick={() => handleProviderChange('elevenlabs')}
@@ -187,7 +195,7 @@ export default function TTSSettings() {
                 )}
               </div>
               <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-1.5">
                   <span className="font-medium text-foreground text-sm">ElevenLabs</span>
                   {!hasSubscription && status.elevenLabsAvailable && (
                     <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold bg-primary-900 text-primary-400 rounded">
@@ -199,12 +207,51 @@ export default function TTSSettings() {
               </div>
             </div>
           </button>
+
+          {/* Azure */}
+          <button
+            type="button"
+            onClick={() => handleProviderChange('azure')}
+            disabled={!status.azureAvailable || !isOnline}
+            className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
+              !status.azureAvailable || !isOnline
+                ? 'opacity-50 cursor-not-allowed border-border bg-surface'
+                : settings.ttsProvider === 'azure'
+                  ? 'border-primary-500 bg-primary-900'
+                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              <div className={`w-4 h-4 mt-0.5 rounded-full border-2 flex-shrink-0 ${
+                settings.ttsProvider === 'azure'
+                  ? 'border-primary-500 bg-primary-500'
+                  : 'border-text-tertiary'
+              }`}>
+                {settings.ttsProvider === 'azure' && (
+                  <div className="w-full h-full flex items-center justify-center">
+                    <div className="w-1.5 h-1.5 bg-white rounded-full" />
+                  </div>
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium text-foreground text-sm">Azure</span>
+                  {!hasSubscription && status.azureAvailable && (
+                    <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold bg-primary-900 text-primary-400 rounded">
+                      PRO
+                    </span>
+                  )}
+                </div>
+                <span className="block text-xs text-text-secondary mt-0.5">Neural voices</span>
+              </div>
+            </div>
+          </button>
         </div>
 
-        {/* Subtle subscription note */}
-        {settings.ttsProvider === 'elevenlabs' && !hasSubscription && status.elevenLabsAvailable && (
+        {/* Subscription note */}
+        {(settings.ttsProvider === 'elevenlabs' || settings.ttsProvider === 'azure') && !hasSubscription && (
           <p className="text-xs text-text-secondary px-1">
-            Pro subscription required for ElevenLabs voices.{' '}
+            Pro subscription required for {providerLabel} voices.{' '}
             <button
               type="button"
               onClick={() => router.push('/pricing')}
@@ -217,13 +264,19 @@ export default function TTSSettings() {
 
         {!isOnline && (
           <p className="text-xs text-amber-500 px-1">
-            Offline. Browser TTS still works, but ElevenLabs voices need internet.
+            Offline. Browser TTS still works, but ElevenLabs and Azure voices need internet.
           </p>
         )}
 
         {!status.elevenLabsAvailable && isOnline && (
           <p className="text-xs text-text-tertiary px-1">
             ElevenLabs unavailable. API key not configured.
+          </p>
+        )}
+
+        {!status.azureAvailable && isOnline && (
+          <p className="text-xs text-text-tertiary px-1">
+            Azure unavailable. Subscription key not configured.
           </p>
         )}
       </div>
@@ -326,6 +379,31 @@ export default function TTSSettings() {
             </>
           )}
 
+          {/* Azure settings */}
+          {settings.ttsProvider === 'azure' && hasSubscription && (
+            <>
+              <Slider
+                value={settings.speechRate}
+                onChange={(value) => updateSetting('speechRate', value)}
+                min={0.5}
+                max={2}
+                step={0.1}
+                label="Speed"
+                valueLabel={(v) => `${v.toFixed(1)}x`}
+              />
+
+              <Slider
+                value={settings.speechPitch}
+                onChange={(value) => updateSetting('speechPitch', value)}
+                min={0.5}
+                max={2}
+                step={0.1}
+                label="Pitch"
+                valueLabel={(v) => v.toFixed(1)}
+              />
+            </>
+          )}
+
           {/* ElevenLabs-specific settings */}
           {settings.ttsProvider === 'elevenlabs' && hasSubscription && (
             <>
@@ -351,7 +429,7 @@ export default function TTSSettings() {
             </>
           )}
 
-          {settings.ttsProvider === 'elevenlabs' && !hasSubscription && (
+          {(settings.ttsProvider === 'elevenlabs' || settings.ttsProvider === 'azure') && !hasSubscription && (
             <p className="text-xs text-text-tertiary text-center py-2">
               Advanced voice controls available with Pro subscription
             </p>

--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -110,6 +110,7 @@ export default function TTSSettings() {
                 placeholder={providerVoices.length === 0 ? 'Loading voices...' : 'Select a voice'}
                 disabled={providerVoices.length === 0}
                 searchable
+                searchPlaceholder="Search voices..."
               />
             </div>
 

--- a/app/components/ui/Dropdown.tsx
+++ b/app/components/ui/Dropdown.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, ReactNode, useState } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
-import { CheckIcon, ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { CheckIcon, ChevronDownIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { cn } from '@/lib/utils';
 
 export interface DropdownOption<T = string> {
@@ -21,6 +21,7 @@ interface DropdownProps<T = string> {
   disabled?: boolean;
   placeholder?: string;
   error?: string;
+  searchable?: boolean;
   renderOption?: (option: DropdownOption<T>) => ReactNode;
 }
 
@@ -34,14 +35,26 @@ export function Dropdown<T = string>({
   disabled = false,
   placeholder = 'Select an option',
   error,
+  searchable = false,
   renderOption
 }: DropdownProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
   const selectedOption = options.find(option => option.value === value);
+
+  const filteredOptions = searchable && searchQuery.trim()
+    ? options.filter(o => o.label.toLowerCase().includes(searchQuery.toLowerCase()))
+    : options;
 
   const handleSelect = (optionValue: T) => {
     onChange(optionValue);
     setIsOpen(false);
+    setSearchQuery('');
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setSearchQuery('');
   };
 
   return (
@@ -77,7 +90,7 @@ export function Dropdown<T = string>({
       </button>
 
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-[65]" onClose={() => setIsOpen(false)}>
+        <Dialog as="div" className="relative z-[65]" onClose={handleClose}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -108,15 +121,31 @@ export function Dropdown<T = string>({
                     </Dialog.Title>
                     <button
                       type="button"
-                      onClick={() => setIsOpen(false)}
+                      onClick={handleClose}
                       className="p-2 rounded-full hover:bg-surface-hover transition-colors"
                     >
                       <XMarkIcon className="w-5 h-5 text-text-tertiary" />
                     </button>
                   </div>
 
+                  {searchable && (
+                    <div className="p-3 border-b border-border">
+                      <div className="relative">
+                        <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary pointer-events-none" />
+                        <input
+                          type="text"
+                          value={searchQuery}
+                          onChange={e => setSearchQuery(e.target.value)}
+                          placeholder="Search voices..."
+                          className="w-full pl-9 pr-4 py-2 text-sm bg-surface-hover border border-border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 text-foreground placeholder:text-text-tertiary"
+                          autoFocus
+                        />
+                      </div>
+                    </div>
+                  )}
+
                   <div className="max-h-80 overflow-y-auto p-2">
-                    {options.map((option, optionIdx) => {
+                    {filteredOptions.map((option, optionIdx) => {
                       const isSelected = option.value === value;
                       return (
                         <button

--- a/app/components/ui/Dropdown.tsx
+++ b/app/components/ui/Dropdown.tsx
@@ -22,6 +22,7 @@ interface DropdownProps<T = string> {
   placeholder?: string;
   error?: string;
   searchable?: boolean;
+  searchPlaceholder?: string;
   renderOption?: (option: DropdownOption<T>) => ReactNode;
 }
 
@@ -36,6 +37,7 @@ export function Dropdown<T = string>({
   placeholder = 'Select an option',
   error,
   searchable = false,
+  searchPlaceholder = 'Search...',
   renderOption
 }: DropdownProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
@@ -136,7 +138,7 @@ export function Dropdown<T = string>({
                           type="text"
                           value={searchQuery}
                           onChange={e => setSearchQuery(e.target.value)}
-                          placeholder="Search voices..."
+                          placeholder={searchPlaceholder}
                           className="w-full pl-9 pr-4 py-2 text-sm bg-surface-hover border border-border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 text-foreground placeholder:text-text-tertiary"
                           autoFocus
                         />

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -83,7 +83,7 @@ export default defineSchema({
     doubleEnterEnabled: v.optional(v.boolean()),
     doubleEnterAction: v.optional(v.union(v.literal('newline'), v.literal('speak'), v.literal('clear'), v.literal('speakAndClear'))),
     doubleEnterTimeoutMs: v.optional(v.number()),
-    ttsProvider: v.union(v.literal('browser'), v.literal('elevenlabs')),
+    ttsProvider: v.union(v.literal('browser'), v.literal('elevenlabs'), v.literal('azure')),
     ttsVoiceId: v.string(),
     ttsStability: v.number(),
     ttsSimilarityBoost: v.number(),

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -32,7 +32,7 @@ export const initializeSettings = mutation({
     doubleEnterEnabled: v.boolean(),
     doubleEnterAction: v.union(v.literal('newline'), v.literal('speak'), v.literal('clear'), v.literal('speakAndClear')),
     doubleEnterTimeoutMs: v.number(),
-    ttsProvider: v.union(v.literal('browser'), v.literal('elevenlabs')),
+    ttsProvider: v.union(v.literal('browser'), v.literal('elevenlabs'), v.literal('azure')),
     ttsVoiceId: v.string(),
     ttsStability: v.number(),
     ttsSimilarityBoost: v.number(),

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -133,7 +133,7 @@ export const updateSettings = mutation({
     doubleEnterEnabled: v.optional(v.boolean()),
     doubleEnterAction: v.optional(v.union(v.literal('newline'), v.literal('speak'), v.literal('clear'), v.literal('speakAndClear'))),
     doubleEnterTimeoutMs: v.optional(v.number()),
-    ttsProvider: v.optional(v.union(v.literal('browser'), v.literal('elevenlabs'))),
+    ttsProvider: v.optional(v.union(v.literal('browser'), v.literal('elevenlabs'), v.literal('azure'))),
     ttsVoiceId: v.optional(v.string()),
     ttsStability: v.optional(v.number()),
     ttsSimilarityBoost: v.optional(v.number()),

--- a/lib/azure-tts.ts
+++ b/lib/azure-tts.ts
@@ -22,7 +22,6 @@ export class AzureTTS {
   private loadingVoices: Promise<void> | null = null;
   private currentSessionId: number = 0;
   private abortController: AbortController | null = null;
-  private lastRequestTime: number = 0;
   private fallbackTTS: WebSpeechTTS;
 
   private callbacks: {
@@ -107,9 +106,6 @@ export class AzureTTS {
     this.currentSessionId++;
     const sessionId = this.currentSessionId;
     const isSessionActive = () => sessionId === this.currentSessionId;
-
-    const currentTime = Date.now();
-    this.lastRequestTime = currentTime;
 
     this.abortController = new AbortController();
 
@@ -200,15 +196,9 @@ export class AzureTTS {
       const err = error as Error & { name?: string };
       if (err?.name === 'AbortError') return;
 
-      const timeSinceLastRequest = Date.now() - this.lastRequestTime;
-      const isRapidRequest = timeSinceLastRequest < 2000;
-
       console.error('Azure TTS error:', error);
-
-      if (!isRapidRequest) {
-        this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
-        this.fallbackTTS.speak(text);
-      }
+      this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+      this.fallbackTTS.speak(text);
     }
   }
 

--- a/lib/azure-tts.ts
+++ b/lib/azure-tts.ts
@@ -1,0 +1,275 @@
+import { TextToSpeech as WebSpeechTTS } from './tts';
+
+export interface AzureVoice {
+  voice_id: string;
+  name: string;
+}
+
+/**
+ * Azure Cognitive Services TTS provider.
+ *
+ * Follows the same singleton + session-cancellation pattern as ElevenLabsTTS.
+ * Audio is fetched via the /api/azure/tts server-side proxy (keeps credentials
+ * server-side) and played back via a Blob URL.
+ */
+export class AzureTTS {
+  private static instance: AzureTTS;
+  private voices: AzureVoice[] = [];
+  private audio: HTMLAudioElement | null = null;
+  private isSpeaking: boolean = false;
+  private isAvailableFlag: boolean = false;
+  private voicesLoaded: boolean = false;
+  private loadingVoices: Promise<void> | null = null;
+  private currentSessionId: number = 0;
+  private abortController: AbortController | null = null;
+  private lastRequestTime: number = 0;
+  private fallbackTTS: WebSpeechTTS;
+
+  private callbacks: {
+    onStart?: () => void;
+    onEnd?: () => void;
+    onError?: (error: Error) => void;
+    onVoicesChanged?: (voices: AzureVoice[]) => void;
+  } = {};
+
+  private constructor() {
+    this.fallbackTTS = WebSpeechTTS.getInstance();
+  }
+
+  public static getInstance(): AzureTTS {
+    if (!AzureTTS.instance) {
+      AzureTTS.instance = new AzureTTS();
+    }
+    return AzureTTS.instance;
+  }
+
+  public async loadVoices() {
+    if (typeof window === 'undefined') return;
+
+    if (this.loadingVoices) {
+      return this.loadingVoices;
+    }
+
+    this.loadingVoices = (async () => {
+      try {
+        const response = await fetch('/api/azure/voices');
+        const data = await response.json();
+
+        this.voices = (data?.voices ?? []).map((v: AzureVoice) => ({
+          voice_id: v.voice_id,
+          name: v.name || 'Unnamed Voice',
+        }));
+
+        this.isAvailableFlag = data?.available ?? this.voices.length > 0;
+        this.callbacks.onVoicesChanged?.(this.voices);
+      } catch (error) {
+        this.isAvailableFlag = false;
+        this.voices = [];
+        this.callbacks.onVoicesChanged?.(this.voices);
+        console.error('Error loading Azure voices:', error);
+      } finally {
+        this.voicesLoaded = true;
+        this.loadingVoices = null;
+      }
+    })();
+
+    return this.loadingVoices;
+  }
+
+  public hasLoadedVoices(): boolean {
+    return this.voicesLoaded;
+  }
+
+  public setCallbacks(callbacks: {
+    onStart?: () => void;
+    onEnd?: () => void;
+    onError?: (error: Error) => void;
+    onVoicesChanged?: (voices: AzureVoice[]) => void;
+  }) {
+    this.callbacks = callbacks;
+
+    this.fallbackTTS.setCallbacks({
+      onStart: callbacks.onStart,
+      onEnd: callbacks.onEnd,
+      onError: callbacks.onError,
+    });
+  }
+
+  public getVoices(): AzureVoice[] {
+    return this.voices;
+  }
+
+  public async speak(text: string, options?: {
+    voiceId?: string;
+    rate?: number;
+    pitch?: number;
+    volume?: number;
+  }) {
+    this.stop();
+
+    this.currentSessionId++;
+    const sessionId = this.currentSessionId;
+    const isSessionActive = () => sessionId === this.currentSessionId;
+
+    const currentTime = Date.now();
+    this.lastRequestTime = currentTime;
+
+    this.abortController = new AbortController();
+
+    // Load voices if needed
+    if (!this.isAvailableFlag) {
+      if (!this.voicesLoaded) {
+        await this.loadVoices();
+      }
+
+      if (!isSessionActive()) return;
+
+      if (!this.isAvailableFlag) {
+        console.warn('Azure TTS is not available, falling back to browser TTS');
+        this.fallbackTTS.speak(text);
+        return;
+      }
+    }
+
+    // Resolve voice ID
+    let voiceId = options?.voiceId;
+    const voiceExists = voiceId && this.voices.some(v => v.voice_id === voiceId);
+    if (!voiceExists) {
+      voiceId = this.voices.length > 0 ? this.voices[0].voice_id : undefined;
+    }
+
+    try {
+      this.callbacks.onStart?.();
+      this.isSpeaking = true;
+
+      if (!isSessionActive()) {
+        this.isSpeaking = false;
+        return;
+      }
+
+      const response = await fetch('/api/azure/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text,
+          voiceId,
+          rate: options?.rate,
+          pitch: options?.pitch,
+          volume: options?.volume,
+        }),
+        signal: this.abortController.signal,
+      });
+
+      if (!isSessionActive()) {
+        this.isSpeaking = false;
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Azure TTS API request failed: ${response.statusText}`);
+      }
+
+      const blob = await response.blob();
+
+      if (!isSessionActive()) {
+        this.isSpeaking = false;
+        return;
+      }
+
+      const audioUrl = URL.createObjectURL(blob);
+      this.audio = new Audio(audioUrl);
+
+      // Call play() immediately (before any await) to stay within the user gesture window
+      const playPromise = this.audio.play();
+
+      this.audio.onended = () => {
+        if (!isSessionActive()) return;
+        this.isSpeaking = false;
+        this.callbacks.onEnd?.();
+        URL.revokeObjectURL(audioUrl);
+      };
+
+      this.audio.onerror = () => {
+        if (!isSessionActive()) return;
+        this.isSpeaking = false;
+        const mediaError = this.audio?.error;
+        const message = mediaError
+          ? `Audio playback error (code ${mediaError.code}): ${mediaError.message}`
+          : 'Audio playback error';
+        this.callbacks.onError?.(new Error(message));
+        URL.revokeObjectURL(audioUrl);
+      };
+
+      await playPromise;
+    } catch (error) {
+      this.isSpeaking = false;
+
+      if (!isSessionActive()) return;
+
+      const err = error as Error & { name?: string };
+      if (err?.name === 'AbortError') return;
+
+      const timeSinceLastRequest = Date.now() - this.lastRequestTime;
+      const isRapidRequest = timeSinceLastRequest < 2000;
+
+      console.error('Azure TTS error:', error);
+
+      if (!isRapidRequest) {
+        this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+        this.fallbackTTS.speak(text);
+      }
+    }
+  }
+
+  public stop() {
+    this.currentSessionId++;
+
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+
+    if (this.audio) {
+      this.audio.onended = null;
+      this.audio.onerror = null;
+      this.audio.pause();
+
+      const audioToClean = this.audio;
+      setTimeout(() => {
+        const audioSrc = audioToClean.src;
+        audioToClean.src = '';
+        if (audioSrc && audioSrc.startsWith('blob:')) {
+          URL.revokeObjectURL(audioSrc);
+        }
+      }, 100);
+
+      this.audio = null;
+    }
+
+    const wasSpeaking = this.isSpeaking;
+    this.isSpeaking = false;
+
+    if (wasSpeaking) {
+      this.callbacks.onEnd?.();
+    }
+  }
+
+  public pause() {
+    if (this.audio) {
+      this.audio.pause();
+    }
+  }
+
+  public resume() {
+    if (this.audio) {
+      this.audio.play().catch(error => {
+        console.error('Error resuming Azure audio:', error);
+        this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+    }
+  }
+
+  public isAvailable(): boolean {
+    return this.isAvailableFlag;
+  }
+}

--- a/lib/azure-tts.ts
+++ b/lib/azure-tts.ts
@@ -101,9 +101,6 @@ export class AzureTTS {
 
   public async speak(text: string, options?: {
     voiceId?: string;
-    rate?: number;
-    pitch?: number;
-    volume?: number;
   }) {
     this.stop();
 
@@ -150,13 +147,7 @@ export class AzureTTS {
       const response = await fetch('/api/azure/tts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text,
-          voiceId,
-          rate: options?.rate,
-          pitch: options?.pitch,
-          volume: options?.volume,
-        }),
+        body: JSON.stringify({ text, voiceId }),
         signal: this.abortController.signal,
       });
 

--- a/lib/hooks/useTTS.ts
+++ b/lib/hooks/useTTS.ts
@@ -15,11 +15,13 @@ export function useTTS() {
     isSpeaking: boolean;
     activeProvider: TTSProviderType;
     elevenLabsAvailable: boolean;
+    azureAvailable: boolean;
     browserTTSAvailable: boolean;
   }>({
     isSpeaking: false,
     activeProvider: 'browser',
     elevenLabsAvailable: false,
+    azureAvailable: false,
     browserTTSAvailable: false
   });
   
@@ -112,26 +114,26 @@ export function useTTS() {
       modelId: customOptions?.modelId || modelId,
     };
 
-    // Check if current provider is ElevenLabs or the voice is an ElevenLabs voice
-    const voice = options.voiceId 
-      ? voices.find(v => v.id === options.voiceId) 
+    // Check if current provider is a premium provider or the voice is a premium voice
+    const voice = options.voiceId
+      ? voices.find(v => v.id === options.voiceId)
       : null;
-    
-    const isElevenLabsVoice = voice?.provider === 'elevenlabs';
+
+    const isPremiumVoice = voice?.provider === 'elevenlabs' || voice?.provider === 'azure';
     const currentProvider = ttsRef.current.getCurrentProvider();
-    const usingElevenLabs = isElevenLabsVoice || currentProvider === 'elevenlabs';
-    
-    // If trying to use ElevenLabs without a subscription, force browser TTS
-    if (usingElevenLabs && !hasSubscription) {
+    const usingPremium = isPremiumVoice || currentProvider === 'elevenlabs' || currentProvider === 'azure';
+
+    // If trying to use a premium provider without a subscription, force browser TTS
+    if (usingPremium && !hasSubscription) {
       console.log('Forcing browser TTS for non-subscribers');
-      
+
       // Find a browser voice to use instead
       const browserVoices = voices.filter(v => v.provider === 'browser');
       const fallbackVoice = browserVoices.length > 0 ? browserVoices[0].id : undefined;
-      
+
       // Temporarily switch to browser provider if needed
       const originalProvider = ttsRef.current.getCurrentProvider();
-      if (originalProvider === 'elevenlabs') {
+      if (originalProvider === 'elevenlabs' || originalProvider === 'azure') {
         ttsRef.current.setProvider('browser');
       }
       
@@ -144,7 +146,7 @@ export function useTTS() {
       });
       
       // Update local state to reflect the temporary provider change
-      if (originalProvider === 'elevenlabs') {
+      if (originalProvider === 'elevenlabs' || originalProvider === 'azure') {
         setStatus({
           ...status,
           activeProvider: 'browser'
@@ -202,10 +204,18 @@ export function useTTS() {
     setStatus(ttsRef.current.getStatus());
   }, []);
 
+  const loadAzureVoices = useCallback(async () => {
+    if (!ttsRef.current) return;
+    await ttsRef.current.loadAzureVoices();
+    setVoices(ttsRef.current.getAllVoices());
+    setStatus(ttsRef.current.getStatus());
+  }, []);
+
   // Helper to check if a provider is actually available (considering subscription)
   const isProviderAvailable = useCallback((providerType: TTSProviderType) => {
     if (providerType === 'browser') return true;
     if (providerType === 'elevenlabs') return hasSubscription && status.elevenLabsAvailable;
+    if (providerType === 'azure') return hasSubscription && status.azureAvailable;
     return false;
   }, [hasSubscription, status]);
 
@@ -222,6 +232,7 @@ export function useTTS() {
     getVoicesByProvider,
     refreshVoices,
     loadElevenLabsVoices,
+    loadAzureVoices,
     status,
     hasSubscription,
     isProviderAvailable,

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -167,13 +167,11 @@ export class TTSProvider {
 
     const azureVoices = this.azureTTS.getVoices().map(voice => ({
       id: voice.voice_id,
-      name: `${voice.name} (Azure)`,
+      name: voice.name,
       provider: 'azure' as TTSProviderType,
     }));
 
-    const allVoices = [...browserVoices, ...elevenLabsVoices, ...azureVoices];
-    console.log('All available voices:', allVoices);
-    return allVoices;
+    return [...browserVoices, ...elevenLabsVoices, ...azureVoices];
   }
 
   public getVoicesByProvider(provider: TTSProviderType): TTSVoice[] {
@@ -218,14 +216,10 @@ export class TTSProvider {
       }
     }
 
-    console.log(`Speaking with provider: ${provider}, requested voiceId: ${options?.voiceId}`);
-
     if (provider === 'elevenlabs') {
       const allVoices = this.getAllVoices();
       const selectedVoice = allVoices.find(v => v.id === options?.voiceId && v.provider === 'elevenlabs');
       const voiceToUse = selectedVoice?.id || allVoices.find(v => v.provider === 'elevenlabs')?.id;
-
-      console.log('Using ElevenLabs voice ID:', voiceToUse);
 
       this.elevenlabsTTS.speak(text, {
         voiceId: voiceToUse,
@@ -237,8 +231,6 @@ export class TTSProvider {
       const allVoices = this.getAllVoices();
       const selectedVoice = allVoices.find(v => v.id === options?.voiceId && v.provider === 'azure');
       const voiceToUse = selectedVoice?.id || allVoices.find(v => v.provider === 'azure')?.id;
-
-      console.log('Using Azure voice ID:', voiceToUse);
 
       this.azureTTS.speak(text, { voiceId: voiceToUse });
     } else {

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -1,7 +1,8 @@
 import { ElevenLabsTTS } from './elevenlabs-tts';
+import { AzureTTS } from './azure-tts';
 import { TextToSpeech as WebSpeechTTS } from './tts';
 
-export type TTSProviderType = 'browser' | 'elevenlabs';
+export type TTSProviderType = 'browser' | 'elevenlabs' | 'azure';
 
 export interface TTSVoice {
   id: string;
@@ -13,6 +14,7 @@ export interface TTSVoice {
 export class TTSProvider {
   private static instance: TTSProvider;
   private elevenlabsTTS: ElevenLabsTTS;
+  private azureTTS: AzureTTS;
   private webSpeechTTS: WebSpeechTTS;
   private activeProvider: TTSProviderType = 'browser';
   private isSpeaking: boolean = false;
@@ -27,8 +29,9 @@ export class TTSProvider {
   private constructor() {
     this.webSpeechTTS = WebSpeechTTS.getInstance();
     this.elevenlabsTTS = ElevenLabsTTS.getInstance();
+    this.azureTTS = AzureTTS.getInstance();
     this.setupCallbacks();
-    
+
     // Default to ElevenLabs if available
     if (this.elevenlabsTTS.isAvailable()) {
       this.activeProvider = 'elevenlabs';
@@ -80,7 +83,24 @@ export class TTSProvider {
         this.callbacks.onError?.(error);
       },
       onVoicesChanged: () => {
-        // Notify that voices have changed
+        this.callbacks.onVoicesChanged?.(this.getAllVoices());
+      }
+    });
+
+    this.azureTTS.setCallbacks({
+      onStart: () => {
+        this.isSpeaking = true;
+        this.callbacks.onStart?.();
+      },
+      onEnd: () => {
+        this.isSpeaking = false;
+        this.callbacks.onEnd?.();
+      },
+      onError: (error) => {
+        this.isSpeaking = false;
+        this.callbacks.onError?.(error);
+      },
+      onVoicesChanged: () => {
         this.callbacks.onVoicesChanged?.(this.getAllVoices());
       }
     });
@@ -115,6 +135,15 @@ export class TTSProvider {
       console.warn('ElevenLabs is not available, staying with browser TTS');
       return;
     }
+
+    if (
+      provider === 'azure'
+      && this.azureTTS.hasLoadedVoices()
+      && !this.azureTTS.isAvailable()
+    ) {
+      console.warn('Azure TTS is not available, staying with browser TTS');
+      return;
+    }
     
     this.activeProvider = provider;
   }
@@ -136,7 +165,13 @@ export class TTSProvider {
       provider: 'elevenlabs' as TTSProviderType,
     }));
 
-    const allVoices = [...browserVoices, ...elevenLabsVoices];
+    const azureVoices = this.azureTTS.getVoices().map(voice => ({
+      id: voice.voice_id,
+      name: `${voice.name} (Azure)`,
+      provider: 'azure' as TTSProviderType,
+    }));
+
+    const allVoices = [...browserVoices, ...elevenLabsVoices, ...azureVoices];
     console.log('All available voices:', allVoices);
     return allVoices;
   }
@@ -159,6 +194,11 @@ export class TTSProvider {
     this.callbacks.onVoicesChanged?.(this.getAllVoices());
   }
 
+  public async loadAzureVoices() {
+    await this.azureTTS.loadVoices();
+    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+  }
+
   public speak(text: string, options?: {
     voiceId?: string;
     rate?: number;
@@ -170,33 +210,21 @@ export class TTSProvider {
   }) {
     // Determine which provider to use based on the selected voice
     let provider = this.activeProvider;
-    
+
     if (options?.voiceId) {
       const voice = this.getVoiceById(options.voiceId);
       if (voice) {
         provider = voice.provider;
       }
     }
-    
+
     console.log(`Speaking with provider: ${provider}, requested voiceId: ${options?.voiceId}`);
-    
+
     if (provider === 'elevenlabs') {
-      // Get all available voices
       const allVoices = this.getAllVoices();
-      
-      // Find the selected ElevenLabs voice
-      const selectedElevenLabsVoice = allVoices.find(v => 
-        v.id === options?.voiceId && v.provider === 'elevenlabs'
-      );
-      
-      // Log for debugging
-      console.log('Selected ElevenLabs voice:', selectedElevenLabsVoice);
-      console.log('Voice settings - stability:', options?.stability, 'similarityBoost:', options?.similarityBoost);
-      
-      // If no voice was found, get the first available ElevenLabs voice
-      const voiceToUse = selectedElevenLabsVoice?.id || 
-        allVoices.find(v => v.provider === 'elevenlabs')?.id;
-      
+      const selectedVoice = allVoices.find(v => v.id === options?.voiceId && v.provider === 'elevenlabs');
+      const voiceToUse = selectedVoice?.id || allVoices.find(v => v.provider === 'elevenlabs')?.id;
+
       console.log('Using ElevenLabs voice ID:', voiceToUse);
 
       this.elevenlabsTTS.speak(text, {
@@ -205,12 +233,25 @@ export class TTSProvider {
         similarityBoost: options?.similarityBoost,
         modelId: options?.modelId,
       });
+    } else if (provider === 'azure') {
+      const allVoices = this.getAllVoices();
+      const selectedVoice = allVoices.find(v => v.id === options?.voiceId && v.provider === 'azure');
+      const voiceToUse = selectedVoice?.id || allVoices.find(v => v.provider === 'azure')?.id;
+
+      console.log('Using Azure voice ID:', voiceToUse);
+
+      this.azureTTS.speak(text, {
+        voiceId: voiceToUse,
+        rate: options?.rate,
+        pitch: options?.pitch,
+        volume: options?.volume,
+      });
     } else {
       this.webSpeechTTS.speak(text, {
         voiceURI: options?.voiceId,
         rate: options?.rate,
         pitch: options?.pitch,
-        volume: options?.volume
+        volume: options?.volume,
       });
     }
   }
@@ -218,11 +259,14 @@ export class TTSProvider {
   public stop() {
     this.webSpeechTTS.stop();
     this.elevenlabsTTS.stop();
+    this.azureTTS.stop();
   }
 
   public pause() {
     if (this.activeProvider === 'elevenlabs') {
       this.elevenlabsTTS.pause();
+    } else if (this.activeProvider === 'azure') {
+      this.azureTTS.pause();
     } else {
       this.webSpeechTTS.pause();
     }
@@ -231,13 +275,15 @@ export class TTSProvider {
   public resume() {
     if (this.activeProvider === 'elevenlabs') {
       this.elevenlabsTTS.resume();
+    } else if (this.activeProvider === 'azure') {
+      this.azureTTS.resume();
     } else {
       this.webSpeechTTS.resume();
     }
   }
 
   public isAvailable(): boolean {
-    return this.webSpeechTTS.isAvailable() || this.elevenlabsTTS.isAvailable();
+    return this.webSpeechTTS.isAvailable() || this.elevenlabsTTS.isAvailable() || this.azureTTS.isAvailable();
   }
 
   public getStatus() {
@@ -245,6 +291,7 @@ export class TTSProvider {
       isSpeaking: this.isSpeaking,
       activeProvider: this.activeProvider,
       elevenLabsAvailable: this.elevenlabsTTS.isAvailable(),
+      azureAvailable: this.azureTTS.isAvailable(),
       browserTTSAvailable: this.webSpeechTTS.isAvailable()
     };
   }

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -240,12 +240,7 @@ export class TTSProvider {
 
       console.log('Using Azure voice ID:', voiceToUse);
 
-      this.azureTTS.speak(text, {
-        voiceId: voiceToUse,
-        rate: options?.rate,
-        pitch: options?.pitch,
-        volume: options?.volume,
-      });
+      this.azureTTS.speak(text, { voiceId: voiceToUse });
     } else {
       this.webSpeechTTS.speak(text, {
         voiceURI: options?.voiceId,

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const nextConfig = {
+  serverExternalPackages: ['sherpa-onnx-node', 'js-tts-wrapper'],
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "convex": "^1.34.1",
         "framer-motion": "^12.9.2",
         "idb": "^8.0.3",
-        "js-tts-wrapper": "^0.1.73",
+        "js-tts-wrapper": "^0.1.74",
         "nanoid": "^5.1.6",
         "next": "^16.2.3",
         "react": "^19.2.5",
@@ -11294,9 +11294,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.73",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.73.tgz",
-      "integrity": "sha512-kaeY0FvSTbVhDm55lEw3Gy7hUwpvufoF0NdFR6iQ0Yq83sAU/9A2Up+LQ+SNZV+nZc+uynpEd2eZN6rYNW4ITg==",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.74.tgz",
+      "integrity": "sha512-IG2JyiAJ3G5VW9WAeA9jV//0w5B+t1tOY+SvE5kIX+uLMxI9yZcSeMu1zgWZ1LeUcWT8Ysmb36GfiordxY5dZg==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "convex": "^1.34.1",
         "framer-motion": "^12.9.2",
         "idb": "^8.0.3",
-        "js-tts-wrapper": "^0.1.74",
+        "js-tts-wrapper": "^0.1.75",
         "nanoid": "^5.1.6",
         "next": "^16.2.3",
         "react": "^19.2.5",
@@ -11294,9 +11294,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.74",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.74.tgz",
-      "integrity": "sha512-IG2JyiAJ3G5VW9WAeA9jV//0w5B+t1tOY+SvE5kIX+uLMxI9yZcSeMu1zgWZ1LeUcWT8Ysmb36GfiordxY5dZg==",
+      "version": "0.1.75",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.75.tgz",
+      "integrity": "sha512-lDCyo6nyW5+cHhVIQf6c6hmTugYu6/d3sOtqBZmnWdtZMSsRaQG4HkqfRHGnEEHovac49p/yW1ggd+MweDZccQ==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "convex": "^1.34.1",
     "framer-motion": "^12.9.2",
     "idb": "^8.0.3",
-    "js-tts-wrapper": "^0.1.73",
+    "js-tts-wrapper": "^0.1.74",
     "nanoid": "^5.1.6",
     "next": "^16.2.3",
     "react": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "convex": "^1.34.1",
     "framer-motion": "^12.9.2",
     "idb": "^8.0.3",
-    "js-tts-wrapper": "^0.1.74",
+    "js-tts-wrapper": "^0.1.75",
     "nanoid": "^5.1.6",
     "next": "^16.2.3",
     "react": "^19.2.5",


### PR DESCRIPTION
Closes #478

## Summary

- New \`lib/azure-tts.ts\` — singleton client mirroring ElevenLabs pattern (session cancellation, Blob URL playback, fallback to browser TTS)
- New \`/api/azure/tts\` and \`/api/azure/voices\` — server-side proxy routes keep \`AZURE_SUBSCRIPTION_KEY\` / \`AZURE_REGION\` out of the browser
- \`TTSProviderType\` extended to \`'browser' | 'elevenlabs' | 'azure'\`; Azure wired through \`TTSProvider\`, \`useTTS\`, and \`TTSSettings\`
- Convex schema + validators updated with \`v.literal('azure')\`
- \`Dropdown\` gets a \`searchable\` + \`searchPlaceholder\` prop — real-time label filter, needed for 400+ Azure voices
- \`next.config.js\`: \`serverExternalPackages\` added for \`js-tts-wrapper\`/\`sherpa-onnx-node\` to fix Turbopack bundling error
- Azure uses plain-text synthesis via \`AzureTTSClient.synthToBytestream()\` — no rate/pitch/volume settings (voice characteristics are controlled by the selected Azure neural voice)

## Test plan

- [ ] Set \`AZURE_SUBSCRIPTION_KEY\` + \`AZURE_REGION\` in \`.env.local\`
- [ ] Azure voices load in TTS Settings (400+ voices visible, searchable)
- [ ] Selecting an Azure voice and clicking Preview speaks "This is how I sound"
- [ ] Stop button works mid-speech
- [ ] Settings persist across page reload (Convex sync)
- [ ] ElevenLabs and browser TTS unaffected
- [ ] \`npm run build\` passes
- [ ] 239 tests pass