### PR TITLE
Make composer keyboard-aware

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -12,6 +12,7 @@ import ConnectivityBanner from './components/navigation/ConnectivityBanner';
 import InstallBanner from './components/navigation/InstallBanner';
 import Sidebar from './components/Sidebar';
 import MobileBottomStack from './components/navigation/MobileBottomStack';
+import ViewportCssVars from './components/navigation/ViewportCssVars';
 import OfflineAppShell from './components/offline/OfflineAppShell';
 import OfflineDataSync from './components/offline/OfflineDataSync';
 import OnlineStartupWatch from './components/startup/OnlineStartupWatch';
@@ -113,6 +114,7 @@ export default function ClientLayout({
         <StaticAuthProvider>
           <SettingsProvider>
             <MobileBottomProvider>
+              <ViewportCssVars />
               <OfflineAppShell mode={offlineMode} />
             </MobileBottomProvider>
           </SettingsProvider>
@@ -127,6 +129,7 @@ export default function ClientLayout({
         <AuthProvider>
           <SettingsProvider>
             <MobileBottomProvider>
+              <ViewportCssVars />
               <OnlineStartupWatch onReady={handleStartupReady}>
                 <OfflineDataSync />
                 <div className="min-h-dvh flex flex-col md:flex-row">

--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -337,14 +337,14 @@ export default function Composer({
         )}
 
         {/* Textarea — full bleed, fills the screen */}
-        <div className="flex-1 min-h-0">
+        <div className="flex-1 min-h-[120px] overflow-hidden">
           <textarea
             ref={inputRef}
             value={currentText}
             onChange={(e) => handleTextChange(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="What do you want to say?"
-            className="w-full h-full bg-transparent text-foreground placeholder:text-text-tertiary px-6 py-5 resize-none focus:outline-none"
+            className="w-full h-full overflow-y-auto bg-transparent text-foreground placeholder:text-text-tertiary px-6 py-5 resize-none focus:outline-none"
             style={{ fontSize: `${textSizePx}px`, lineHeight: '1.6' }}
           />
         </div>

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -446,21 +446,25 @@ export default function PhrasesInterface() {
   );
 
   return (
-    <>
-      <ConnectionRequestsBanner />
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <div className="shrink-0">
+        <ConnectionRequestsBanner />
+      </div>
       {captureError && (
         <div
-          className="sticky top-0 z-40 border-b border-red-900 bg-surface px-4 py-3 text-sm text-red-300"
+          className="sticky top-0 z-40 shrink-0 border-b border-red-900 bg-surface px-4 py-3 text-sm text-red-300"
           role="status"
           aria-live="polite"
         >
           Couldn&apos;t save message to history. It will be retried next time.
         </div>
       )}
-      <AACTabs
-        phrasesContent={phrasesContent}
-        typeContent={composer}
-      />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <AACTabs
+          phrasesContent={phrasesContent}
+          typeContent={composer}
+        />
+      </div>
       <BoardGridPopup
         boards={transformedBoards}
         selectedBoard={selectedBoard}
@@ -473,6 +477,6 @@ export default function PhrasesInterface() {
           router.push(`/phrases/boards/edit/${boardId}`);
         }}
       />
-    </>
+    </div>
   );
 }

--- a/app/components/navigation/MobileBottomStack.tsx
+++ b/app/components/navigation/MobileBottomStack.tsx
@@ -14,11 +14,13 @@ export default function MobileBottomStack() {
   }, [registerDockContainer]);
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 md:hidden flex flex-col">
+    <div className="fixed bottom-keyboard-aware left-0 right-0 z-50 md:hidden flex flex-col">
       {/* Dock content slot - portal target */}
       <div ref={dockRef} className="bg-surface" />
       {/* Tab bar */}
-      <BottomTabBar />
+      <div className="mobile-keyboard-hide">
+        <BottomTabBar />
+      </div>
     </div>
   );
 }

--- a/app/components/navigation/ViewportCssVars.tsx
+++ b/app/components/navigation/ViewportCssVars.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
+
+const KEYBOARD_OPEN_THRESHOLD_PX = 80;
+
+export default function ViewportCssVars() {
+  const viewport = useVisualViewport();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const root = document.documentElement;
+    const viewportHeight = viewport.height ?? window.innerHeight;
+    const keyboardInset = Math.max(
+      0,
+      window.innerHeight - ((viewport.top ?? 0) + viewportHeight)
+    );
+    const isKeyboardOpen = keyboardInset > KEYBOARD_OPEN_THRESHOLD_PX;
+
+    root.style.setProperty('--visual-viewport-height', `${viewportHeight}px`);
+    root.style.setProperty('--keyboard-inset', `${keyboardInset}px`);
+    root.dataset.keyboardOpen = isKeyboardOpen ? 'true' : 'false';
+
+    return () => {
+      root.style.removeProperty('--visual-viewport-height');
+      root.style.removeProperty('--keyboard-inset');
+      delete root.dataset.keyboardOpen;
+    };
+  }, [viewport.height, viewport.top]);
+
+  return null;
+}

