### PR TITLE
Add voice filters (gender + language) to TTSSettings

### DIFF
--- a/app/api/azure/voices/route.ts
+++ b/app/api/azure/voices/route.ts
@@ -19,6 +19,8 @@ export async function GET() {
     const voices = unifiedVoices.map(v => ({
       voice_id: v.id,
       name: v.name,
+      gender: v.gender,
+      languageCodes: v.languageCodes ?? [],
     }));
 
     return NextResponse.json({ voices, available: voices.length > 0 });

--- a/app/api/elevenlabs/voices/route.ts
+++ b/app/api/elevenlabs/voices/route.ts
@@ -18,6 +18,8 @@ export async function GET() {
     const mapped = voices.map(v => ({
       voice_id: v.id,
       name: v.name,
+      gender: v.gender,
+      languageCodes: v.languageCodes ?? [],
     }));
 
     return NextResponse.json({ voices: mapped, available: mapped.length > 0 });

--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTTS } from '@/lib/hooks/useTTS';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { TTSProviderType } from '@/lib/tts-provider';
@@ -32,6 +32,8 @@ export default function TTSSettings() {
   const { isOnline } = useOnlineStatus();
 
   const [providerVoices, setProviderVoices] = useState(voices);
+  const [genderFilter, setGenderFilter] = useState<'All' | 'Male' | 'Female' | 'Unknown'>('All');
+  const [langFilter, setLangFilter] = useState<string>('All');
 
   // Refresh browser voices when switching to browser provider
   useEffect(() => {
@@ -57,15 +59,42 @@ export default function TTSSettings() {
     setProviderVoices(getVoicesByProvider(settings.ttsProvider));
   }, [voices, settings.ttsProvider, getVoicesByProvider]);
 
-  // Auto-select first voice if current voice doesn't exist in this provider
+  // Reset filters when provider changes
   useEffect(() => {
-    if (providerVoices.length > 0) {
-      const currentVoiceExists = providerVoices.some(v => v.id === settings.ttsVoiceId);
-      if (!currentVoiceExists) {
-        updateSetting('ttsVoiceId', providerVoices[0].id);
+    setGenderFilter('All');
+    setLangFilter('All');
+  }, [settings.ttsProvider]);
+
+  const filteredVoices = useMemo(() => {
+    let result = providerVoices;
+    if (genderFilter !== 'All') result = result.filter(v => v.gender === genderFilter);
+    if (langFilter !== 'All') result = result.filter(v => v.languageCodes?.some(lc => lc.bcp47 === langFilter));
+    return result;
+  }, [providerVoices, genderFilter, langFilter]);
+
+  const languageOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const opts: { code: string; display: string }[] = [];
+    for (const voice of providerVoices) {
+      for (const lc of voice.languageCodes ?? []) {
+        if (!seen.has(lc.bcp47)) {
+          seen.add(lc.bcp47);
+          opts.push({ code: lc.bcp47, display: lc.display });
+        }
       }
     }
-  }, [providerVoices, settings.ttsVoiceId, updateSetting]);
+    return opts.sort((a, b) => a.display.localeCompare(b.display));
+  }, [providerVoices]);
+
+  // Auto-select first voice if current voice doesn't exist in filtered list
+  useEffect(() => {
+    if (filteredVoices.length > 0) {
+      const currentVoiceExists = filteredVoices.some(v => v.id === settings.ttsVoiceId);
+      if (!currentVoiceExists) {
+        updateSetting('ttsVoiceId', filteredVoices[0].id);
+      }
+    }
+  }, [filteredVoices, settings.ttsVoiceId, updateSetting]);
 
   const handleProviderChange = useCallback((newProvider: TTSProviderType) => {
     if (newProvider === 'elevenlabs' && (!status.elevenLabsAvailable || !isOnline)) return;
@@ -84,7 +113,7 @@ export default function TTSSettings() {
     speak(SAMPLE_TEXT);
   }, [speak, stop, isSpeaking]);
 
-  const selectedVoiceName = providerVoices.find(v => v.id === settings.ttsVoiceId)?.name;
+  const selectedVoiceName = filteredVoices.find(v => v.id === settings.ttsVoiceId)?.name;
 
   const providerLabel = settings.ttsProvider === 'elevenlabs'
     ? 'ElevenLabs'
@@ -98,10 +127,34 @@ export default function TTSSettings() {
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-foreground">Voice</h3>
         <div className="bg-surface-hover rounded-2xl p-4">
+          {settings.ttsProvider !== 'browser' && providerVoices.length > 0 && (
+            <div className="grid grid-cols-2 gap-2 mb-3">
+              <select
+                value={genderFilter}
+                onChange={e => setGenderFilter(e.target.value as 'All' | 'Male' | 'Female' | 'Unknown')}
+                className="rounded-xl border border-border bg-surface text-sm px-3 py-2 text-foreground"
+              >
+                <option value="All">All genders</option>
+                <option value="Female">Female</option>
+                <option value="Male">Male</option>
+                <option value="Unknown">Unknown</option>
+              </select>
+              <select
+                value={langFilter}
+                onChange={e => setLangFilter(e.target.value)}
+                className="rounded-xl border border-border bg-surface text-sm px-3 py-2 text-foreground"
+              >
+                <option value="All">All languages</option>
+                {languageOptions.map(l => (
+                  <option key={l.code} value={l.code}>{l.display}</option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="flex items-center gap-3">
             <div className="flex-1 min-w-0">
               <Dropdown
-                options={providerVoices.map(voice => ({
+                options={filteredVoices.map(voice => ({
                   value: voice.id,
                   label: voice.name
                 }))}
@@ -132,6 +185,9 @@ export default function TTSSettings() {
           {selectedVoiceName && (
             <p className="mt-2 text-xs text-text-tertiary">
               Provider: {providerLabel}
+              {settings.ttsProvider !== 'browser' && providerVoices.length > 0 && (
+                <span className="ml-2">· {filteredVoices.length} of {providerVoices.length} voices</span>
+              )}
             </p>
           )}
         </div>

--- a/lib/azure-tts.ts
+++ b/lib/azure-tts.ts
@@ -3,6 +3,8 @@ import { TextToSpeech as WebSpeechTTS } from './tts';
 export interface AzureVoice {
   voice_id: string;
   name: string;
+  gender?: 'Male' | 'Female' | 'Unknown';
+  languageCodes?: { bcp47: string; iso639_3: string; display: string }[];
 }
 
 /**
@@ -57,6 +59,8 @@ export class AzureTTS {
         this.voices = (data?.voices ?? []).map((v: AzureVoice) => ({
           voice_id: v.voice_id,
           name: v.name || 'Unnamed Voice',
+          gender: v.gender,
+          languageCodes: v.languageCodes,
         }));
 
         this.isAvailableFlag = data?.available ?? this.voices.length > 0;

--- a/lib/elevenlabs-tts.ts
+++ b/lib/elevenlabs-tts.ts
@@ -3,6 +3,8 @@ import { TextToSpeech as WebSpeechTTS } from './tts';
 export interface Voice {
   voice_id: string;
   name: string;
+  gender?: 'Male' | 'Female' | 'Unknown';
+  languageCodes?: { bcp47: string; iso639_3: string; display: string }[];
 }
 
 
@@ -62,6 +64,8 @@ export class ElevenLabsTTS {
         this.voices = (data?.voices ?? []).map((v: Voice) => ({
           voice_id: v.voice_id,
           name: v.name || 'Unnamed Voice',
+          gender: v.gender,
+          languageCodes: v.languageCodes,
         }));
         this.isAvailableFlag = data?.available ?? this.voices.length > 0;
         this.callbacks.onVoicesChanged?.(this.voices);

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -8,6 +8,8 @@ export interface TTSVoice {
   id: string;
   name: string;
   provider: TTSProviderType;
+  gender?: 'Male' | 'Female' | 'Unknown';
+  languageCodes?: { bcp47: string; iso639_3: string; display: string }[];
 }
 
 // Unified class that can use either provider
@@ -163,12 +165,16 @@ export class TTSProvider {
       id: voice.voice_id,
       name: `${voice.name} (ElevenLabs)`,
       provider: 'elevenlabs' as TTSProviderType,
+      gender: voice.gender,
+      languageCodes: voice.languageCodes,
     }));
 
     const azureVoices = this.azureTTS.getVoices().map(voice => ({
       id: voice.voice_id,
       name: voice.name,
       provider: 'azure' as TTSProviderType,
+      gender: voice.gender,
+      languageCodes: voice.languageCodes,
     }));
 
     return [...browserVoices, ...elevenLabsVoices, ...azureVoices];

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "convex": "^1.34.1",
         "framer-motion": "^12.9.2",
         "idb": "^8.0.3",
-        "js-tts-wrapper": "^0.1.75",
+        "js-tts-wrapper": "^0.1.78",
         "nanoid": "^5.1.6",
         "next": "^16.2.3",
         "react": "^19.2.5",
@@ -11273,9 +11273,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.75",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.75.tgz",
-      "integrity": "sha512-lDCyo6nyW5+cHhVIQf6c6hmTugYu6/d3sOtqBZmnWdtZMSsRaQG4HkqfRHGnEEHovac49p/yW1ggd+MweDZccQ==",
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.78.tgz",
+      "integrity": "sha512-YbunKbQ71OWvIu7Sf4kdzAI7NtPAACDQD1tVUArQhRVsN1xQ5Xv7gjRKVMV6aRHi3pea2ZkmhIs7v5Gpffk5AQ==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "convex": "^1.34.1",
     "framer-motion": "^12.9.2",
     "idb": "^8.0.3",
-    "js-tts-wrapper": "^0.1.75",
+    "js-tts-wrapper": "^0.1.78",
     "nanoid": "^5.1.6",
     "next": "^16.2.3",
     "react": "^19.2.5",


### PR DESCRIPTION
## Summary

- Extends Azure and ElevenLabs voice API routes to return `gender` and `languageCodes` from `js-tts-wrapper`'s `UnifiedVoice`
- Propagates those fields through `AzureVoice`, `Voice`, and `TTSVoice` interfaces
- Adds gender + language filter dropdowns in `TTSSettings` for ElevenLabs/Azure providers
- Filters reset on provider switch; auto-selects first matching voice when active voice is filtered out
- Shows "X of Y voices" count in the provider label
- Bumps `js-tts-wrapper` from `0.1.75` → `0.1.78`

Closes #488

## Test plan

- [ ] Switch to ElevenLabs or Azure — filter dropdowns appear
- [ ] Filter by gender — voice list narrows, selected voice updates if needed
- [ ] Filter by language — list narrows further
- [ ] Switch to Browser — filters are hidden
- [ ] Switch provider — filters reset to "All"
- [ ] Voice preview button still works after filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice selection now supports filtering by speaker gender (Male, Female, Unknown) and language, streamlining the process of finding suitable voices.
  * Enhanced voice metadata now includes speaker gender and supported languages across all text-to-speech providers.

* **Chores**
  * Updated underlying TTS framework dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->