### PR TITLE
Fix #524: Use dropdown for TTS provider selection

### DIFF
--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -5,13 +5,25 @@ import { useTTS } from '@/lib/hooks/useTTS';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { TTSProviderType } from '@/lib/tts-provider';
 import { useSettings } from '../contexts/SettingsContext';
-import { Dropdown } from '@/app/components/ui/Dropdown';
+import { Dropdown, DropdownOption } from '@/app/components/ui/Dropdown';
 import { Slider } from '@/app/components/ui/Slider';
 import { useRouter } from 'next/navigation';
 import { PlayCircleIcon, StopCircleIcon } from '@heroicons/react/24/solid';
 
 // Sample text used for voice preview
 const SAMPLE_TEXT = 'This is how I sound.';
+
+const providerDetails: Record<TTSProviderType, { name: string; description: string }> = {
+  browser: { name: 'Browser TTS', description: 'System voices' },
+  elevenlabs: { name: 'ElevenLabs', description: 'AI voices' },
+  azure: { name: 'Azure', description: 'Neural voices' },
+};
+
+type ProviderDropdownOption = DropdownOption<TTSProviderType> & {
+  name: string;
+  description: string;
+  showProBadge: boolean;
+};
 
 export default function TTSSettings() {
   const { settings, updateSetting } = useSettings();
@@ -121,6 +133,80 @@ export default function TTSSettings() {
       ? 'Azure'
       : 'Browser TTS';
 
+  const providerOptions = useMemo<ProviderDropdownOption[]>(() => {
+    const elevenLabsDisabled = !isOnline || !status.elevenLabsAvailable;
+    const azureDisabled = !isOnline || !status.azureAvailable;
+
+    return [
+      {
+        value: 'browser',
+        label: providerDetails.browser.name,
+        name: providerDetails.browser.name,
+        description: providerDetails.browser.description,
+        disabled: false,
+        showProBadge: false,
+      },
+      {
+        value: 'elevenlabs',
+        label: !isOnline
+          ? 'ElevenLabs (offline)'
+          : !status.elevenLabsAvailable
+            ? 'ElevenLabs (unavailable)'
+            : providerDetails.elevenlabs.name,
+        name: providerDetails.elevenlabs.name,
+        description: !isOnline
+          ? 'Needs internet'
+          : !status.elevenLabsAvailable
+            ? 'API key not configured'
+            : !hasSubscription
+              ? 'AI voices - Pro'
+              : providerDetails.elevenlabs.description,
+        disabled: elevenLabsDisabled,
+        showProBadge: !hasSubscription && !elevenLabsDisabled,
+      },
+      {
+        value: 'azure',
+        label: !isOnline
+          ? 'Azure (offline)'
+          : !status.azureAvailable
+            ? 'Azure (unavailable)'
+            : providerDetails.azure.name,
+        name: providerDetails.azure.name,
+        description: !isOnline
+          ? 'Needs internet'
+          : !status.azureAvailable
+            ? 'Subscription key not configured'
+            : !hasSubscription
+              ? 'Neural voices - Pro'
+              : providerDetails.azure.description,
+        disabled: azureDisabled,
+        showProBadge: !hasSubscription && !azureDisabled,
+      },
+    ];
+  }, [hasSubscription, isOnline, status.azureAvailable, status.elevenLabsAvailable]);
+
+  const selectedProviderOption = providerOptions.find(option => option.value === settings.ttsProvider);
+
+  const renderProviderOption = useCallback((option: DropdownOption<TTSProviderType>) => {
+    const providerOption = option as ProviderDropdownOption;
+
+    return (
+      <span className="block">
+        <span className="flex items-center gap-2">
+          <span className="font-medium">{providerOption.label}</span>
+          {providerOption.showProBadge && (
+            <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold bg-primary-900 text-primary-400 rounded">
+              PRO
+            </span>
+          )}
+        </span>
+        <span className="block text-xs opacity-80 mt-0.5">
+          {providerOption.description}
+        </span>
+      </span>
+    );
+  }, []);
+
   return (
     <div className="space-y-6">
       {/* Voice Selection Card */}
@@ -196,113 +282,19 @@ export default function TTSSettings() {
       {/* Provider Selection Card */}
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-foreground">Provider</h3>
-        <div className="grid grid-cols-3 gap-3">
-          {/* Browser TTS */}
-          <button
-            type="button"
-            onClick={() => handleProviderChange('browser')}
-            className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
-              settings.ttsProvider === 'browser'
-                ? 'border-primary-500 bg-primary-900'
-                : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
-            }`}
-          >
-            <div className="flex items-start gap-3">
-              <div className={`w-4 h-4 mt-0.5 rounded-full border-2 flex-shrink-0 ${
-                settings.ttsProvider === 'browser'
-                  ? 'border-primary-500 bg-primary-500'
-                  : 'border-text-tertiary'
-              }`}>
-                {settings.ttsProvider === 'browser' && (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <div className="w-1.5 h-1.5 bg-white rounded-full" />
-                  </div>
-                )}
-              </div>
-              <div className="min-w-0">
-                <span className="block font-medium text-foreground text-sm">Browser</span>
-                <span className="block text-xs text-text-secondary mt-0.5">System voices</span>
-              </div>
-            </div>
-          </button>
-
-          {/* ElevenLabs */}
-          <button
-            type="button"
-            onClick={() => handleProviderChange('elevenlabs')}
-            disabled={!status.elevenLabsAvailable || !isOnline}
-            className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
-              !status.elevenLabsAvailable || !isOnline
-                ? 'opacity-50 cursor-not-allowed border-border bg-surface'
-                : settings.ttsProvider === 'elevenlabs'
-                  ? 'border-primary-500 bg-primary-900'
-                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
-            }`}
-          >
-            <div className="flex items-start gap-3">
-              <div className={`w-4 h-4 mt-0.5 rounded-full border-2 flex-shrink-0 ${
-                settings.ttsProvider === 'elevenlabs'
-                  ? 'border-primary-500 bg-primary-500'
-                  : 'border-text-tertiary'
-              }`}>
-                {settings.ttsProvider === 'elevenlabs' && (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <div className="w-1.5 h-1.5 bg-white rounded-full" />
-                  </div>
-                )}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="font-medium text-foreground text-sm">ElevenLabs</span>
-                  {!hasSubscription && status.elevenLabsAvailable && (
-                    <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold bg-primary-900 text-primary-400 rounded">
-                      PRO
-                    </span>
-                  )}
-                </div>
-                <span className="block text-xs text-text-secondary mt-0.5">AI voices</span>
-              </div>
-            </div>
-          </button>
-
-          {/* Azure */}
-          <button
-            type="button"
-            onClick={() => handleProviderChange('azure')}
-            disabled={!status.azureAvailable || !isOnline}
-            className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
-              !status.azureAvailable || !isOnline
-                ? 'opacity-50 cursor-not-allowed border-border bg-surface'
-                : settings.ttsProvider === 'azure'
-                  ? 'border-primary-500 bg-primary-900'
-                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
-            }`}
-          >
-            <div className="flex items-start gap-3">
-              <div className={`w-4 h-4 mt-0.5 rounded-full border-2 flex-shrink-0 ${
-                settings.ttsProvider === 'azure'
-                  ? 'border-primary-500 bg-primary-500'
-                  : 'border-text-tertiary'
-              }`}>
-                {settings.ttsProvider === 'azure' && (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <div className="w-1.5 h-1.5 bg-white rounded-full" />
-                  </div>
-                )}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="font-medium text-foreground text-sm">Azure</span>
-                  {!hasSubscription && status.azureAvailable && (
-                    <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold bg-primary-900 text-primary-400 rounded">
-                      PRO
-                    </span>
-                  )}
-                </div>
-                <span className="block text-xs text-text-secondary mt-0.5">Neural voices</span>
-              </div>
-            </div>
-          </button>
+        <div className="space-y-2">
+          <Dropdown<TTSProviderType>
+            options={providerOptions}
+            value={settings.ttsProvider}
+            onChange={handleProviderChange}
+            placeholder="Select a provider"
+            renderOption={renderProviderOption}
+          />
+          {selectedProviderOption && (
+            <p className="text-xs text-text-secondary px-1">
+              {selectedProviderOption.description}
+            </p>
+          )}
         </div>
 
         {/* Subscription note */}

--- a/app/components/typing-tabs/utils.ts
+++ b/app/components/typing-tabs/utils.ts
@@ -18,12 +18,14 @@ export function generateLabelFromText(text: string, tabNumber: number): string {
 }
 
 export function createDefaultTab(tabNumber: number, text: string = ''): TypingTab {
+  const now = Date.now();
+
   return {
     id: nanoid(),
     label: generateLabelFromText(text, tabNumber),
     text,
-    createdAt: Date.now(),
-    lastModified: Date.now(),
+    createdAt: now,
+    lastModified: now,
     isCustomLabel: false,
   };
 }

--- a/tests/components/TTSSettings.test.tsx
+++ b/tests/components/TTSSettings.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TTSSettings from '@/app/components/TTSSettings';
+import { useSettings } from '@/app/contexts/SettingsContext';
+import { useTTS } from '@/lib/hooks/useTTS';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import { TTSProviderType, TTSVoice } from '@/lib/tts-provider';
+
+jest.mock('@/app/contexts/SettingsContext', () => ({
+  useSettings: jest.fn(),
+}));
+
+jest.mock('@/lib/hooks/useTTS', () => ({
+  useTTS: jest.fn(),
+}));
+
+jest.mock('@/lib/hooks/useOnlineStatus', () => ({
+  useOnlineStatus: jest.fn(),
+}));
+
+const mockUseSettings = jest.mocked(useSettings);
+const mockUseTTS = jest.mocked(useTTS);
+const mockUseOnlineStatus = jest.mocked(useOnlineStatus);
+
+const mockUpdateSetting = jest.fn();
+
+const voices: TTSVoice[] = [
+  { id: 'browser-voice-1', name: 'Browser Voice', provider: 'browser' },
+  { id: 'eleven-voice-1', name: 'Eleven Voice', provider: 'elevenlabs' },
+  { id: 'azure-voice-1', name: 'Azure Voice', provider: 'azure' },
+];
+
+const defaultSettings = {
+  ttsProvider: 'browser' as TTSProviderType,
+  ttsVoiceId: 'browser-voice-1',
+  speechRate: 1,
+  speechPitch: 1,
+  speechVolume: 1,
+  ttsStability: 0.5,
+  ttsSimilarityBoost: 0.5,
+  ttsModelPreference: 'fast' as const,
+};
+
+const defaultStatus = {
+  isSpeaking: false,
+  activeProvider: 'browser' as TTSProviderType,
+  elevenLabsAvailable: true,
+  azureAvailable: true,
+  browserTTSAvailable: true,
+};
+
+function renderTTSSettings({
+  settings = {},
+  status = {},
+  isOnline = true,
+  hasSubscription = true,
+}: {
+  settings?: Partial<typeof defaultSettings>;
+  status?: Partial<typeof defaultStatus>;
+  isOnline?: boolean;
+  hasSubscription?: boolean;
+} = {}) {
+  const mergedSettings = { ...defaultSettings, ...settings };
+  const mergedStatus = { ...defaultStatus, ...status };
+
+  mockUseSettings.mockReturnValue({
+    settings: mergedSettings,
+    updateSetting: mockUpdateSetting,
+  } as never);
+
+  mockUseOnlineStatus.mockReturnValue({
+    isOnline,
+  } as never);
+
+  mockUseTTS.mockReturnValue({
+    voices,
+    speak: jest.fn(),
+    stop: jest.fn(),
+    isSpeaking: false,
+    status: mergedStatus,
+    getVoicesByProvider: jest.fn((provider: TTSProviderType) => voices.filter(voice => voice.provider === provider)),
+    refreshVoices: jest.fn(),
+    loadElevenLabsVoices: jest.fn(),
+    loadAzureVoices: jest.fn(),
+    hasSubscription,
+  } as never);
+
+  return render(<TTSSettings />);
+}
+
+async function openProviderDropdown(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Browser TTS' }));
+}
+
+describe('TTSSettings provider dropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders provider selection as a dropdown with Browser TTS selected by default', () => {
+    renderTTSSettings();
+
+    expect(screen.getByRole('button', { name: 'Browser TTS' })).toBeInTheDocument();
+  });
+
+  it('shows all provider options when opened', async () => {
+    const user = userEvent.setup();
+    renderTTSSettings();
+
+    await openProviderDropdown(user);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Browser TTS')).toBeInTheDocument();
+    expect(within(dialog).getByText('ElevenLabs')).toBeInTheDocument();
+    expect(within(dialog).getByText('Azure')).toBeInTheDocument();
+  });
+
+  it('changes provider when an available provider is selected', async () => {
+    const user = userEvent.setup();
+    renderTTSSettings();
+
+    await openProviderDropdown(user);
+    await user.click(screen.getByText('ElevenLabs'));
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith('ttsProvider', 'elevenlabs');
+  });
+
+  it('disables ElevenLabs while offline', async () => {
+    const user = userEvent.setup();
+    renderTTSSettings({ isOnline: false });
+
+    await openProviderDropdown(user);
+
+    const elevenLabsOption = screen.getByRole('button', { name: /ElevenLabs \(offline\)/i });
+    expect(elevenLabsOption).toBeDisabled();
+
+    await user.click(elevenLabsOption);
+    expect(mockUpdateSetting).not.toHaveBeenCalledWith('ttsProvider', 'elevenlabs');
+  });
+
+  it('disables Azure when unavailable', async () => {
+    const user = userEvent.setup();
+    renderTTSSettings({ status: { azureAvailable: false } });
+
+    await openProviderDropdown(user);
+
+    const azureOption = screen.getByRole('button', { name: /Azure \(unavailable\)/i });
+    expect(azureOption).toBeDisabled();
+
+    await user.click(azureOption);
+    expect(mockUpdateSetting).not.toHaveBeenCalledWith('ttsProvider', 'azure');
+  });
+
+  it('keeps premium providers selectable for non-subscribers when available', async () => {
+    const user = userEvent.setup();
+    renderTTSSettings({ hasSubscription: false });
+
+    await openProviderDropdown(user);
+
+    expect(screen.getAllByText('PRO')).toHaveLength(2);
+
+    await user.click(screen.getByText('Azure'));
+    expect(mockUpdateSetting).toHaveBeenCalledWith('ttsProvider', 'azure');
+  });
+
+  it('preserves existing subscription, offline, and unavailable provider warning copy', () => {
+    const { rerender } = renderTTSSettings({
+      settings: { ttsProvider: 'elevenlabs', ttsVoiceId: 'eleven-voice-1' },
+      hasSubscription: false,
+    });
+
+    expect(screen.getByText(/Pro subscription required for ElevenLabs voices/i)).toBeInTheDocument();
+
+    mockUseOnlineStatus.mockReturnValue({
+      isOnline: false,
+    } as never);
+    mockUseTTS.mockReturnValue({
+      voices,
+      speak: jest.fn(),
+      stop: jest.fn(),
+      isSpeaking: false,
+      status: defaultStatus,
+      getVoicesByProvider: jest.fn((provider: TTSProviderType) => voices.filter(voice => voice.provider === provider)),
+      refreshVoices: jest.fn(),
+      loadElevenLabsVoices: jest.fn(),
+      loadAzureVoices: jest.fn(),
+      hasSubscription: true,
+    } as never);
+    rerender(<TTSSettings />);
+
+    expect(screen.getByText(/Offline\. Browser TTS still works, but ElevenLabs and Azure voices need internet\./i)).toBeInTheDocument();
+
+    mockUseOnlineStatus.mockReturnValue({
+      isOnline: true,
+    } as never);
+    mockUseTTS.mockReturnValue({
+      voices,
+      speak: jest.fn(),
+      stop: jest.fn(),
+      isSpeaking: false,
+      status: {
+        ...defaultStatus,
+        elevenLabsAvailable: false,
+        azureAvailable: false,
+      },
+      getVoicesByProvider: jest.fn((provider: TTSProviderType) => voices.filter(voice => voice.provider === provider)),
+      refreshVoices: jest.fn(),
+      loadElevenLabsVoices: jest.fn(),
+      loadAzureVoices: jest.fn(),
+      hasSubscription: true,
+    } as never);
+    rerender(<TTSSettings />);
+
+    expect(screen.getByText(/ElevenLabs unavailable\. API key not configured\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Azure unavailable\. Subscription key not configured\./i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the TTS provider card selector with the shared Dropdown component
- keep existing provider availability guards, subscription/offline warnings, and voice settings behavior
- add focused TTSSettings coverage for provider dropdown states

## Tests
- npm test -- --runTestsByPath tests/components/TTSSettings.test.tsx
- npm test -- --runTestsByPath tests/lib/hooks/useTTS.test.ts
- npm run build

Fixes #524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Redesigned text-to-speech provider selection to a dropdown with richer provider descriptions and PRO badges
  * Options now reflect online status, provider availability, and subscription/configuration state, with unavailable choices disabled and contextual warnings shown
  * Minor consistency fix for tab timestamps to use a single creation/modification time

* **Tests**
  * Added comprehensive tests covering provider dropdown rendering, option states, selection behavior, and conditional warning/copy text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->