### PR TITLE
Fix mobile composer keyboard layout

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -132,12 +132,14 @@ export default function ClientLayout({
               <ViewportCssVars />
               <OnlineStartupWatch onReady={handleStartupReady}>
                 <OfflineDataSync />
-                <div className="min-h-dvh flex flex-col md:flex-row">
+                <div className="flex h-visual-viewport min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">
                   <Sidebar />
-                  <div className="flex-1 md:pl-16 lg:pl-16">
-                    <ConnectivityBanner />
-                    <InstallBanner />
-                    <main className="min-h-dvh pb-bottom-stack">
+                  <div className="flex min-h-0 flex-1 flex-col md:pl-16 lg:pl-16">
+                    <div className="shrink-0">
+                      <ConnectivityBanner />
+                      <InstallBanner />
+                    </div>
+                    <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:min-h-dvh md:overflow-visible">
                       {children}
                     </main>
                   </div>

--- a/app/components/navigation/ViewportCssVars.tsx
+++ b/app/components/navigation/ViewportCssVars.tsx
@@ -4,13 +4,32 @@ import { useEffect, useRef } from 'react';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 
 const KEYBOARD_OPEN_THRESHOLD_PX = 80;
+const TEXT_INPUT_TYPES = new Set([
+  'email',
+  'number',
+  'password',
+  'search',
+  'tel',
+  'text',
+  'url',
+]);
 
 function isEditableElement(element: Element | null): boolean {
   if (!(element instanceof HTMLElement)) return false;
 
-  return element.isContentEditable
-    || element.tagName === 'TEXTAREA'
-    || element.tagName === 'INPUT';
+  if (element.isContentEditable) return true;
+
+  if (element instanceof HTMLTextAreaElement) {
+    return !element.disabled && !element.readOnly;
+  }
+
+  if (element instanceof HTMLInputElement) {
+    return !element.disabled
+      && !element.readOnly
+      && TEXT_INPUT_TYPES.has(element.type.toLowerCase());
+  }
+
+  return false;
 }
 
 export default function ViewportCssVars() {

--- a/app/components/navigation/ViewportCssVars.tsx
+++ b/app/components/navigation/ViewportCssVars.tsx
@@ -1,26 +1,45 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
 
 const KEYBOARD_OPEN_THRESHOLD_PX = 80;
 
+function isEditableElement(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+
+  return element.isContentEditable
+    || element.tagName === 'TEXTAREA'
+    || element.tagName === 'INPUT';
+}
+
 export default function ViewportCssVars() {
   const viewport = useVisualViewport();
+  const layoutHeightRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const root = document.documentElement;
     const viewportHeight = viewport.height ?? window.innerHeight;
+    const currentLayoutHeight = viewport.innerHeight ?? window.innerHeight;
+    const focusedEditable = isEditableElement(document.activeElement);
+    const previousLayoutHeight = layoutHeightRef.current ?? currentLayoutHeight;
+    const layoutHeight = Math.max(previousLayoutHeight, currentLayoutHeight, viewportHeight);
     const keyboardInset = Math.max(
       0,
-      window.innerHeight - ((viewport.top ?? 0) + viewportHeight)
+      layoutHeight - ((viewport.top ?? 0) + viewportHeight)
     );
-    const isKeyboardOpen = keyboardInset > KEYBOARD_OPEN_THRESHOLD_PX;
+    const isKeyboardOpen = focusedEditable && keyboardInset > KEYBOARD_OPEN_THRESHOLD_PX;
+
+    if (!isKeyboardOpen) {
+      layoutHeightRef.current = currentLayoutHeight;
+    } else {
+      layoutHeightRef.current = layoutHeight;
+    }
 
     root.style.setProperty('--visual-viewport-height', `${viewportHeight}px`);
-    root.style.setProperty('--keyboard-inset', `${keyboardInset}px`);
+    root.style.setProperty('--keyboard-inset', `${isKeyboardOpen ? keyboardInset : 0}px`);
     root.dataset.keyboardOpen = isKeyboardOpen ? 'true' : 'false';
 
     return () => {
@@ -28,7 +47,7 @@ export default function ViewportCssVars() {
       root.style.removeProperty('--keyboard-inset');
       delete root.dataset.keyboardOpen;
     };
-  }, [viewport.height, viewport.top]);
+  }, [viewport.height, viewport.innerHeight, viewport.top]);
 
   return null;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,7 @@
 
   /* Mobile bottom stack height (nav + dock + safe area) */
   --bottom-stack-height: calc(108px + env(safe-area-inset-bottom, 0px));
+  --active-bottom-stack-height: var(--bottom-stack-height);
 
   /* Text colors with WCAG AAA compliance */
   --text-primary: #f5f4f2;
@@ -132,7 +133,7 @@ body {
 
   /* Padding to clear the mobile bottom stack (dock + nav) */
   .pb-bottom-stack {
-    padding-bottom: var(--bottom-stack-height);
+    padding-bottom: var(--active-bottom-stack-height);
   }
   @media (min-width: 768px) {
     .pb-bottom-stack {
@@ -169,6 +170,9 @@ body {
   }
   html[data-keyboard-open="true"] .mobile-keyboard-hide {
     display: none;
+  }
+  html[data-keyboard-open="true"] {
+    --active-bottom-stack-height: 0px;
   }
 
   /* Touch-friendly tap targets (minimum 44x44px) */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   return (
     <div className={`flex flex-col bg-background ${
       user
-        ? 'h-visual-viewport min-h-0 overflow-hidden'
+        ? 'h-full min-h-0 overflow-hidden'
         : 'min-h-screen'
     }`}>
       {!user ? (

--- a/tests/app/HomePage.test.tsx
+++ b/tests/app/HomePage.test.tsx
@@ -84,8 +84,9 @@ describe('Home', () => {
     });
     mockUseQuery.mockReturnValue({ role: 'communicator' });
 
-    render(<Home />);
+    const { container } = render(<Home />);
 
     expect(screen.getByText('Phrases Interface')).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveClass('h-full', 'min-h-0', 'overflow-hidden');
   });
 });

--- a/tests/components/navigation/ViewportCssVars.test.tsx
+++ b/tests/components/navigation/ViewportCssVars.test.tsx
@@ -5,6 +5,7 @@ describe('ViewportCssVars', () => {
   const originalVisualViewport = window.visualViewport;
   const originalInnerHeight = window.innerHeight;
   let focusedTextarea: HTMLTextAreaElement | null = null;
+  let focusedInput: HTMLInputElement | null = null;
 
   const setViewport = ({ height, offsetTop }: { height: number; offsetTop: number }) => {
     Object.defineProperty(window, 'innerHeight', {
@@ -25,6 +26,8 @@ describe('ViewportCssVars', () => {
   afterEach(() => {
     focusedTextarea?.remove();
     focusedTextarea = null;
+    focusedInput?.remove();
+    focusedInput = null;
     document.documentElement.style.removeProperty('--visual-viewport-height');
     document.documentElement.style.removeProperty('--keyboard-inset');
     delete document.documentElement.dataset.keyboardOpen;
@@ -55,6 +58,22 @@ describe('ViewportCssVars', () => {
 
   it('does not mark the keyboard open without a focused editable field', async () => {
     setViewport({ height: 500, offsetTop: 20 });
+
+    render(<ViewportCssVars />);
+
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('500px');
+      expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('0px');
+      expect(document.documentElement.dataset.keyboardOpen).toBe('false');
+    });
+  });
+
+  it('does not mark the keyboard open for non-text inputs', async () => {
+    setViewport({ height: 500, offsetTop: 20 });
+    focusedInput = document.createElement('input');
+    focusedInput.type = 'checkbox';
+    document.body.appendChild(focusedInput);
+    focusedInput.focus();
 
     render(<ViewportCssVars />);
 

--- a/tests/components/navigation/ViewportCssVars.test.tsx
+++ b/tests/components/navigation/ViewportCssVars.test.tsx
@@ -4,6 +4,7 @@ import ViewportCssVars from '@/app/components/navigation/ViewportCssVars';
 describe('ViewportCssVars', () => {
   const originalVisualViewport = window.visualViewport;
   const originalInnerHeight = window.innerHeight;
+  let focusedTextarea: HTMLTextAreaElement | null = null;
 
   const setViewport = ({ height, offsetTop }: { height: number; offsetTop: number }) => {
     Object.defineProperty(window, 'innerHeight', {
@@ -22,6 +23,8 @@ describe('ViewportCssVars', () => {
   };
 
   afterEach(() => {
+    focusedTextarea?.remove();
+    focusedTextarea = null;
     document.documentElement.style.removeProperty('--visual-viewport-height');
     document.documentElement.style.removeProperty('--keyboard-inset');
     delete document.documentElement.dataset.keyboardOpen;
@@ -37,6 +40,9 @@ describe('ViewportCssVars', () => {
 
   it('sets visual viewport and keyboard CSS variables', async () => {
     setViewport({ height: 500, offsetTop: 20 });
+    focusedTextarea = document.createElement('textarea');
+    document.body.appendChild(focusedTextarea);
+    focusedTextarea.focus();
 
     render(<ViewportCssVars />);
 
@@ -47,6 +53,18 @@ describe('ViewportCssVars', () => {
     });
   });
 
+  it('does not mark the keyboard open without a focused editable field', async () => {
+    setViewport({ height: 500, offsetTop: 20 });
+
+    render(<ViewportCssVars />);
+
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('500px');
+      expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('0px');
+      expect(document.documentElement.dataset.keyboardOpen).toBe('false');
+    });
+  });
+
   it('cleans up CSS variables and keyboard data on unmount', async () => {
     setViewport({ height: 760, offsetTop: 0 });
 
@@ -54,7 +72,7 @@ describe('ViewportCssVars', () => {
 
     await waitFor(() => {
       expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('760px');
-      expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('40px');
+      expect(document.documentElement.style.getPropertyValue('--keyboard-inset')).toBe('0px');
       expect(document.documentElement.dataset.keyboardOpen).toBe('false');
     });
 


### PR DESCRIPTION
## Summary
- Constrain the online app shell to the visual viewport on mobile so signed-in composer pages receive a real height
- Make bottom-stack padding dynamic and remove it while the keyboard is open
- Make the signed-in home page fill its parent instead of creating a second viewport-sized box
- Harden keyboard detection for browsers that resize innerHeight when the keyboard opens

Closes #499

## Verification
- npm test
- npm run build
- npx eslint . --ext .js,.jsx,.ts,.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overall layout sizing and overflow so main content scrolls correctly and uses available screen height.
  * Connectivity and install banners now remain positioned consistently instead of affecting page scrolling.
  * Keyboard detection now reliably removes bottom padding when the on-screen keyboard appears and better tracks viewport height.

* **Tests**
  * Expanded tests covering keyboard detection and layout/scrolling behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->