### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.58.1",
         "@typescript-eslint/parser": "^8.58.1",
-        "convex-test": "^0.0.47",
+        "convex-test": "^0.0.48",
         "eslint": "^10.2.0",
         "eslint-config-next": "^16.2.3",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -59,7 +59,7 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.1",
-        "vercel": "^50.42.0"
+        "vercel": "^51.2.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -70,9 +70,9 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.95",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.95.tgz",
-      "integrity": "sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==",
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -699,12 +699,12 @@
       "license": "(Apache-2.0 WITH LLVM-exception)"
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.8.tgz",
-      "integrity": "sha512-N9yqCQCdkn/4XpfiVnaoS6wXDeC2yQf85ioHGolOIOCWXOPwMd63fONUfRhwOZSlXGTAsgyUNZu87Ps0tcVYsg==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.9.tgz",
+      "integrity": "sha512-59h6F9wo4RrulOUh9u3Dm35VHA6k86OwU8qL4giaAMKpWcsKS+zAI7GFgVAvEMDWXam8DyTKy4/npOFT2dWlAg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.6.0",
+        "@clerk/shared": "^4.7.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -713,14 +713,14 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.0.12.tgz",
-      "integrity": "sha512-dq4iOLKf5PImLlA2YAs7c2E+yBiOYlbMlnw386xw+sTe/kv4KpRQPk2g/7PeEvFxFaV1gY764iy2sr4jy2bdQA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.1.0.tgz",
+      "integrity": "sha512-DrvCTKmc9vECjopYW6IDXP70ltVrvpNUwRzP0nlQOCrwMBhYaC/7t1HijvzzPaPcMQ7p3A7xeYwL1ffqize1zQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.2.8",
-        "@clerk/react": "^6.2.1",
-        "@clerk/shared": "^4.6.0",
+        "@clerk/backend": "^3.2.9",
+        "@clerk/react": "^6.3.0",
+        "@clerk/shared": "^4.7.0",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -734,12 +734,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.2.1.tgz",
-      "integrity": "sha512-fZpCBHTRgxkLk1S7FPp8iDpl2ZoZ/VFKvQWs3CFRX4Z9FFEcC5eAMPYbEL3treUv3TzQxcGTSgp5gd9+mFx4LQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.3.0.tgz",
+      "integrity": "sha512-etqEqdP5WlVn1Bb1NF2Drgvn3UzBSXmrkKtluObTQeqOoCsTO0uFv40oDi7QBs9WQWY1tvavI5aIHzY+uHKcdw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.6.0",
+        "@clerk/shared": "^4.7.0",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
-      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.7.0.tgz",
+      "integrity": "sha512-pm2dpxHS2teY87jmpatprG2uBAuuXuHHWvuezL3a5pRoUiIWXgWlLvwRZRgKXwDeIkIT9UCAIQBkcjueSEzqHA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@elevenlabs/elevenlabs-js": {
-      "version": "2.42.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.42.0.tgz",
-      "integrity": "sha512-SNql5kYylTJ6u2xEHBfE+DkM1K6bttqwGIlJUshqdvNlbxDGtXaf5Ot59cJJ/YS2+LP85cjSdQ2/49nyC0IG9w==",
+      "version": "2.43.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.43.0.tgz",
+      "integrity": "sha512-+1eqTvVjEdgzr8L+u/3ebavWXx/sd06zuTTAKb1wwcar3NNQBYjqmMxuVOH6iUjSUvQUWvwK7sFWZEEcE8wp6A==",
       "license": "MIT",
       "dependencies": {
         "command-exists": "^1.2.9",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3974,9 +3974,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.1.tgz",
-      "integrity": "sha512-oDDGPn/4jD3viZLphixgu1jwT0bqIqP25FNXC5OkWrUqHZOF4wATtSyVzluOt4DqcMqSoKMClyhUllKSxpQCng==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4681,17 +4681,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4704,7 +4704,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4720,16 +4720,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4745,14 +4745,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4767,14 +4767,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4785,9 +4785,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4802,15 +4802,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4827,9 +4827,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4841,16 +4841,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4908,16 +4908,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4932,13 +4932,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5239,13 +5239,13 @@
       ]
     },
     "node_modules/@vercel/backends": {
-      "version": "0.0.59",
-      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.0.59.tgz",
-      "integrity": "sha512-Fep7kvcH0zkqxTlYHC4iaeg+dGhbU/sNMOUrqYnkOF7Dl14ao9yO4q2JGi+WnCrHheSis2q85xA84sDzdFuDmQ==",
+      "version": "0.0.60",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.0.60.tgz",
+      "integrity": "sha512-EfRapSJ0vIJw67U39+RJIrUqlcy012AUkraV7t5ITZmB2JJAMu/58X4Y9+uWu1hE2PTziUg3/acCx0crIdS1fA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/build-utils": "13.14.2",
+        "@vercel/build-utils": "13.15.0",
         "@vercel/nft": "1.5.0",
         "execa": "3.2.0",
         "fs-extra": "11.1.0",
@@ -5344,9 +5344,9 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.14.2",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.14.2.tgz",
-      "integrity": "sha512-L1wHzpSXVcaXji5+ylNV5yTpAKf/t6qEGNOdFrMSAqSWlcYtL9rrY1OFbqN+5gIAWXjdCqnkmBRVp1lk20uwdw==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.15.0.tgz",
+      "integrity": "sha512-DgR2LPbE1+UvJVV9dq9z46PZIU9RBwoRX2FsXIC4WZ9AkVOrqhh9i8WgbQpXlZSOUopT31VmJ6nW8diYhlUWSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5363,13 +5363,13 @@
       "license": "MIT"
     },
     "node_modules/@vercel/cervel": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.46.tgz",
