### PR TITLE
Restore JS keyboard inset detection

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -12,6 +12,7 @@ import ConnectivityBanner from './components/navigation/ConnectivityBanner';
 import InstallBanner from './components/navigation/InstallBanner';
 import Sidebar from './components/Sidebar';
 import MobileBottomStack from './components/navigation/MobileBottomStack';
+import KeyboardInsetCssVar from './components/navigation/KeyboardInsetCssVar';
 import OfflineAppShell from './components/offline/OfflineAppShell';
 import OfflineDataSync from './components/offline/OfflineDataSync';
 import OnlineStartupWatch from './components/startup/OnlineStartupWatch';
@@ -113,6 +114,7 @@ export default function ClientLayout({
         <StaticAuthProvider>
           <SettingsProvider>
             <MobileBottomProvider>
+              <KeyboardInsetCssVar />
               <OfflineAppShell mode={offlineMode} />
             </MobileBottomProvider>
           </SettingsProvider>
@@ -127,6 +129,7 @@ export default function ClientLayout({
         <AuthProvider>
           <SettingsProvider>
             <MobileBottomProvider>
+              <KeyboardInsetCssVar />
               <OnlineStartupWatch onReady={handleStartupReady}>
                 <OfflineDataSync />
                 <div className="flex h-dvh min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">

--- a/app/components/navigation/KeyboardInsetCssVar.tsx
+++ b/app/components/navigation/KeyboardInsetCssVar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useVisualViewport } from '@/lib/hooks/useVisualViewport';
+
+const KEYBOARD_OPEN_THRESHOLD_PX = 80;
+
+const TEXT_INPUT_TYPES = new Set([
+  'email',
+  'number',
+  'password',
+  'search',
+  'tel',
+  'text',
+  'url',
+]);
+
+function isEditableElement(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  if (element.isContentEditable) return true;
+  if (element instanceof HTMLTextAreaElement) return !element.disabled && !element.readOnly;
+  if (element instanceof HTMLInputElement) {
+    return !element.disabled && !element.readOnly && TEXT_INPUT_TYPES.has(element.type.toLowerCase());
+  }
+  return false;
+}
+
+export default function KeyboardInsetCssVar() {
+  const viewport = useVisualViewport();
+  const layoutHeightRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const viewportHeight = viewport.height ?? window.innerHeight;
+    const currentLayoutHeight = viewport.innerHeight ?? window.innerHeight;
+    const previousLayoutHeight = layoutHeightRef.current ?? currentLayoutHeight;
+    const layoutHeight = Math.max(previousLayoutHeight, currentLayoutHeight, viewportHeight);
+    const keyboardInset = Math.max(0, layoutHeight - ((viewport.top ?? 0) + viewportHeight));
+    const isKeyboardOpen = isEditableElement(document.activeElement) && keyboardInset > KEYBOARD_OPEN_THRESHOLD_PX;
+
+    layoutHeightRef.current = isKeyboardOpen ? layoutHeight : currentLayoutHeight;
+
+    document.documentElement.style.setProperty(
+      '--keyboard-inset',
+      `${isKeyboardOpen ? keyboardInset : 0}px`
+    );
+
+    return () => {
+      document.documentElement.style.removeProperty('--keyboard-inset');
+    };
+  }, [viewport.height, viewport.innerHeight, viewport.top]);
+
+  return null;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -157,7 +157,7 @@ body {
     max-height: 100dvh;
   }
   .bottom-keyboard-aware {
-    bottom: env(keyboard-inset-height, 0px);
+    bottom: var(--keyboard-inset, 0px);
   }
 
   /* Touch-friendly tap targets (minimum 44x44px) */


### PR DESCRIPTION
## Summary

Fixes #508 — keyboard was covering the portaled toolbar because `env(keyboard-inset-height)` falls back to `0px` on most Android browsers (and some iOS configurations), leaving the dock stuck at `bottom: 0`.

- **New `KeyboardInsetCssVar.tsx`**: lightweight component (split from the removed `ViewportCssVars`) that uses `window.visualViewport` to compute the keyboard height and sets `--keyboard-inset` on the document root. Reuses the existing `useVisualViewport` hook already present in the codebase.
- **`globals.css`**: reverts `.bottom-keyboard-aware` to `var(--keyboard-inset, 0px)` (JS-set, reliable cross-browser).
- **`ClientLayout.tsx`**: adds `<KeyboardInsetCssVar />` to both online and offline layout branches.

`h-dvh` for container height and `interactive-widget=resizes-visual` viewport meta are kept — only the dock positioning is fixed.

## Test plan

- [ ] Mobile: tap textarea → keyboard opens → toolbar appears above keyboard
- [ ] Mobile: tabs (Phrases/Type) remain visible, not pushed behind keyboard
- [ ] Mobile: Phrases tab → no toolbar in dock
- [ ] Desktop: toolbar renders inline in Composer, no change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved on-screen keyboard handling with dynamic layout adjustments that prevent UI elements from being obscured by the virtual keyboard on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->