### PR TITLE
Consolidate duplicated TTS callback logic across providers (#515)

### DIFF
--- a/lib/azure-tts.ts
+++ b/lib/azure-tts.ts
@@ -1,4 +1,5 @@
 import { TextToSpeech as WebSpeechTTS } from './tts';
+import { BaseTTSCallbacks } from './tts-types';
 
 export interface AzureVoice {
   voice_id: string;
@@ -26,12 +27,7 @@ export class AzureTTS {
   private abortController: AbortController | null = null;
   private fallbackTTS: WebSpeechTTS;
 
-  private callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: AzureVoice[]) => void;
-  } = {};
+  private callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: AzureVoice[]) => void } = {};
 
   private constructor() {
     this.fallbackTTS = WebSpeechTTS.getInstance();
@@ -83,12 +79,7 @@ export class AzureTTS {
     return this.voicesLoaded;
   }
 
-  public setCallbacks(callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: AzureVoice[]) => void;
-  }) {
+  public setCallbacks(callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: AzureVoice[]) => void }) {
     this.callbacks = callbacks;
 
     this.fallbackTTS.setCallbacks({

--- a/lib/elevenlabs-tts.ts
+++ b/lib/elevenlabs-tts.ts
@@ -1,4 +1,5 @@
 import { TextToSpeech as WebSpeechTTS } from './tts';
+import { BaseTTSCallbacks } from './tts-types';
 
 export interface Voice {
   voice_id: string;
@@ -35,12 +36,7 @@ export class ElevenLabsTTS {
   private abortController: AbortController | null = null;
   private lastRequestTime = 0;
 
-  private callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: Voice[]) => void;
-  } = {};
+  private callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: Voice[]) => void } = {};
 
   private constructor() {
     this.fallbackTTS = WebSpeechTTS.getInstance();
@@ -88,12 +84,7 @@ export class ElevenLabsTTS {
     return this.voicesLoaded;
   }
 
-  public setCallbacks(callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: Voice[]) => void;
-  }) {
+  public setCallbacks(callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: Voice[]) => void }) {
     this.callbacks = callbacks;
     this.fallbackTTS.setCallbacks({
       onStart: callbacks.onStart,

--- a/lib/tts-provider.ts
+++ b/lib/tts-provider.ts
@@ -47,65 +47,24 @@ export class TTSProvider {
     return TTSProvider.instance;
   }
 
+  private makeProviderCallbacks(onVoicesChanged?: () => void) {
+    return {
+      onStart: () => { this.isSpeaking = true; this.callbacks.onStart?.(); },
+      onEnd: () => { this.isSpeaking = false; this.callbacks.onEnd?.(); },
+      onError: (error: Error) => { this.isSpeaking = false; this.callbacks.onError?.(error); },
+      ...(onVoicesChanged ? { onVoicesChanged } : {}),
+    };
+  }
+
   private setupCallbacks() {
-    // Setup callbacks for both TTS providers
+    const onVoicesChanged = () => this.callbacks.onVoicesChanged?.(this.getAllVoices());
+
     this.webSpeechTTS.setCallbacks({
-      onStart: () => {
-        this.isSpeaking = true;
-        this.callbacks.onStart?.();
-      },
-      onEnd: () => {
-        this.isSpeaking = false;
-        this.callbacks.onEnd?.();
-      },
-      onError: (error) => {
-        this.isSpeaking = false;
-        this.callbacks.onError?.(error);
-      },
-      onVoicesChanged: () => {
-        // Notify that voices have changed
-        this.callbacks.onVoicesChanged?.(this.getAllVoices());
-      },
-      onWordBoundary: (word, charIndex) => {
-        this.callbacks.onWordBoundary?.(word, charIndex);
-      },
+      ...this.makeProviderCallbacks(onVoicesChanged),
+      onWordBoundary: (word, charIndex) => this.callbacks.onWordBoundary?.(word, charIndex),
     });
-
-    this.elevenlabsTTS.setCallbacks({
-      onStart: () => {
-        this.isSpeaking = true;
-        this.callbacks.onStart?.();
-      },
-      onEnd: () => {
-        this.isSpeaking = false;
-        this.callbacks.onEnd?.();
-      },
-      onError: (error) => {
-        this.isSpeaking = false;
-        this.callbacks.onError?.(error);
-      },
-      onVoicesChanged: () => {
-        this.callbacks.onVoicesChanged?.(this.getAllVoices());
-      }
-    });
-
-    this.azureTTS.setCallbacks({
-      onStart: () => {
-        this.isSpeaking = true;
-        this.callbacks.onStart?.();
-      },
-      onEnd: () => {
-        this.isSpeaking = false;
-        this.callbacks.onEnd?.();
-      },
-      onError: (error) => {
-        this.isSpeaking = false;
-        this.callbacks.onError?.(error);
-      },
-      onVoicesChanged: () => {
-        this.callbacks.onVoicesChanged?.(this.getAllVoices());
-      }
-    });
+    this.elevenlabsTTS.setCallbacks(this.makeProviderCallbacks(onVoicesChanged));
+    this.azureTTS.setCallbacks(this.makeProviderCallbacks(onVoicesChanged));
   }
 
   public setCallbacks(callbacks: {

--- a/lib/tts-types.ts
+++ b/lib/tts-types.ts
@@ -1,0 +1,9 @@
+/**
+ * Base callback interface shared by all TTS providers.
+ * Provider-specific callbacks (e.g. onVoicesChanged with typed voices) extend this.
+ */
+export interface BaseTTSCallbacks {
+  onStart?: () => void;
+  onEnd?: () => void;
+  onError?: (error: Error) => void;
+}

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -1,15 +1,16 @@
+import { BaseTTSCallbacks } from './tts-types';
+
+interface WebSpeechCallbacks extends BaseTTSCallbacks {
+  onVoicesChanged?: (voices: SpeechSynthesisVoice[]) => void;
+  onWordBoundary?: (word: string, charIndex: number) => void;
+}
+
 export class TextToSpeech {
   private static instance: TextToSpeech;
   private utterance: SpeechSynthesisUtterance | null = null;
   private isSpeaking: boolean = false;
   private voices: SpeechSynthesisVoice[] = [];
-  private callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: SpeechSynthesisVoice[]) => void;
-    onWordBoundary?: (word: string, charIndex: number) => void;
-  } = {};
+  private callbacks: WebSpeechCallbacks = {};
 
   private constructor() {
     // Private constructor to enforce singleton pattern
@@ -49,13 +50,7 @@ export class TextToSpeech {
     }
   }
 
-  public setCallbacks(callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: SpeechSynthesisVoice[]) => void;
-    onWordBoundary?: (word: string, charIndex: number) => void;
-  }) {
+  public setCallbacks(callbacks: WebSpeechCallbacks) {
     this.callbacks = callbacks;
   }
 


### PR DESCRIPTION
## Summary

- Extracts `BaseTTSCallbacks` interface into `lib/tts-types.ts`, replacing four separate inline type definitions across the TTS files
- Each provider's `callbacks` field and `setCallbacks()` method now reference the shared base type
- Replaces the 50-line `setupCallbacks()` in `TTSProvider` — which copy-pasted identical `onStart`/`onEnd`/`onError` handlers three times — with a `makeProviderCallbacks()` helper that builds the shared handlers once

Net: 55 lines removed, zero behaviour change.

Closes #515