-      "integrity": "sha512-mU3xK7GpD9luYspDjF42P1VWFHFQvzbzQuk5CNSpgGoOzajLwUeYXYQaE+9Qvpv7tYIjRxekqMu70lygZAc+fw==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.47.tgz",
+      "integrity": "sha512-5SuS9rZWylcP337f18TcV/dreVKLmLCRpG6f9rYx5KWS/WaxSXW1x5KHOYyBgH5rcW/U3Qfy5FbvedW98EpMNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.0.59"
+        "@vercel/backends": "0.0.60"
       },
       "bin": {
         "cervel": "bin/cervel.mjs"
@@ -5389,13 +5389,13 @@
       }
     },
     "node_modules/@vercel/elysia": {
-      "version": "0.1.62",
-      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.62.tgz",
-      "integrity": "sha512-npn26vFlSoXieZDM2schhA//yB0PhZNyuF4k3sbbdRUUYUhFMYOuwQKy4kNBzmonHx/AN1+IxM0COC8IMWhVjA==",
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.63.tgz",
+      "integrity": "sha512-GO9V+1BXoZkE96ln8xT2vbgqvgKzfCrwU+OMs7KlB6G1EDGg65q7LEDc1Nmi0WAPRgM+1UBgWaSmCRRJwfjmXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -5407,15 +5407,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/express": {
-      "version": "0.1.72",
-      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.72.tgz",
-      "integrity": "sha512-6XCQbLGKGRAed2Zb9mMuDDKgMWV1fhEm2rsX/BRkNuwtpTVO5U7r8YxiqmWko6JRB5YlxFcJKOr4yHTTVECs2g==",
+      "version": "0.1.73",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.73.tgz",
+      "integrity": "sha512-Z0S1QNl18HAZLDz1JgCyOgm+42FgaCFVRm4KUpZO5HFjEnYQlJkm361ILGQZB6RY45gmLQM9e1lE2y9bIo05NQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/cervel": "0.0.46",
+        "@vercel/cervel": "0.0.47",
         "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -5434,13 +5434,13 @@
       }
     },
     "node_modules/@vercel/fastify": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.65.tgz",
