### PR TITLE
Fix Azure and ElevenLabs voice ignored on first speak

### DIFF
--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -217,22 +217,14 @@ export class TTSProvider {
     }
 
     if (provider === 'elevenlabs') {
-      const allVoices = this.getAllVoices();
-      const selectedVoice = allVoices.find(v => v.id === options?.voiceId && v.provider === 'elevenlabs');
-      const voiceToUse = selectedVoice?.id || allVoices.find(v => v.provider === 'elevenlabs')?.id;
-
       this.elevenlabsTTS.speak(text, {
-        voiceId: voiceToUse,
+        voiceId: options?.voiceId,
         stability: options?.stability,
         similarityBoost: options?.similarityBoost,
         modelId: options?.modelId,
       });
     } else if (provider === 'azure') {
-      const allVoices = this.getAllVoices();
-      const selectedVoice = allVoices.find(v => v.id === options?.voiceId && v.provider === 'azure');
-      const voiceToUse = selectedVoice?.id || allVoices.find(v => v.provider === 'azure')?.id;
-
-      this.azureTTS.speak(text, { voiceId: voiceToUse });
+      this.azureTTS.speak(text, { voiceId: options?.voiceId });
     } else {
       this.webSpeechTTS.speak(text, {
         voiceURI: options?.voiceId,


### PR DESCRIPTION
## Summary

- Closes #485
- In `TTSProvider.speak()`, the Azure and ElevenLabs branches were resolving the voice ID by calling `getAllVoices()` synchronously before provider voices had loaded — losing the intended voice ID and falling back to the first voice
- Fix: pass `options?.voiceId` directly to each provider's `speak()` method; both already handle resolution and fallback internally after loading their voices

## Test plan

- [ ] Select Azure provider, pick a non-default voice, navigate away from settings, trigger speech — correct voice plays on the first attempt
- [ ] Same test for ElevenLabs
- [ ] Browser TTS unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated voice ID handling for text-to-speech providers to pass voice selections directly to the provider services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->