### PR TITLE
fix: handle IndexedDB backing store errors in offline sync

### DIFF
--- a/app/components/offline/OfflineDataSync.tsx
+++ b/app/components/offline/OfflineDataSync.tsx
@@ -28,11 +28,15 @@ export default function OfflineDataSync() {
     const nextUserId = user?.id ?? null;
 
     if (previousUserId && previousUserId !== nextUserId) {
-      void clearOfflineCacheForUser(previousUserId);
+      void clearOfflineCacheForUser(previousUserId).catch((error) => {
+        console.error('Failed to clear offline cache on user change:', error);
+      });
     }
 
     if (!nextUserId) {
-      void clearOfflineCacheForUser(previousUserId);
+      void clearOfflineCacheForUser(previousUserId).catch((error) => {
+        console.error('Failed to clear offline cache on sign-out:', error);
+      });
     }
 
     previousUserIdRef.current = nextUserId;

--- a/lib/offline/storage.ts
+++ b/lib/offline/storage.ts
@@ -120,16 +120,23 @@ function getStorage(): Storage | null {
 }
 
 async function getDb() {
-  return openDB<OfflineBoardCacheDb>(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(BOARD_STORE)) {
-        const boards = db.createObjectStore(BOARD_STORE, {
-          keyPath: 'cacheKey',
-        });
-        boards.createIndex('byUserId', 'userId');
-      }
-    },
-  });
+  try {
+    return await openDB<OfflineBoardCacheDb>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(BOARD_STORE)) {
+          const boards = db.createObjectStore(BOARD_STORE, {
+            keyPath: 'cacheKey',
+          });
+          boards.createIndex('byUserId', 'userId');
+        }
+      },
+    });
+  } catch (error) {
+    // IndexedDB can fail in private browsing, when storage is full, or if the
+    // backing store is corrupted. Throw a typed error so callers can decide
+    // whether to surface it or degrade silently.
+    throw new Error(`IndexedDB unavailable: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 function normalizeBoardDocuments(


### PR DESCRIPTION
Closes #480

## Changes

**`lib/offline/storage.ts`**
Wrap `openDB()` in `getDb()` with try/catch. IndexedDB can fail with `UnknownError: Internal error opening backing store` in private browsing, when storage is full, or when the backing store is corrupted. The raw error now surfaces with a clear message so callers can log and degrade gracefully.

**`app/components/offline/OfflineDataSync.tsx`**
Add `.catch()` to both `void clearOfflineCacheForUser()` calls. These used `void` with no rejection handler — if IndexedDB failed they produced genuine unhandled rejections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for offline cache operations during user authentication changes, ensuring failures are now properly logged with contextual messages instead of being silently ignored
* Enhanced error reporting when IndexedDB is unavailable, with clearer diagnostic information to help troubleshoot offline functionality issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->