-      "integrity": "sha512-JYsqe2ct2r64VdBa98sfeFC4vKRpNiLrMNSYjkCdKTtJoaIwODuWJY88v3J4xONxzyrwpHurwOcXQJD4HA8IeA==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.66.tgz",
+      "integrity": "sha512-OI14UsUAFSphzcQichQPWUzBYb2EoUbdBdcpWwk1mscQmvbx5t3OmOAOTyGjhndDSHGSsK6vW8sXm1uKm26MTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -5609,14 +5609,14 @@
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.12.tgz",
-      "integrity": "sha512-t1+x2o0y/aghqdAbgNE9mhle1l9VS7c1q16qZOsC4zTTFXxT9aeMOQlVjlHUn9HQQnBHXETm8eq/pvqkfryi3g==",
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.13.tgz",
+      "integrity": "sha512-jUAxDnHSJSkQiGBrLLeoJRrCFl5Jfoh7IA82i76JvS5xVAWoL40IhVbLx+5fQummv0dkal3HxElV1dja635dvg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "13.14.2",
+        "@vercel/build-utils": "13.15.0",
         "esbuild": "0.27.0",
         "etag": "1.8.1",
         "fs-extra": "11.1.0"
@@ -5630,32 +5630,32 @@
       "license": "MIT"
     },
     "node_modules/@vercel/go": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.4.7.tgz",
-      "integrity": "sha512-BPFHPiOeq8QSt87R0KXE+V2b5K7vlKna/NRrEggAin4qtf2XHc2R5Iq/rrIZtj8sUF5LJegCbACGBB+PFjmnzQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.5.0.tgz",
+      "integrity": "sha512-xMHQLqQiEfK+YJlC5eJ4S/1E4fBEUAf1u2DwQYsZlS3rLlHVqTOcZ973Z+wZV5pr4/d3vvpgB4/GQ0eqdig0jw==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/h3": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.71.tgz",
-      "integrity": "sha512-veXqy6ObH2+c3gkcPGxDwu6UxhkYjs+ODHOqxMSjAOvdVmSJ9UlD2zFXwaqWY3CTDFcuuAxySqKlijWmba8sGw==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.72.tgz",
+      "integrity": "sha512-0qmmS63bPjiMAAe7KHj9DQ35UFAUwtf9nxlH+dhMqUqdZdXPh5y1KMwggwlAWNvRC6owO+5GfSf3bbBmyZkBCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/hono": {
-      "version": "0.2.65",
-      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.65.tgz",
-      "integrity": "sha512-TvNYBHzB6WE7lI+RbHhwgc1R18oIjyAJ0uVOXTEMFE4rtCpbGnNUBmNrMS+Mtf2IllS5uc9FSfrPxuI4JSZiSg==",
+      "version": "0.2.66",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.66.tgz",
+      "integrity": "sha512-J5OYrmtq1MW14KJp724G+021qFKppdr0YuCWf3G4yHlQFN9jv+iqApYzj3YScUmnzpp46wJrRyQyxh2q4l3N1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -5685,31 +5685,31 @@
       }
     },
     "node_modules/@vercel/koa": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.45.tgz",
-      "integrity": "sha512-PqhvUUri8NR6x160A8UIYsp6uYhBmrWZtJkqBelb3WCLQSP1wJH1RZxZWXRrMdWJDPSgeJV8AO69FnyPgbtegw==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.46.tgz",
+      "integrity": "sha512-5CRadXEBLr123WN0NWyGVuSwXRVCqhPd4trdFxOMqIKKtp2y6UN8/Yi+aVY+novdWksxz918VcX+o42HxK+zNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/nestjs": {
-      "version": "0.2.66",
-      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.66.tgz",
-      "integrity": "sha512-DqhH2hoelCN3jJ7PPtAOjjHG3Phss/3bQT9m9AKG4Y6I4v1oQpaq4XKGYk0Ce5n96b2za+Rc/QhXpMjVtFxOyQ==",
+      "version": "0.2.67",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.67.tgz",
+      "integrity": "sha512-3uYvE9VvumCmVvHSJPmrRFJiK1n6jwP/g05ufPwGjv7uzfaj9WbhU9RwcQU5GfMWTFfKwOsuMLqrPywhNym6Ng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.4",
+        "@vercel/node": "5.7.5",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/next": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.16.6.tgz",
-      "integrity": "sha512-cS4/Xb3RwxwgOeysrlgKfsXqs0hqykewJW1iy8rSfBLe7F82meoqFe9JUIGMBraf1jo0f/9jWzOoX1eYMA7zRQ==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.16.7.tgz",
+      "integrity": "sha512-ecVW+1V4aUhAUpEDNmtPQw8LazD2zFG1E0sUSjxVm9DFymCI87Vlex6evLVSh3C6T6V8D16RU7hXe9cDRxFtfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5785,9 +5785,9 @@
       }
     },
     "node_modules/@vercel/nft/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5838,9 +5838,9 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.4.tgz",
