### PR TITLE
Fix mobile live sharing active indicator

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -83,6 +83,14 @@ export default function Composer({
   const { user } = useAuth();
   const { isOnline } = useOnlineStatus();
   const isMobile = useIsMobile();
+  const {
+    isSharing: isLiveTypingSharing,
+    isCreating: isLiveTypingCreating,
+    updateContent: updateLiveTypingContent,
+    createSession: createLiveTypingSession,
+    endSession: endLiveTypingSession,
+    getShareableLink,
+  } = useLiveTyping();
 
   const {
     tabs,
@@ -148,6 +156,8 @@ export default function Composer({
 
   const textSizePx = settings.textSize;
   const currentText = enableTabs ? activeTab.text : text;
+  const shareableLink = getShareableLink();
+  const isLiveTypingButtonActive = isLiveTypingSharing || showLiveTypingModal || showLiveTypingSheet;
 
   const showUndoHint = canUndo
     && entry?.tabId === (activeTabId || 'default')
@@ -235,7 +245,19 @@ export default function Composer({
     };
   }, [error]);
 
-  // Update shared session content when text changes
+  useEffect(() => {
+    if (enableLiveTyping && user && isLiveTypingSharing) {
+      updateLiveTypingContent(currentText);
+    }
+  }, [currentText, enableLiveTyping, isLiveTypingSharing, updateLiveTypingContent, user]);
+
+  const handleStartLiveTyping = useCallback(async () => {
+    const created = await createLiveTypingSession();
+    if (created) {
+      updateLiveTypingContent(currentText);
+    }
+  }, [createLiveTypingSession, currentText, updateLiveTypingContent]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key !== 'Enter' || e.shiftKey || e.nativeEvent.isComposing) return;
@@ -404,10 +426,10 @@ export default function Composer({
                   disabled={!isOnline}
                   className={`p-2.5 rounded-xl transition-all ${
                     !isOnline ? 'bg-surface-hover text-text-tertiary opacity-40'
-                      : (showLiveTypingModal || showLiveTypingSheet) ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
+                      : isLiveTypingButtonActive ? 'bg-gradient-to-r from-green-500 to-green-600 text-white'
                         : 'bg-surface-hover text-text-secondary hover:text-green-500 hover:bg-status-success'
                   }`}
-                  aria-label={showLiveTypingModal || showLiveTypingSheet ? 'Live Typing Active' : 'Live Typing'}
+                  aria-label={isLiveTypingButtonActive ? 'Live Typing Active' : 'Live Typing'}
                 >
                   <ShareIcon className="w-5 h-5" />
                 </button>
@@ -469,77 +491,27 @@ export default function Composer({
       )}
 
       {enableLiveTyping && user && (
-        <ComposerLiveTyping
-          currentText={currentText}
-          isMobile={isMobile}
-          isSheetOpen={showLiveTypingSheet}
-          isModalOpen={showLiveTypingModal}
-          onCloseSheet={() => setShowLiveTypingSheet(false)}
-          onCloseModal={() => setShowLiveTypingModal(false)}
-        />
-      )}
-    </>
-  );
-}
-
-function ComposerLiveTyping({
-  currentText,
-  isMobile,
-  isSheetOpen,
-  isModalOpen,
-  onCloseSheet,
-  onCloseModal,
-}: {
-  currentText: string;
-  isMobile: boolean;
-  isSheetOpen: boolean;
-  isModalOpen: boolean;
-  onCloseSheet: () => void;
-  onCloseModal: () => void;
-}) {
-  const {
-    isSharing,
-    isCreating,
-    updateContent,
-    createSession,
-    endSession,
-    getShareableLink,
-  } = useLiveTyping();
-  const shareableLink = getShareableLink();
-
-  useEffect(() => {
-    if (isSharing) {
-      updateContent(currentText);
-    }
-  }, [currentText, isSharing, updateContent]);
-
-  const handleStartSharing = useCallback(async () => {
-    const created = await createSession();
-    if (created) {
-      updateContent(currentText);
-    }
-  }, [createSession, currentText, updateContent]);
-
-  return (
-    <>
-      <LiveTypingBottomSheet
-        isOpen={isSheetOpen}
-        onClose={onCloseSheet}
-        isSharing={isSharing}
-        isCreating={isCreating}
-        shareableLink={shareableLink}
-        onStartSharing={handleStartSharing}
-        onEndSession={async () => { await endSession(); }}
-      />
-      {isModalOpen && !isMobile && shareableLink && (
-        <LiveTypingLinkModal
-          shareableLink={shareableLink}
-          onClose={onCloseModal}
-          onEndSession={async () => {
-            await endSession();
-            onCloseModal();
-          }}
-        />
+        <>
+          <LiveTypingBottomSheet
+            isOpen={showLiveTypingSheet}
+            onClose={() => setShowLiveTypingSheet(false)}
+            isSharing={isLiveTypingSharing}
+            isCreating={isLiveTypingCreating}
+            shareableLink={shareableLink}
+            onStartSharing={handleStartLiveTyping}
+            onEndSession={async () => { await endLiveTypingSession(); }}
+          />
+          {showLiveTypingModal && !isMobile && shareableLink && (
+            <LiveTypingLinkModal
+              shareableLink={shareableLink}
+              onClose={() => setShowLiveTypingModal(false)}
+              onEndSession={async () => {
+                await endLiveTypingSession();
+                setShowLiveTypingModal(false);
+              }}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -501,9 +501,11 @@ export default function Composer({
             onStartSharing={handleStartLiveTyping}
             onEndSession={async () => { await endLiveTypingSession(); }}
           />
-          {showLiveTypingModal && !isMobile && shareableLink && (
+          {showLiveTypingModal && !isMobile && (
             <LiveTypingLinkModal
               shareableLink={shareableLink}
+              isCreating={isLiveTypingCreating}
+              onStartSharing={handleStartLiveTyping}
               onClose={() => setShowLiveTypingModal(false)}
               onEndSession={async () => {
                 await endLiveTypingSession();

--- a/app/components/live-typing/LiveTypingLinkModal.tsx
+++ b/app/components/live-typing/LiveTypingLinkModal.tsx
@@ -1,19 +1,29 @@
 'use client';
 
 import { useState } from 'react';
-import { XMarkIcon, ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, ClipboardIcon, CheckIcon, ArrowPathIcon, ShareIcon } from '@heroicons/react/24/outline';
 
 interface LiveTypingLinkModalProps {
-  shareableLink: string;
+  shareableLink: string | null;
+  isCreating: boolean;
+  onStartSharing: () => Promise<void>;
   onClose: () => void;
   onEndSession: () => Promise<void>;
 }
 
-export default function LiveTypingLinkModal({ shareableLink, onClose, onEndSession }: LiveTypingLinkModalProps) {
+export default function LiveTypingLinkModal({
+  shareableLink,
+  isCreating,
+  onStartSharing,
+  onClose,
+  onEndSession,
+}: LiveTypingLinkModalProps) {
   const [copied, setCopied] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
 
   const handleCopy = async () => {
+    if (!shareableLink) return;
+
     try {
       await navigator.clipboard.writeText(shareableLink);
       setCopied(true);
@@ -33,6 +43,14 @@ export default function LiveTypingLinkModal({ shareableLink, onClose, onEndSessi
     }
   };
 
+  const handleStartSharing = async () => {
+    try {
+      await onStartSharing();
+    } catch (err) {
+      console.error('Failed to start live typing:', err);
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-overlay flex items-center justify-center p-4 z-50">
       <div className="rounded-lg shadow-xl max-w-md w-full p-6 bg-surface">
@@ -47,51 +65,87 @@ export default function LiveTypingLinkModal({ shareableLink, onClose, onEndSessi
           </button>
         </div>
 
-        <div className="mb-6">
-          <p className="text-text-secondary mb-4">
-            Share this link with others so they can see what you're typing in real-time. The session will expire in 24 hours.
-          </p>
+        {!shareableLink ? (
+          <>
+            <div className="mb-6 text-center">
+              <ShareIcon className="w-12 h-12 mx-auto text-text-secondary mb-3" />
+              <p className="text-text-secondary">
+                Let others see what you're typing in real-time. The session expires in 24 hours.
+              </p>
+            </div>
 
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={shareableLink}
-              readOnly
-              className="flex-1 px-4 py-3 bg-background border border-border rounded-lg text-foreground text-sm"
-            />
-            <button
-              onClick={handleCopy}
-              className={`px-4 py-3 rounded-lg transition-colors ${
-                copied
-                  ? 'bg-green-500 text-white'
-                  : 'bg-primary-500 hover:bg-primary-600 text-white'
-              }`}
-              aria-label="Copy link"
-            >
-              {copied ? (
-                <CheckIcon className="w-5 h-5" />
-              ) : (
-                <ClipboardIcon className="w-5 h-5" />
-              )}
-            </button>
-          </div>
-        </div>
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex-1 px-4 py-3 bg-background hover:bg-surface-hover text-foreground border border-border rounded-lg transition-colors"
+              >
+                Close
+              </button>
+              <button
+                onClick={handleStartSharing}
+                disabled={isCreating}
+                className="flex-1 px-4 py-3 bg-green-500 hover:bg-green-600 text-white rounded-lg transition-colors disabled:opacity-50"
+              >
+                {isCreating ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <ArrowPathIcon className="w-5 h-5 animate-spin" />
+                    Creating...
+                  </span>
+                ) : (
+                  'Start Live Typing'
+                )}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="mb-6">
+              <p className="text-text-secondary mb-4">
+                Share this link with others so they can see what you're typing in real-time. The session will expire in 24 hours.
+              </p>
 
-        <div className="flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-3 bg-background hover:bg-surface-hover text-foreground border border-border rounded-lg transition-colors"
-          >
-            Close
-          </button>
-          <button
-            onClick={handleEndSession}
-            disabled={isEnding}
-            className="flex-1 px-4 py-3 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors disabled:opacity-50"
-          >
-            {isEnding ? 'Ending...' : 'End Live Typing'}
-          </button>
-        </div>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={shareableLink}
+                  readOnly
+                  className="flex-1 px-4 py-3 bg-background border border-border rounded-lg text-foreground text-sm"
+                />
+                <button
+                  onClick={handleCopy}
+                  className={`px-4 py-3 rounded-lg transition-colors ${
+                    copied
+                      ? 'bg-green-500 text-white'
+                      : 'bg-primary-500 hover:bg-primary-600 text-white'
+                  }`}
+                  aria-label="Copy link"
+                >
+                  {copied ? (
+                    <CheckIcon className="w-5 h-5" />
+                  ) : (
+                    <ClipboardIcon className="w-5 h-5" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex-1 px-4 py-3 bg-background hover:bg-surface-hover text-foreground border border-border rounded-lg transition-colors"
+              >
+                Close
+              </button>
+              <button
+                onClick={handleEndSession}
+                disabled={isEnding}
+                className="flex-1 px-4 py-3 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors disabled:opacity-50"
+              >
+                {isEnding ? 'Ending...' : 'End Live Typing'}
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/tests/components/Composer.test.tsx
+++ b/tests/components/Composer.test.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Composer from '@/app/components/Composer';
+import { useAuth } from '@/app/contexts/AuthContext';
+import { useLiveTyping } from '@/lib/hooks/useLiveTyping';
+import { useIsMobile } from '@/lib/hooks/useIsMobile';
 
 jest.mock('nanoid', () => {
   let idCounter = 0;
@@ -105,6 +108,10 @@ const localStorageMock = (() => {
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
+const mockUseAuth = jest.mocked(useAuth);
+const mockUseLiveTyping = jest.mocked(useLiveTyping);
+const mockUseIsMobile = jest.mocked(useIsMobile);
+
 describe('Composer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -184,5 +191,38 @@ describe('Composer', () => {
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith('Restored draft');
     });
+  });
+
+  it('shows live typing as active on mobile while sharing after the sheet is closed', () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+      },
+      loading: false,
+    });
+    mockUseIsMobile.mockReturnValue(true);
+    mockUseLiveTyping.mockReturnValue({
+      session: null,
+      isSharing: true,
+      isCreating: false,
+      error: null,
+      createSession: jest.fn(),
+      endSession: jest.fn(),
+      updateContent: jest.fn(),
+      getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
+    });
+
+    render(
+      <Composer
+        text="Sharing now"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableLiveTyping={true}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Live Typing Active' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Live Typing' })).not.toBeInTheDocument();
   });
 });

--- a/tests/components/live-typing/LiveTypingLinkModal.test.tsx
+++ b/tests/components/live-typing/LiveTypingLinkModal.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LiveTypingLinkModal from '@/app/components/live-typing/LiveTypingLinkModal';
+
+describe('LiveTypingLinkModal', () => {
+  it('starts a live typing session when no shareable link exists yet', async () => {
+    const user = userEvent.setup();
+    const onStartSharing = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <LiveTypingLinkModal
+        shareableLink={null}
+        isCreating={false}
+        onStartSharing={onStartSharing}
+        onClose={jest.fn()}
+        onEndSession={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Start Live Typing' }));
+
+    expect(onStartSharing).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows sharing controls when a shareable link exists', () => {
+    render(
+      <LiveTypingLinkModal
+        shareableLink="https://example.com/typing-share/view/session-key"
+        isCreating={false}
+        onStartSharing={jest.fn()}
+        onClose={jest.fn()}
+        onEndSession={jest.fn()}
+      />
+    );
+
+    expect(screen.getByDisplayValue('https://example.com/typing-share/view/session-key')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'End Live Typing' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Lift live typing session state into the Composer so the toolbar can reflect active sharing after the mobile sheet closes
- Keep the bottom sheet and desktop modal wired to the same live typing state/actions
- Add a regression test for mobile active sharing state

Closes #491

## Verification
- npm test -- --runTestsByPath tests/components/Composer.test.tsx
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to initiate live-typing sharing from the composer and link modal/sheet, including a "start sharing" CTA and creating state.

* **Bug Fixes**
  * Improved live-typing session integration: synchronized live content updates, unified toolbar active state and accessibility label, and proper modal/sheet close behavior after ending sessions.

* **Tests**
  * Added/updated tests covering composer live-typing UI states and link modal behaviors (start, copy, end).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->