### PR TITLE
Fix Composer not filling available height

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -139,7 +139,7 @@ export default function ClientLayout({
                       <ConnectivityBanner />
                       <InstallBanner />
                     </div>
-                    <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:min-h-dvh md:overflow-visible">
+                    <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:overflow-visible">
                       {children}
                     </main>
                   </div>

--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -320,7 +320,7 @@ export default function Composer({
 
   return (
     <>
-      <div className={`flex flex-col flex-1 min-h-0 ${className}`}>
+      <div className={`flex flex-col flex-1 min-h-0 h-full ${className}`}>
         {/* Tab bar */}
         {enableTabs && (
           <div className="shrink-0">

--- a/app/globals.css
+++ b/app/globals.css
@@ -69,6 +69,9 @@
   --color-text-tertiary: var(--text-tertiary);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --height-visual-viewport: var(--visual-viewport-height, 100dvh);
+  --min-height-visual-viewport: var(--visual-viewport-height, 100dvh);
+  --max-height-visual-viewport: var(--visual-viewport-height, 100dvh);
 }
 
 @keyframes gradient {


### PR DESCRIPTION
## Summary

Fixes #502 — Composer component not filling available space in the Type tab.

- **`app/components/Composer.tsx`**: Added `h-full` to the root div so that `flex-1` resolves correctly when the Composer is rendered inside an `absolute inset-0` block parent (Framer Motion tab panel in `AACTabs`)
- **`app/globals.css`**: Mapped `--height-visual-viewport` in `@theme inline` so Tailwind v4 generates `height: var(--visual-viewport-height, 100dvh)` for `h-visual-viewport` instead of `height: var(--height-visual-viewport)` (which resolved to `auto`)
- **`app/ClientLayout.tsx`**: Removed `md:min-h-dvh` from `<main>` — the outer wrapper already provides `md:min-h-dvh`, so this was causing `main` to overflow the viewport whenever install/connectivity banners were visible above it

## Test plan

- [ ] Open the app on desktop — Type tab Composer fills the full available height
- [ ] Open with install banner visible — no overflow below viewport
- [ ] Mobile layout unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted responsive layout behavior on medium and larger screens.
  * Enhanced component height handling for better space utilization.
  * Added viewport height CSS variables with fallback values for improved responsive design support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->