-      "integrity": "sha512-pSU3hl7fSPPD/0W0RzwbogFTiTUT+LDIu0+qOdd/ZZAPQauefs09KQiRZGkt3oPmKnAWTvoQv/Ea4dWZcE9ijQ==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.5.tgz",
+      "integrity": "sha512-mLcDmgOVJNn0TBok4YynYaPo8AKSqGehpvK2f+AWSR0hnGxfX5fj56NGE9RuTtvqO8uYMTHDGFsEA/cf9tXhpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5848,7 +5848,7 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.14.2",
+        "@vercel/build-utils": "13.15.0",
         "@vercel/error-utils": "2.0.3",
         "@vercel/nft": "1.5.0",
         "@vercel/static-config": "3.2.0",
@@ -6006,9 +6006,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.29.0.tgz",
-      "integrity": "sha512-B5nnIJrMjsT2bawrsNmgwjDRarSm2PGr6o2yUFvYlfUyggR0cqt8L9GvPJPijUt2biebukWE18rAzf41JDfkUA==",
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.31.0.tgz",
+      "integrity": "sha512-ZN8NEt0CEZL4ZRF5BT6iw6FUcyRvT5wuyehkWtRVmnVf1+JJNs3oi+zc0aVve/TAxDwQZY2ZOvvKuIfwWadJ9g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6164,9 +6164,9 @@
       }
     },
     "node_modules/@vercel/sandbox/node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6184,14 +6184,14 @@
       }
     },
     "node_modules/@vercel/static-build": {
-      "version": "2.9.12",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.12.tgz",
-      "integrity": "sha512-vYXSx99LUy/5ai+Lr30brwT3wP9PebJOf48jEH2FxhacCJjNeTw5Z18V1WkJF/BQ4SFfomF3Wje7Io9PFybHFA==",
+      "version": "2.9.13",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.13.tgz",
+      "integrity": "sha512-GMAxd7udk97J2RR5D/GV1DuDEPTw3xKnyQqVane2frW15tj/cjXjSxX84HdIRSIqM5RzTxHMqiD5eWsZnQ3twg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-        "@vercel/gatsby-plugin-vercel-builder": "2.1.12",
+        "@vercel/gatsby-plugin-vercel-builder": "2.1.13",
         "@vercel/static-config": "3.2.0",
         "ts-morph": "12.0.0"
       }
@@ -6286,12 +6286,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.158",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
-      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.95",
+        "@ai-sdk/gateway": "3.0.96",
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
@@ -6658,9 +6658,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
-      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -6834,9 +6834,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7055,9 +7055,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7407,9 +7407,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.47.tgz",
-      "integrity": "sha512-EBJQ2Ys2sHWFCZYYO1bAqudrrMW3y+SP7BF2+E5rYIGVntU4v+EoWxx1h/X+2ISMKvecf4RJLV6ojBvWNUFDcw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.48.tgz",
+      "integrity": "sha512-ewAkXwNJE0TpHAfHJt38NR6ZsArqdzd4HUy9BxegKENvupYwWCVJezFfkIJoYaZThqPABEfmiChvG8KCqCTm5w==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -7805,9 +7805,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.335",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
-      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -9335,9 +9335,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13869,9 +13869,9 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.12.37.tgz",
-      "integrity": "sha512-zpqbH+2TI6dvg7mxGm30Mnv17aJL3ZfRGshMiBK85dHBfhzqMbKUHNXCzsHhiKBQTzti6JqG1YoRbYrJwvdUjA==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.12.38.tgz",
+      "integrity": "sha512-UIU8gyA2t0oYRobkf2MGUeo0KMjuNn+rHP3y1xZPoZinEVdo+56rUXIJBUbIWmVX4W6mkdKSOHU/ouRKt138vQ==",
       "cpu": [
         "arm64"
       ],