--- a/app/components/offline/OfflineAppShell.tsx
+++ b/app/components/offline/OfflineAppShell.tsx
@@ -209,9 +209,9 @@ export default function OfflineAppShell({
   );
 
   return (
-    <div className="min-h-dvh bg-background">
-      <section className="mx-auto flex min-h-dvh w-full max-w-6xl flex-col px-4 py-6">
-        <div className="flex min-h-[65dvh] flex-1 flex-col rounded-3xl border border-border bg-surface shadow-2xl">
+    <div className="h-visual-viewport min-h-0 overflow-hidden bg-background">
+      <section className="mx-auto flex h-full min-h-0 w-full max-w-6xl flex-col px-4 py-6">
+        <div className="flex min-h-0 flex-1 flex-col rounded-3xl border border-border bg-surface shadow-2xl">
           <AACTabs
             phrasesContent={phrasesContent}
             typeContent={typeContent}
@@ -219,7 +219,7 @@ export default function OfflineAppShell({
         </div>
 
         {messages.length > 0 && (
-          <div className="mt-4 rounded-3xl border border-border bg-surface px-5 py-4 shadow-lg">
+          <div className="mt-4 max-h-[30%] shrink-0 overflow-y-auto rounded-3xl border border-border bg-surface px-5 py-4 shadow-lg">
             <h2 className="text-sm font-semibold text-foreground">Recent on this device</h2>
             <p className="mt-1 text-xs text-text-secondary">
               Tap a recent message to bring it back into the typing area.

--- a/app/globals.css
+++ b/app/globals.css
@@ -155,6 +155,21 @@ body {
   .max-h-dvh {
     max-height: 100dvh;
   }
+  .h-visual-viewport {
+    height: var(--visual-viewport-height, 100dvh);
+  }
+  .min-h-visual-viewport {
+    min-height: var(--visual-viewport-height, 100dvh);
+  }
+  .max-h-visual-viewport {
+    max-height: var(--visual-viewport-height, 100dvh);
+  }
+  .bottom-keyboard-aware {
+    bottom: var(--keyboard-inset, 0px);
+  }
+  html[data-keyboard-open="true"] .mobile-keyboard-hide {
+    display: none;
+  }
 
   /* Touch-friendly tap targets (minimum 44x44px) */
   .touch-target {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,11 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className={`flex flex-col bg-background ${
+      user
+        ? 'h-visual-viewport min-h-0 overflow-hidden'
+        : 'min-h-screen'
+    }`}>
       {!user ? (
         <>
           <GuestCommunication />

--- a/tests/components/Composer.test.tsx
+++ b/tests/components/Composer.test.tsx
@@ -161,6 +161,22 @@ describe('Composer', () => {
     expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
   });
 
+  it('lets the textarea shrink first while keeping composer controls rendered', () => {
+    render(
+      <Composer
+        text="Some text"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+      />
+    );
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.parentElement).toHaveClass('flex-1', 'min-h-[120px]', 'overflow-hidden');
+    expect(textarea).toHaveClass('h-full', 'overflow-y-auto', 'resize-none');
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
+  });
+
   it('restores the active tab draft on mount when tabs enabled', async () => {
     localStorageMock.setItem('typingTabs', JSON.stringify({
       tabs: [

--- a/tests/components/navigation/MobileBottomStack.test.tsx
+++ b/tests/components/navigation/MobileBottomStack.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import MobileBottomStack from '@/app/components/navigation/MobileBottomStack';
+import { MobileBottomProvider } from '@/app/contexts/MobileBottomContext';
+
+jest.mock('@/app/components/navigation/BottomTabBar', () => ({
+  __esModule: true,
+  default: () => <nav aria-label="Bottom navigation">Bottom navigation</nav>,
+}));
+
+describe('MobileBottomStack', () => {
+  it('positions the mobile stack above the keyboard and hides navigation while typing', () => {
+    const { container } = render(
+      <MobileBottomProvider>
+        <MobileBottomStack />
+      </MobileBottomProvider>
+    );
+
+    const stack = container.firstElementChild;
+    expect(stack).toHaveClass('bottom-keyboard-aware');
+
+    const nav = screen.getByRole('navigation', { name: 'Bottom navigation' });
+    expect(nav.parentElement).toHaveClass('mobile-keyboard-hide');
+  });
+});

--- a/tests/components/navigation/ViewportCssVars.test.tsx
+++ b/tests/components/navigation/ViewportCssVars.test.tsx
@@ -1,0 +1,67 @@
+import { render, waitFor } from '@testing-library/react';
+import ViewportCssVars from '@/app/components/navigation/ViewportCssVars';
+
+describe('ViewportCssVars', () => {
+  const originalVisualViewport = window.visualViewport;
+  const originalInnerHeight = window.innerHeight;
+
+  const setViewport = ({ height, offsetTop }: { height: number; offsetTop: number }) => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: {
+        height,
+        offsetTop,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+    });
+  };
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--visual-viewport-height');
+    document.documentElement.style.removeProperty('--keyboard-inset');
+    delete document.documentElement.dataset.keyboardOpen;
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: originalVisualViewport,
+    });
+  });
+
+  it('sets visual viewport and keyboard CSS variables', async () => {
+    setViewport({ height: 500, offsetTop: 20 });
+
+    render(<ViewportCssVars />);
+
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('500px');
+      expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('280px');
+      expect(document.documentElement.dataset.keyboardOpen).toBe('true');
+    });
+  });
+
+  it('cleans up CSS variables and keyboard data on unmount', async () => {
+    setViewport({ height: 760, offsetTop: 0 });
+
+    const { unmount } = render(<ViewportCssVars />);
+
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('760px');
+      expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('40px');
+      expect(document.documentElement.dataset.keyboardOpen).toBe('false');
+    });
+
+    unmount();
+
+    expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('');
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add viewport CSS variables for visible viewport height and keyboard inset
- Move the mobile bottom stack above the keyboard and hide bottom navigation while typing
- Constrain signed-in and offline composer layouts to the visible viewport
- Let the composer textarea shrink first while keeping controls rendered
- Add tests for viewport vars, mobile bottom stack keyboard classes, and composer textarea layout

Closes #494

## Verification
- npm test
- npm run build
- npx eslint . --ext .js,.jsx,.ts,.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard-aware positioning system that dynamically adjusts the interface layout when the on-screen keyboard appears or disappears, improving usability on mobile devices.
  * Enhanced message composer with improved minimum height constraints and scrollable content area for a better composition experience.

* **Improvements**
  * Optimized screen space utilization to adapt to different viewport sizes and keyboard visibility states.
  * Refined interface layout structure for better content organization and visual stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->