### PR TITLE
Fix #526: Stabilize mobile composer scrolling

### DIFF
--- a/app/components/Composer.tsx
+++ b/app/components/Composer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useLayoutEffect } from 'react';
 import { SparklesIcon, XMarkIcon, ArrowPathIcon, ShareIcon, BookmarkIcon } from '@heroicons/react/24/outline';
 import { useSettings } from '../contexts/SettingsContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -49,6 +49,19 @@ interface ComposerProps {
 
 type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
 
+type TextareaScrollIntent = {
+  selectionStart: number;
+  selectionEnd: number;
+  shouldScrollToEnd: boolean;
+};
+
+type TextareaScrollSnapshot = {
+  selectionStart: number;
+  selectionEnd: number;
+  wasAtEnd: boolean;
+  wasNearBottom: boolean;
+};
+
 export default function Composer({
   text,
   onChange,
@@ -74,6 +87,9 @@ export default function Composer({
   const [showLiveTypingModal, setShowLiveTypingModal] = useState(false);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const pendingTextareaScrollRef = useRef<TextareaScrollIntent | null>(null);
+  const previousRenderedTextRef = useRef('');
+  const lastTextareaSnapshotRef = useRef<TextareaScrollSnapshot | null>(null);
   const prevTextRef = useRef(text);
   const prevActiveTabIdRef = useRef<string | null>(null);
   const hasProcessedInitialTextRef = useRef(false);
@@ -161,6 +177,56 @@ export default function Composer({
   const currentText = enableTabs ? activeTab.text : text;
   const shareableLink = getShareableLink();
   const isLiveTypingButtonActive = isLiveTypingSharing || showLiveTypingModal || showLiveTypingSheet;
+
+  const captureTextareaSnapshot = useCallback((value?: string) => {
+    const textarea = inputRef.current;
+    if (!textarea) return;
+
+    const currentValue = value ?? textarea.value;
+    const selectionStart = textarea.selectionStart ?? currentValue.length;
+    const selectionEnd = textarea.selectionEnd ?? selectionStart;
+    const distanceFromBottom = textarea.scrollHeight - textarea.scrollTop - textarea.clientHeight;
+    const wasNearBottom = distanceFromBottom <= 24;
+
+    lastTextareaSnapshotRef.current = {
+      selectionStart,
+      selectionEnd,
+      wasAtEnd: selectionStart >= currentValue.length,
+      wasNearBottom,
+    };
+  }, []);
+
+  const captureTextareaScrollIntent = useCallback((nextValue: string) => {
+    const textarea = inputRef.current;
+    if (!textarea || document.activeElement !== textarea) {
+      pendingTextareaScrollRef.current = null;
+      return;
+    }
+
+    const selectionStart = textarea.selectionStart ?? nextValue.length;
+    const selectionEnd = textarea.selectionEnd ?? selectionStart;
+    const distanceFromBottom = textarea.scrollHeight - textarea.scrollTop - textarea.clientHeight;
+    const isNearBottom = distanceFromBottom <= 24;
+    const isCaretAtEnd = selectionStart >= nextValue.length;
+    const previousSnapshot = lastTextareaSnapshotRef.current;
+    const wasEditingEarlier = !!previousSnapshot
+      && !previousSnapshot.wasAtEnd
+      && !previousSnapshot.wasNearBottom;
+    const shouldScrollToEnd = !wasEditingEarlier
+      && (isCaretAtEnd || isNearBottom || !!previousSnapshot?.wasAtEnd || !!previousSnapshot?.wasNearBottom);
+
+    pendingTextareaScrollRef.current = {
+      selectionStart,
+      selectionEnd,
+      shouldScrollToEnd,
+    };
+    lastTextareaSnapshotRef.current = {
+      selectionStart,
+      selectionEnd,
+      wasAtEnd: isCaretAtEnd,
+      wasNearBottom: isNearBottom,
+    };
+  }, []);
 
   const showUndoHint = canUndo
     && entry?.tabId === (activeTabId || 'default')
@@ -315,11 +381,54 @@ export default function Composer({
   };
 
   const handleTextChange = (value: string) => {
+    captureTextareaScrollIntent(value);
     if (canUndo && value.trim().length > 0) resetUndo();
     if (error) setError(null);
     if (enableTabs) updateActiveTabText(value);
     onChange(value);
   };
+
+  useLayoutEffect(() => {
+    const textarea = inputRef.current;
+    if (!textarea) {
+      previousRenderedTextRef.current = currentText;
+      pendingTextareaScrollRef.current = null;
+      return;
+    }
+
+    const pending = pendingTextareaScrollRef.current;
+    const previousText = previousRenderedTextRef.current;
+    const snapshot = lastTextareaSnapshotRef.current;
+    const wasExternalAppend = currentText.length > previousText.length
+      && !!snapshot
+      && (snapshot.wasAtEnd || snapshot.wasNearBottom);
+
+    if (pending && document.activeElement === textarea) {
+      const selectionStart = Math.min(pending.selectionStart, currentText.length);
+      const selectionEnd = Math.min(pending.selectionEnd, currentText.length);
+      textarea.setSelectionRange(selectionStart, selectionEnd);
+
+      if (pending.shouldScrollToEnd) {
+        textarea.scrollTop = textarea.scrollHeight;
+      }
+    } else if (wasExternalAppend) {
+      textarea.setSelectionRange(currentText.length, currentText.length);
+      textarea.scrollTop = textarea.scrollHeight;
+    }
+
+    previousRenderedTextRef.current = currentText;
+    pendingTextareaScrollRef.current = null;
+    captureTextareaSnapshot(currentText);
+  }, [captureTextareaSnapshot, currentText]);
+
+  const handleTabSelect = useCallback((tabId: string) => {
+    switchTab(tabId);
+    pendingTextareaScrollRef.current = {
+      selectionStart: Number.MAX_SAFE_INTEGER,
+      selectionEnd: Number.MAX_SAFE_INTEGER,
+      shouldScrollToEnd: true,
+    };
+  }, [switchTab]);
 
   const toolbarContent = (
     <div className={`flex items-center gap-3 px-4 pt-2 ${shouldPortalToolbar ? 'pb-2' : 'pb-4'}`}>
@@ -405,14 +514,14 @@ export default function Composer({
 
   return (
     <>
-      <div className={`flex flex-col flex-1 min-h-0 h-full ${className}`}>
+      <div className={`flex flex-col flex-1 min-h-0 h-full overflow-hidden ${className}`}>
         {/* Tab bar */}
         {enableTabs && (
-          <div className="shrink-0">
+          <div className="sticky top-0 z-10 shrink-0">
             <TabBar
               tabs={tabs}
               activeTabId={activeTabId}
-              onTabSelect={switchTab}
+              onTabSelect={handleTabSelect}
               onTabClose={closeTab}
               onTabCreate={createTab}
               onTabRename={renameTab}
@@ -422,11 +531,15 @@ export default function Composer({
         )}
 
         {/* Textarea — full bleed, fills the screen */}
-        <div className="flex-1 min-h-[120px] overflow-hidden">
+        <div className="flex-1 min-h-0 overflow-hidden md:min-h-[120px]">
           <textarea
             ref={inputRef}
             value={currentText}
             onChange={(e) => handleTextChange(e.target.value)}
+            onSelect={() => captureTextareaSnapshot()}
+            onClick={() => captureTextareaSnapshot()}
+            onKeyUp={() => captureTextareaSnapshot()}
+            onBlur={() => captureTextareaSnapshot()}
             onKeyDown={handleKeyDown}
             placeholder="What do you want to say?"
             className="w-full h-full overflow-y-auto bg-transparent text-foreground placeholder:text-text-tertiary px-6 py-5 resize-none focus:outline-none"
@@ -510,7 +623,7 @@ export default function Composer({
           onClose={() => setShowTabList(false)}
           tabs={tabs}
           activeTabId={activeTabId}
-          onSwitchTab={(tabId) => { switchTab(tabId); const tab = tabs.find(t => t.id === tabId); if (tab) onChange(tab.text); }}
+          onSwitchTab={(tabId) => { handleTabSelect(tabId); const tab = tabs.find(t => t.id === tabId); if (tab) onChange(tab.text); }}
           onCloseTab={(tabId) => { closeTab(tabId); const remaining = tabs.filter(t => t.id !== tabId); if (remaining.length > 0) onChange(remaining[0].text); }}
           onCloseAllTabs={() => { closeAllTabs(); onChange(''); }}
           onCreateTab={() => { createTab(); onChange(''); }}

--- a/tests/components/Composer.test.tsx
+++ b/tests/components/Composer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Composer from '@/app/components/Composer';
 import { useAuth } from '@/app/contexts/AuthContext';
@@ -119,6 +119,50 @@ const mockUseLiveTyping = jest.mocked(useLiveTyping);
 const mockUseIsMobile = jest.mocked(useIsMobile);
 const mockUseOptionalMobileBottom = jest.mocked(useOptionalMobileBottom);
 
+function setTextareaLayout(textarea: HTMLTextAreaElement, {
+  scrollHeight = 1000,
+  clientHeight = 200,
+}: {
+  scrollHeight?: number;
+  clientHeight?: number;
+} = {}) {
+  Object.defineProperty(textarea, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(textarea, 'clientHeight', { value: clientHeight, configurable: true });
+}
+
+function ControlledComposer({
+  initialValue = 'Line 1',
+}: {
+  initialValue?: string;
+}) {
+  const [value, setValue] = React.useState(initialValue);
+
+  return (
+    <Composer
+      text={value}
+      onChange={setValue}
+      onSpeak={jest.fn()}
+    />
+  );
+}
+
+function ControlledComposerWithAppend() {
+  const [value, setValue] = React.useState('Hello');
+
+  return (
+    <>
+      <button onClick={() => setValue(current => `${current} world`)}>
+        Append
+      </button>
+      <Composer
+        text={value}
+        onChange={setValue}
+        onSpeak={jest.fn()}
+      />
+    </>
+  );
+}
+
 describe('Composer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -178,10 +222,77 @@ describe('Composer', () => {
     );
 
     const textarea = screen.getByRole('textbox');
-    expect(textarea.parentElement).toHaveClass('flex-1', 'min-h-[120px]', 'overflow-hidden');
+    expect(textarea.parentElement?.parentElement).toHaveClass('overflow-hidden');
+    expect(textarea.parentElement).toHaveClass('flex-1', 'min-h-0', 'overflow-hidden', 'md:min-h-[120px]');
     expect(textarea).toHaveClass('h-full', 'overflow-y-auto', 'resize-none');
     expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
+  });
+
+  it('keeps typing tabs pinned while the textarea can shrink', () => {
+    mockUseIsMobile.mockReturnValue(true);
+
+    render(
+      <Composer
+        text="Some text"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableTabs={true}
+      />
+    );
+
+    const tabButton = screen.getByRole('button', { name: /Active tab:/i });
+    expect(tabButton.closest('.sticky')).toHaveClass('sticky', 'top-0', 'z-10', 'shrink-0');
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.parentElement).toHaveClass('min-h-0');
+  });
+
+  it('scrolls the textarea to the bottom when typing at the end', async () => {
+    const user = userEvent.setup();
+    render(<ControlledComposer />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    setTextareaLayout(textarea);
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    fireEvent.select(textarea);
+
+    await user.type(textarea, ' extra text');
+
+    expect(textarea.scrollTop).toBe(1000);
+  });
+
+  it('does not force the textarea to the bottom when editing earlier text', () => {
+    render(<ControlledComposer initialValue={'Line 1\nLine 2\nLine 3'} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    setTextareaLayout(textarea);
+    textarea.scrollTop = 100;
+    textarea.focus();
+    textarea.setSelectionRange(2, 2);
+    fireEvent.select(textarea);
+
+    fireEvent.change(textarea, { target: { value: 'LiXne 1\nLine 2\nLine 3' } });
+
+    expect(textarea.scrollTop).not.toBe(1000);
+  });
+
+  it('scrolls external appended text into view when focused at the end', async () => {
+    const user = userEvent.setup();
+    render(<ControlledComposerWithAppend />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    setTextareaLayout(textarea);
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    fireEvent.select(textarea);
+
+    await user.click(screen.getByRole('button', { name: 'Append' }));
+
+    expect(textarea).toHaveValue('Hello world');
+    expect(textarea.selectionStart).toBe('Hello world'.length);
+    expect(textarea.scrollTop).toBe(1000);
   });
 
   it('restores the active tab draft on mount when tabs enabled', async () => {


### PR DESCRIPTION
## Summary
- keep the composer overflow contained so mobile keyboard/dock changes do not push the whole composer layout
- pin typing tabs at the top of the composer while allowing the textarea area to shrink on mobile
- add caret-following textarea scroll behavior for typing, external appends, and tab switches
- add Composer tests for layout and scroll behavior

## Tests
- npm test -- --runTestsByPath tests/components/Composer.test.tsx
- npm test -- --runTestsByPath tests/components/typing-tabs/TabBar.test.tsx
- npm test -- --runTestsByPath tests/components/navigation/MobileBottomStack.test.tsx
- npm test
- npm run build
- npm run lint

Note: npm run lint exits 0 with the existing PhrasesInterface.tsx hook dependency warning.

Fixes #526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced textarea auto-scrolling behavior when composing text
  * Improved text selection and scroll position preservation across updates

* **Bug Fixes**
  * Fixed textarea container layout on responsive screen sizes
  * Corrected scroll behavior when switching between tabs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->