@@ -13882,9 +13882,9 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.37.tgz",
-      "integrity": "sha512-2mB1BhEJJLG8Ow/YGAe7c3AL5fSkk9qDk3wmZRsfDW+Gno5eBaUusXseDI0ltjh2mZcW74l9F19ez4CyhwqNQQ==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.38.tgz",
+      "integrity": "sha512-+Wa/RmmZys7UzP9nUnaBq9+npj5LrQ73amqFO5cFX5CycYV1h36Dv+X2nyTYYp1nmt7oI/eKg7VPIvv8iMcHxQ==",
       "cpu": [
         "x64"
       ],
@@ -13895,9 +13895,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.12.37.tgz",
-      "integrity": "sha512-6yVnp7ucK4oJEjUfKbkyvJm+e6UdETTp7PnWFb1+Wr6nxSCN038BGSACCIKlVHEsQl+6huwrvymljkWrIro1mA==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.12.38.tgz",
+      "integrity": "sha512-sZmH66L6o1QNBh2MYgFFUTsbqEj1q+uwV0ChBIH6nVDHYQBtPyBndbcXv+KmJQSRpTBmRGET10CYZsK5Y+SCpA==",
       "cpu": [
         "arm64"
       ],
@@ -13908,9 +13908,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.12.37.tgz",
-      "integrity": "sha512-WF69clWjTlBu6NIBdL8OLEEN4NwOlYjjB/AjCMs29pB6gtSzKJEKIjmTATfaSSExTGPeXsOriCXcMdHaMH4WNg==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.12.38.tgz",
+      "integrity": "sha512-2kZmoD8kE077gKu5AWYB5P5giqDOjKVd20PvUjdu3+tu6FhFXGiAywP2biTu7ivloWiKtx8nygnih+cCHigx6A==",
       "cpu": [
         "x64"
       ],
@@ -13921,23 +13921,23 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.12.37.tgz",
-      "integrity": "sha512-SpblPUl/ODliBk4WzKLRa0VPyc30I3HU9U/qRUmhya7eTNLkJE8sQOmj2kvRL8k2cWrHES2pyvRwwq1jT/MPpw==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.12.38.tgz",
+      "integrity": "sha512-WrfTnQd9uy6Y6aJisnS1X7lELLzc/Q/w6Gi3zj8VawTNL1HIPIAYeKVLuDaxio/0IHanrz0hgu7VIIiDGJkwCQ==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.12.37",
-        "sherpa-onnx-darwin-x64": "^1.12.37",
-        "sherpa-onnx-linux-arm64": "^1.12.37",
-        "sherpa-onnx-linux-x64": "^1.12.37",
-        "sherpa-onnx-win-ia32": "^1.12.37",
-        "sherpa-onnx-win-x64": "^1.12.37"
+        "sherpa-onnx-darwin-arm64": "^1.12.38",
+        "sherpa-onnx-darwin-x64": "^1.12.38",
+        "sherpa-onnx-linux-arm64": "^1.12.38",
+        "sherpa-onnx-linux-x64": "^1.12.38",
+        "sherpa-onnx-win-ia32": "^1.12.38",
+        "sherpa-onnx-win-x64": "^1.12.38"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.12.37.tgz",
-      "integrity": "sha512-8kR6wk43mICTI78kTslColnO5d8Am0EbtPtz5NZH1LxOp4sktlQw3Ujc+/qlqJlPr0F4Ptdy8iG1CC0ELOv5VA==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.12.38.tgz",
+      "integrity": "sha512-NBluqnyXM2DemURbTnGPdkpRSQGlhJ+8RbtxFt6hRYSaJ7gTN0154rJ6IebHI7UiZSuXe3r8ZYUs3UZYqhplAQ==",
       "cpu": [
         "ia32"
       ],
