### PR TITLE
Fix mobile composer toolbar overlap

### DIFF
--- a/app/components/navigation/MobileBottomStack.tsx
+++ b/app/components/navigation/MobileBottomStack.tsx
@@ -6,6 +6,7 @@ import BottomTabBar from './BottomTabBar';
 
 export default function MobileBottomStack() {
   const { registerDockContainer } = useMobileBottom();
+  const stackRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -13,8 +14,52 @@ export default function MobileBottomStack() {
     return () => registerDockContainer(null);
   }, [registerDockContainer]);
 
+  useEffect(() => {
+    const stack = stackRef.current;
+    if (!stack || typeof window === 'undefined') return;
+
+    let animationFrameId: number | null = null;
+
+    const updateBottomStackHeight = () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+
+      animationFrameId = window.requestAnimationFrame(() => {
+        const height = stack.getBoundingClientRect().height;
+        document.documentElement.style.setProperty('--active-bottom-stack-height', `${height}px`);
+        animationFrameId = null;
+      });
+    };
+
+    updateBottomStackHeight();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(updateBottomStackHeight);
+      resizeObserver.observe(stack);
+
+      return () => {
+        if (animationFrameId !== null) {
+          window.cancelAnimationFrame(animationFrameId);
+        }
+        resizeObserver.disconnect();
+        document.documentElement.style.removeProperty('--active-bottom-stack-height');
+      };
+    }
+
+    window.addEventListener('resize', updateBottomStackHeight);
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      window.removeEventListener('resize', updateBottomStackHeight);
+      document.documentElement.style.removeProperty('--active-bottom-stack-height');
+    };
+  }, []);
+
   return (
-    <div className="fixed bottom-keyboard-aware left-0 right-0 z-50 md:hidden flex flex-col">
+    <div ref={stackRef} className="fixed bottom-keyboard-aware left-0 right-0 z-50 md:hidden flex flex-col">
       {/* Dock content slot - portal target */}
       <div ref={dockRef} className="bg-surface" />
       {/* Tab bar */}

--- a/tests/components/navigation/MobileBottomStack.test.tsx
+++ b/tests/components/navigation/MobileBottomStack.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import MobileBottomStack from '@/app/components/navigation/MobileBottomStack';
 import { MobileBottomProvider } from '@/app/contexts/MobileBottomContext';
 
@@ -8,6 +8,10 @@ jest.mock('@/app/components/navigation/BottomTabBar', () => ({
 }));
 
 describe('MobileBottomStack', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('positions the mobile stack above the keyboard using native CSS keyboard inset', () => {
     const { container } = render(
       <MobileBottomProvider>
@@ -20,5 +24,30 @@ describe('MobileBottomStack', () => {
 
     const nav = screen.getByRole('navigation', { name: 'Bottom navigation' });
     expect(nav).toBeInTheDocument();
+  });
+
+  it('publishes the measured stack height for content padding', async () => {
+    const setPropertySpy = jest.spyOn(document.documentElement.style, 'setProperty');
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 390,
+      height: 142,
+      top: 0,
+      right: 390,
+      bottom: 142,
+      left: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    render(
+      <MobileBottomProvider>
+        <MobileBottomStack />
+      </MobileBottomProvider>
+    );
+
+    await waitFor(() => {
+      expect(setPropertySpy).toHaveBeenCalledWith('--active-bottom-stack-height', '142px');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #521
- Measure the rendered mobile bottom stack and publish it to `--active-bottom-stack-height`
- Keeps main content padding aligned with the actual toolbar/dock height so the composer textarea stays above the toolbar
- Adds a regression test for the dynamic height CSS variable

## Verification
- npm test
- npm run build
- npm run lint (passes with existing warning in `app/components/home/PhrasesInterface.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The mobile bottom navigation now dynamically measures and exposes its container height to enable responsive layout adjustments.

* **Tests**
  * Added test coverage to verify height measurement and tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->