@@ -13948,9 +13948,9 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.12.37",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.12.37.tgz",
-      "integrity": "sha512-1h1UrJxzA1vkOO2G8JqRQkF9SfEhM/LYW+yFki5izCY5N+eaaxYKdZLmVZI3KAhxk28pkE6dnMETYi0nj2/Cuw==",
+      "version": "1.12.38",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.12.38.tgz",
+      "integrity": "sha512-D7kimY7oosJID+9gTZI3g/Pc43/3ZYQ6EP8rpBhCGTDlND9DaDXpOS7aUCVqUAVRZU3+w6rZyE0s9LVuWoo/9w==",
       "cpu": [
         "x64"
       ],
@@ -15146,16 +15146,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.1",
-        "@typescript-eslint/parser": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15196,9 +15196,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15352,35 +15352,35 @@
       }
     },
     "node_modules/vercel": {
-      "version": "50.44.0",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-50.44.0.tgz",
-      "integrity": "sha512-9FO5H6eFcKOtAzWyKGYMrc/ba3rvIQTvPbSSDAVdAIIesOTy47qV/Zsqf1qOUWrmPdSou3x5F++VfJBfMUhcyg==",
+      "version": "51.2.1",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-51.2.1.tgz",
+      "integrity": "sha512-VhcVytjtiowbN+2VCtRp7z90SIR69AzlgJ/Qj47nwolG5LOg5ZD9KfK+bwQ9daZxN2HlvllDwUyYg5RevjUbYQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.0.59",
+        "@vercel/backends": "0.0.60",
         "@vercel/blob": "2.3.0",
-        "@vercel/build-utils": "13.14.2",
+        "@vercel/build-utils": "13.15.0",
         "@vercel/detect-agent": "1.2.2",
-        "@vercel/elysia": "0.1.62",
-        "@vercel/express": "0.1.72",
-        "@vercel/fastify": "0.1.65",
+        "@vercel/elysia": "0.1.63",
+        "@vercel/express": "0.1.73",
+        "@vercel/fastify": "0.1.66",
         "@vercel/fun": "1.3.0",
-        "@vercel/go": "3.4.7",
-        "@vercel/h3": "0.1.71",
-        "@vercel/hono": "0.2.65",
+        "@vercel/go": "3.5.0",
+        "@vercel/h3": "0.1.72",
+        "@vercel/hono": "0.2.66",
         "@vercel/hydrogen": "1.3.6",
-        "@vercel/koa": "0.1.45",
-        "@vercel/nestjs": "0.2.66",
-        "@vercel/next": "4.16.6",
-        "@vercel/node": "5.7.4",
+        "@vercel/koa": "0.1.46",
+        "@vercel/nestjs": "0.2.67",
+        "@vercel/next": "4.16.7",
+        "@vercel/node": "5.7.5",
         "@vercel/prepare-flags-definitions": "0.2.1",
-        "@vercel/python": "6.29.0",
+        "@vercel/python": "6.31.0",
         "@vercel/redwood": "2.4.12",
         "@vercel/remix-builder": "5.7.2",
         "@vercel/ruby": "2.3.2",
         "@vercel/rust": "1.1.0",
-        "@vercel/static-build": "2.9.12",
+        "@vercel/static-build": "2.9.13",
         "chokidar": "4.0.0",
         "esbuild": "0.27.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.58.1",
     "@typescript-eslint/parser": "^8.58.1",
-    "convex-test": "^0.0.47",
+    "convex-test": "^0.0.48",
     "eslint": "^10.2.0",
     "eslint-config-next": "^16.2.3",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -64,6 +64,6 @@
     "tailwindcss": "^4.1.17",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.1",
-    "vercel": "^50.42.0"
+    "vercel": "^51.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- Update dependencies to current npm-resolved versions
- Bump out-of-range dev tools: convex-test to 0.0.48 and vercel to 51.2.1
- Refresh package-lock.json

Closes #496

## Verification
- npm outdated
- npm test
- npm run build
- npx eslint . --ext .js,.jsx,.ts,.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling dependencies for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->