### PR TITLE
Add symbol support for phrases

### DIFF
--- a/app/api/symbol-proxy/route.ts
+++ b/app/api/symbol-proxy/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const url = searchParams.get('url');
+
+    if (!url) {
+      return NextResponse.json(
+        { error: 'URL parameter is required' },
+        { status: 400 },
+      );
+    }
+
+    // Only allow proxying from Global Symbols domains
+    const parsedUrl = new URL(url);
+    const allowedHosts = ['globalsymbols.com', 'www.globalsymbols.com', 'mulberrysymbols.org', 'www.mulberrysymbols.org'];
+    if (!allowedHosts.some((host) => parsedUrl.hostname === host || parsedUrl.hostname.endsWith(`.${host}`))) {
+      return NextResponse.json(
+        { error: 'URL not allowed' },
+        { status: 403 },
+      );
+    }
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch image' },
+        { status: response.status },
+      );
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'image/png';
+    const buffer = await response.arrayBuffer();
+
+    return new NextResponse(buffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=86400',
+      },
+    });
+  } catch (error) {
+    console.error('Error in symbol proxy:', error);
+    return NextResponse.json(
+      { error: 'Server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/symbol-proxy/route.ts
+++ b/app/api/symbol-proxy/route.ts
@@ -15,8 +15,14 @@ export async function GET(request: Request) {
       );
     }
 
-    // Only allow proxying from Global Symbols domains
+    // Only allow proxying from Global Symbols domains over HTTPS
     const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== 'https:') {
+      return NextResponse.json(
+        { error: 'URL not allowed' },
+        { status: 403 },
+      );
+    }
     const allowedHosts = ['globalsymbols.com', 'www.globalsymbols.com', 'mulberrysymbols.org', 'www.mulberrysymbols.org'];
     if (!allowedHosts.some((host) => parsedUrl.hostname === host || parsedUrl.hostname.endsWith(`.${host}`))) {
       return NextResponse.json(

--- a/app/api/symbol-search/route.ts
+++ b/app/api/symbol-search/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface GlobalSymbolResult {
+  picto: {
+    id: number;
+    image_url: string;
+    name?: string;
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('query');
+    const limit = searchParams.get('limit') ?? '50';
+
+    if (!query || !query.trim()) {
+      return NextResponse.json(
+        { error: 'Query parameter is required' },
+        { status: 400 },
+      );
+    }
+
+    const apiUrl = `https://globalsymbols.com/api/v1/labels/search?query=${encodeURIComponent(query.trim())}&limit=${encodeURIComponent(limit)}`;
+    const response = await fetch(apiUrl);
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to search symbols' },
+        { status: response.status },
+      );
+    }
+
+    const results: GlobalSymbolResult[] = await response.json();
+
+    const symbols = results
+      .filter((r) => r.picto?.image_url)
+      .map((r) => ({
+        id: r.picto.id,
+        imageUrl: r.picto.image_url,
+        name: r.picto.name ?? '',
+      }));
+
+    return NextResponse.json({ symbols });
+  } catch (error) {
+    console.error('Error in symbol search API:', error);
+    return NextResponse.json(
+      { error: 'Server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -3,11 +3,13 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { StopIcon } from '@heroicons/react/24/solid';
+import { SymbolImage } from '../symbols';
 
 interface PhraseTileProps {
   phrase: {
     id?: string;
     text: string;
+    symbolUrl?: string;
   };
   onPress: () => void;
   onStop?: () => void;
@@ -112,7 +114,10 @@ export default function PhraseTile({ phrase, onPress, onStop, onEdit, onLongPres
           <StopIcon className="w-2.5 h-2.5 text-white" />
         </div>
       )}
-      <div className="flex items-center justify-center w-full h-full p-2">
+      <div className="flex flex-col items-center justify-center w-full h-full p-2 gap-1">
+        {phrase.symbolUrl && (
+          <SymbolImage src={phrase.symbolUrl} alt={phrase.text} size="md" />
+        )}
         <p className="text-foreground text-sm sm:text-base font-semibold line-clamp-2 leading-tight text-center w-full">
           {phrase.text}
         </p>

--- a/app/components/phrases/types.ts
+++ b/app/components/phrases/types.ts
@@ -1,6 +1,8 @@
 export interface PhraseSummary {
   id: string;
   text: string;
+  symbolUrl?: string;
+  symbolStorageId?: string;
 }
 
 export interface BoardSummary {

--- a/app/components/symbols/SymbolImage.tsx
+++ b/app/components/symbols/SymbolImage.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Image from 'next/image';
+
+type SymbolSize = 'sm' | 'md' | 'lg';
+
+const SIZE_MAP: Record<SymbolSize, number> = {
+  sm: 32,
+  md: 48,
+  lg: 64,
+};
+
+interface SymbolImageProps {
+  src: string;
+  alt: string;
+  size?: SymbolSize;
+  className?: string;
+}
+
+export default function SymbolImage({ src, alt, size = 'md', className = '' }: SymbolImageProps) {
+  const px = SIZE_MAP[size];
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={px}
+      height={px}
+      className={`rounded-lg bg-white border border-border object-contain ${className}`}
+      unoptimized={src.includes('globalsymbols.com')}
+    />
+  );
+}

--- a/app/components/symbols/SymbolSearchModal.tsx
+++ b/app/components/symbols/SymbolSearchModal.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { XMarkIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { motion, AnimatePresence } from 'framer-motion';
+import SymbolImage from './SymbolImage';
+
+export interface SymbolResult {
+  id: number;
+  imageUrl: string;
+  name: string;
+}
+
+interface SymbolSearchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (symbol: SymbolResult) => void;
+  initialQuery?: string;
+}
+
+export default function SymbolSearchModal({ isOpen, onClose, onSelect, initialQuery = '' }: SymbolSearchModalProps) {
+  const [query, setQuery] = useState(initialQuery);
+  const [results, setResults] = useState<SymbolResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setQuery(initialQuery);
+      setResults([]);
+      setError(null);
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [isOpen, initialQuery]);
+
+  const search = useCallback(async (searchQuery: string) => {
+    if (!searchQuery.trim()) {
+      setResults([]);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/symbol-search?query=${encodeURIComponent(searchQuery.trim())}&limit=50`);
+      if (!response.ok) throw new Error('Search failed');
+      const data = await response.json();
+      setResults(data.symbols ?? []);
+    } catch {
+      setError('Failed to search symbols. Please try again.');
+      setResults([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(query), 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, search]);
+
+  // ESC to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => { document.body.style.overflow = ''; };
+  }, [isOpen]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[70]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            aria-hidden="true"
+          />
+
+          {/* Modal */}
+          <motion.div
+            className="fixed inset-0 z-[75] flex items-center justify-center p-4 sm:p-6"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              className="bg-surface rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] flex flex-col overflow-hidden"
+              initial={{ scale: 0.95, y: 20 }}
+              animate={{ scale: 1, y: 0 }}
+              exit={{ scale: 0.95, y: 20 }}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Search symbols"
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+                <h2 className="text-lg font-semibold text-foreground">Search Symbols</h2>
+                <button
+                  onClick={onClose}
+                  className="p-2 min-h-[44px] min-w-[44px] rounded-full hover:bg-surface-hover transition-colors flex items-center justify-center"
+                  aria-label="Close"
+                >
+                  <XMarkIcon className="w-6 h-6 text-text-secondary" />
+                </button>
+              </div>
+
+              {/* Search input */}
+              <div className="px-4 py-3 border-b border-border">
+                <div className="relative">
+                  <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-text-tertiary" />
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search for a symbol..."
+                    className="w-full pl-10 pr-4 py-2.5 bg-surface border border-border rounded-xl text-foreground text-base placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  />
+                </div>
+              </div>
+
+              {/* Results */}
+              <div className="flex-1 overflow-y-auto p-4">
+                {isLoading && (
+                  <div className="grid grid-cols-4 sm:grid-cols-5 gap-3">
+                    {Array.from({ length: 12 }).map((_, i) => (
+                      <div key={i} className="aspect-square rounded-lg bg-surface-hover animate-pulse" />
+                    ))}
+                  </div>
+                )}
+
+                {error && (
+                  <p className="text-center text-red-400 text-sm py-8">{error}</p>
+                )}
+
+                {!isLoading && !error && results.length === 0 && query.trim() && (
+                  <p className="text-center text-text-tertiary text-sm py-8">No symbols found</p>
+                )}
+
+                {!isLoading && !error && results.length === 0 && !query.trim() && (
+                  <p className="text-center text-text-tertiary text-sm py-8">Type to search for symbols</p>
+                )}
+
+                {!isLoading && !error && results.length > 0 && (
+                  <div className="grid grid-cols-4 sm:grid-cols-5 gap-3">
+                    {results.map((symbol) => (
+                      <button
+                        key={symbol.id}
+                        onClick={() => onSelect(symbol)}
+                        className="flex flex-col items-center gap-1 p-2 rounded-xl hover:bg-surface-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                        aria-label={`Select symbol: ${symbol.name}`}
+                      >
+                        <SymbolImage src={symbol.imageUrl} alt={symbol.name} size="lg" />
+                        <span className="text-xs text-text-secondary line-clamp-1 w-full text-center">
+                          {symbol.name}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Attribution */}
+              <div className="px-4 py-2 border-t border-border text-center">
+                <span className="text-xs text-text-tertiary">
+                  Powered by{' '}
+                  <a
+                    href="https://globalsymbols.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary-500 hover:underline"
+                  >
+                    Global Symbols
+                  </a>
+                </span>
+              </div>
+            </motion.div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/components/symbols/SymbolSelector.tsx
+++ b/app/components/symbols/SymbolSelector.tsx
@@ -18,11 +18,13 @@ interface SymbolSelectorProps {
 export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText = '' }: SymbolSelectorProps) {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const generateUploadUrl = useMutation(api.symbols.generateUploadUrl);
 
   const handleSelect = useCallback(async (symbol: SymbolResult) => {
     setIsSearchOpen(false);
     setIsUploading(true);
+    setUploadError(null);
 
     try {
       // Download image via proxy
@@ -43,6 +45,7 @@ export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText =
       onSymbolChange({ storageId, url: symbol.imageUrl });
     } catch (err) {
       console.error('Error uploading symbol:', err);
+      setUploadError('Failed to upload symbol. Please try again.');
     } finally {
       setIsUploading(false);
     }
@@ -80,8 +83,10 @@ export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText =
             )}
           </button>
         )}
-        <div className="text-sm text-text-secondary">
-          {symbolUrl ? (
+        <div className="text-sm">
+          {uploadError ? (
+            <span className="text-red-400">{uploadError}</span>
+          ) : symbolUrl ? (
             <button
               onClick={() => setIsSearchOpen(true)}
               className="text-primary-500 hover:underline"
@@ -89,7 +94,7 @@ export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText =
               Change symbol
             </button>
           ) : (
-            <span>{isUploading ? 'Uploading...' : 'Add a symbol (optional)'}</span>
+            <span className="text-text-secondary">{isUploading ? 'Uploading...' : 'Add a symbol (optional)'}</span>
           )}
         </div>
       </div>

--- a/app/components/symbols/SymbolSelector.tsx
+++ b/app/components/symbols/SymbolSelector.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { XMarkIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import SymbolImage from './SymbolImage';
+import SymbolSearchModal, { type SymbolResult } from './SymbolSearchModal';
+
+interface SymbolSelectorProps {
+  symbolUrl?: string | null;
+  symbolStorageId?: string | null;
+  onSymbolChange: (symbol: { storageId: Id<'_storage'>; url: string } | null) => void;
+  phraseText?: string;
+}
+
+export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText = '' }: SymbolSelectorProps) {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const generateUploadUrl = useMutation(api.symbols.generateUploadUrl);
+
+  const handleSelect = useCallback(async (symbol: SymbolResult) => {
+    setIsSearchOpen(false);
+    setIsUploading(true);
+
+    try {
+      // Download image via proxy
+      const proxyResponse = await fetch(`/api/symbol-proxy?url=${encodeURIComponent(symbol.imageUrl)}`);
+      if (!proxyResponse.ok) throw new Error('Failed to download symbol image');
+      const blob = await proxyResponse.blob();
+
+      // Upload to Convex storage
+      const uploadUrl = await generateUploadUrl();
+      const uploadResponse = await fetch(uploadUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': blob.type || 'image/png' },
+        body: blob,
+      });
+      if (!uploadResponse.ok) throw new Error('Failed to upload symbol');
+      const { storageId } = await uploadResponse.json();
+
+      onSymbolChange({ storageId, url: symbol.imageUrl });
+    } catch (err) {
+      console.error('Error uploading symbol:', err);
+    } finally {
+      setIsUploading(false);
+    }
+  }, [generateUploadUrl, onSymbolChange]);
+
+  const handleClear = useCallback(() => {
+    onSymbolChange(null);
+  }, [onSymbolChange]);
+
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        {symbolUrl ? (
+          <div className="relative">
+            <SymbolImage src={symbolUrl} alt="Selected symbol" size="lg" />
+            <button
+              onClick={handleClear}
+              className="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-red-500 flex items-center justify-center hover:bg-red-600 transition-colors"
+              aria-label="Remove symbol"
+            >
+              <XMarkIcon className="w-3 h-3 text-white" />
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setIsSearchOpen(true)}
+            disabled={isUploading}
+            className="w-16 h-16 rounded-lg border-2 border-dashed border-border flex items-center justify-center hover:bg-surface-hover transition-colors disabled:opacity-50"
+            aria-label="Add symbol"
+          >
+            {isUploading ? (
+              <div className="w-5 h-5 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <PlusIcon className="w-6 h-6 text-text-tertiary" />
+            )}
+          </button>
+        )}
+        <div className="text-sm text-text-secondary">
+          {symbolUrl ? (
+            <button
+              onClick={() => setIsSearchOpen(true)}
+              className="text-primary-500 hover:underline"
+            >
+              Change symbol
+            </button>
+          ) : (
+            <span>{isUploading ? 'Uploading...' : 'Add a symbol (optional)'}</span>
+          )}
+        </div>
+      </div>
+
+      <SymbolSearchModal
+        isOpen={isSearchOpen}
+        onClose={() => setIsSearchOpen(false)}
+        onSelect={handleSelect}
+        initialQuery={phraseText}
+      />
+    </>
+  );
+}

--- a/app/components/symbols/index.ts
+++ b/app/components/symbols/index.ts
@@ -1,0 +1,4 @@
+export { default as SymbolImage } from './SymbolImage';
+export { default as SymbolSearchModal } from './SymbolSearchModal';
+export { default as SymbolSelector } from './SymbolSelector';
+export type { SymbolResult } from './SymbolSearchModal';

--- a/app/phrases/add/page.tsx
+++ b/app/phrases/add/page.tsx
@@ -9,6 +9,7 @@ import Input from '@/app/components/ui/Input';
 import { Button } from '@/app/components/ui/Button';
 import BackButton from '@/app/components/ui/BackButton';
 import BottomSheet from '@/app/components/ui/BottomSheet';
+import { SymbolSelector } from '@/app/components/symbols';
 import { ChevronDownIcon, UserGroupIcon, CheckIcon } from '@heroicons/react/24/outline';
 
 function AddPhraseForm() {
@@ -17,6 +18,8 @@ function AddPhraseForm() {
   const boardIdFromUrl = searchParams.get('boardId');
   const [selectedBoardId, setSelectedBoardId] = useState<string | null>(boardIdFromUrl);
   const [text, setText] = useState(searchParams.get('text') ?? '');
+  const [symbolStorageId, setSymbolStorageId] = useState<Id<'_storage'> | null>(null);
+  const [symbolPreviewUrl, setSymbolPreviewUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isBoardPickerOpen, setIsBoardPickerOpen] = useState(false);
@@ -56,6 +59,7 @@ function AddPhraseForm() {
       const phraseId = await addPhrase({
         text,
         position: 0, // Will be adjusted by backend based on board
+        ...(symbolStorageId ? { symbolStorageId } : {}),
       });
 
       // Add it to the board
@@ -130,6 +134,26 @@ function AddPhraseForm() {
             placeholder="Enter your phrase"
             required
           />
+
+          <div className="mb-4">
+            <label className="block text-foreground text-sm font-semibold mb-2">
+              Symbol
+            </label>
+            <SymbolSelector
+              symbolUrl={symbolPreviewUrl}
+              symbolStorageId={symbolStorageId}
+              onSymbolChange={(symbol) => {
+                if (symbol) {
+                  setSymbolStorageId(symbol.storageId);
+                  setSymbolPreviewUrl(symbol.url);
+                } else {
+                  setSymbolStorageId(null);
+                  setSymbolPreviewUrl(null);
+                }
+              }}
+              phraseText={text}
+            />
+          </div>
 
           {error && (
             <div className="mb-4 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">

--- a/app/phrases/edit/[id]/page.tsx
+++ b/app/phrases/edit/[id]/page.tsx
@@ -9,12 +9,16 @@ import { use } from 'react';
 import Input from '@/app/components/ui/Input';
 import { Button } from '@/app/components/ui/Button';
 import BackButton from '@/app/components/ui/BackButton';
+import { SymbolSelector } from '@/app/components/symbols';
 import { useAuth } from '@/app/contexts/AuthContext';
 import type { Id } from '@/convex/_generated/dataModel';
 
 export default function EditPhrasePage({ params }: { params: Promise<{ id: string }> }) {
   const resolvedParams = use(params);
   const [text, setText] = useState('');
+  const [symbolStorageId, setSymbolStorageId] = useState<Id<'_storage'> | null>(null);
+  const [symbolPreviewUrl, setSymbolPreviewUrl] = useState<string | null>(null);
+  const [symbolChanged, setSymbolChanged] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
@@ -45,6 +49,8 @@ export default function EditPhrasePage({ params }: { params: Promise<{ id: strin
   useEffect(() => {
     if (phrase) {
       setText(phrase.text);
+      setSymbolPreviewUrl(phrase.symbolUrl ?? null);
+      setSymbolStorageId(phrase.symbolStorageId ?? null);
     }
   }, [phrase]);
 
@@ -59,6 +65,8 @@ export default function EditPhrasePage({ params }: { params: Promise<{ id: strin
       await updatePhrase({
         id: phraseId,
         text,
+        ...(symbolChanged && symbolStorageId ? { symbolStorageId } : {}),
+        ...(symbolChanged && !symbolStorageId ? { removeSymbol: true } : {}),
       });
       router.back();
     } catch (error) {
@@ -123,6 +131,27 @@ export default function EditPhrasePage({ params }: { params: Promise<{ id: strin
             placeholder="Enter your phrase"
             required
           />
+
+          <div className="mb-4">
+            <label className="block text-foreground text-sm font-semibold mb-2">
+              Symbol
+            </label>
+            <SymbolSelector
+              symbolUrl={symbolPreviewUrl}
+              symbolStorageId={symbolStorageId}
+              onSymbolChange={(symbol) => {
+                setSymbolChanged(true);
+                if (symbol) {
+                  setSymbolStorageId(symbol.storageId);
+                  setSymbolPreviewUrl(symbol.url);
+                } else {
+                  setSymbolStorageId(null);
+                  setSymbolPreviewUrl(null);
+                }
+              }}
+              phraseText={text}
+            />
+          </div>
 
           {error && (
             <div className="mt-4 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as migrations from "../migrations.js";
 import type * as phraseBoards from "../phraseBoards.js";
 import type * as phrases from "../phrases.js";
 import type * as profiles from "../profiles.js";
+import type * as symbols from "../symbols.js";
 import type * as typingSessions from "../typingSessions.js";
 import type * as userSettings from "../userSettings.js";
 import type * as users from "../users.js";
@@ -33,6 +34,7 @@ declare const fullApi: ApiFromModules<{
   phraseBoards: typeof phraseBoards;
   phrases: typeof phrases;
   profiles: typeof profiles;
+  symbols: typeof symbols;
   typingSessions: typeof typingSessions;
   userSettings: typeof userSettings;
   users: typeof users;

--- a/convex/phrases.ts
+++ b/convex/phrases.ts
@@ -40,6 +40,7 @@ export const addPhrase = mutation({
   args: {
     text: v.string(),
     position: v.number(),
+    symbolStorageId: v.optional(v.id('_storage')),
   },
   handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
@@ -47,10 +48,17 @@ export const addPhrase = mutation({
       throw new Error('Unauthenticated');
     }
 
+    let symbolUrl: string | undefined;
+    if (args.symbolStorageId) {
+      symbolUrl = await ctx.storage.getUrl(args.symbolStorageId) ?? undefined;
+    }
+
     const phraseId = await ctx.db.insert('phrases', {
       userId: identity.subject,
       text: args.text,
       position: args.position,
+      symbolStorageId: args.symbolStorageId,
+      symbolUrl,
     });
 
     return phraseId;
@@ -63,6 +71,8 @@ export const updatePhrase = mutation({
     id: v.id('phrases'),
     text: v.optional(v.string()),
     position: v.optional(v.number()),
+    symbolStorageId: v.optional(v.id('_storage')),
+    removeSymbol: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
@@ -70,7 +80,7 @@ export const updatePhrase = mutation({
       throw new Error('Unauthenticated');
     }
 
-    const { id, ...updates } = args;
+    const { id, removeSymbol, symbolStorageId, ...updates } = args;
 
     // Verify ownership
     const phrase = await ctx.db.get(id);
@@ -78,7 +88,25 @@ export const updatePhrase = mutation({
       throw new Error('Unauthorized');
     }
 
-    await ctx.db.patch(id, updates);
+    const patch: Record<string, unknown> = { ...updates };
+
+    if (removeSymbol) {
+      // Delete old symbol from storage
+      if (phrase.symbolStorageId) {
+        await ctx.storage.delete(phrase.symbolStorageId);
+      }
+      patch.symbolStorageId = undefined;
+      patch.symbolUrl = undefined;
+    } else if (symbolStorageId) {
+      // Delete old symbol if replacing
+      if (phrase.symbolStorageId) {
+        await ctx.storage.delete(phrase.symbolStorageId);
+      }
+      patch.symbolStorageId = symbolStorageId;
+      patch.symbolUrl = await ctx.storage.getUrl(symbolStorageId) ?? undefined;
+    }
+
+    await ctx.db.patch(id, patch);
   },
 });
 
@@ -97,6 +125,11 @@ export const deletePhrase = mutation({
     const phrase = await ctx.db.get(args.id);
     if (!phrase || phrase.userId !== identity.subject) {
       throw new Error('Unauthorized');
+    }
+
+    // Clean up symbol from storage
+    if (phrase.symbolStorageId) {
+      await ctx.storage.delete(phrase.symbolStorageId);
     }
 
     await ctx.db.delete(args.id);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -34,6 +34,8 @@ export default defineSchema({
     text: v.string(),
     frequency: v.optional(v.number()),
     position: v.number(),
+    symbolStorageId: v.optional(v.id('_storage')),
+    symbolUrl: v.optional(v.string()),
   }).index('by_user_id', ['userId']),
 
   phraseBoards: defineTable({

--- a/convex/symbols.ts
+++ b/convex/symbols.ts
@@ -1,5 +1,4 @@
 import { mutation } from './_generated/server';
-import { v } from 'convex/values';
 import { getUserIdentity } from './users';
 
 export const generateUploadUrl = mutation({
@@ -9,16 +8,5 @@ export const generateUploadUrl = mutation({
       throw new Error('Unauthenticated');
     }
     return await ctx.storage.generateUploadUrl();
-  },
-});
-
-export const deleteSymbol = mutation({
-  args: { storageId: v.id('_storage') },
-  handler: async (ctx, args) => {
-    const identity = await getUserIdentity(ctx);
-    if (!identity) {
-      throw new Error('Unauthenticated');
-    }
-    await ctx.storage.delete(args.storageId);
   },
 });

--- a/convex/symbols.ts
+++ b/convex/symbols.ts
@@ -1,0 +1,24 @@
+import { mutation } from './_generated/server';
+import { v } from 'convex/values';
+import { getUserIdentity } from './users';
+
+export const generateUploadUrl = mutation({
+  handler: async (ctx) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+export const deleteSymbol = mutation({
+  args: { storageId: v.id('_storage') },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+    await ctx.storage.delete(args.storageId);
+  },
+});

--- a/lib/hooks/usePhraseBoardData.ts
+++ b/lib/hooks/usePhraseBoardData.ts
@@ -59,7 +59,12 @@ export function usePhraseBoardData() {
     ?.map((pbp: any) => pbp.phrase)
     .filter(Boolean)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .map((phrase: any) => ({ id: String(phrase._id), text: phrase.text })) || [];
+    .map((phrase: any) => ({
+      id: String(phrase._id),
+      text: phrase.text,
+      symbolUrl: phrase.symbolUrl,
+      symbolStorageId: phrase.symbolStorageId ? String(phrase.symbolStorageId) : undefined,
+    })) || [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const transformedBoards: BoardSummary[] = boards?.map((board: any) => ({

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'globalsymbols.com',
       },
+      {
+        protocol: 'https',
+        hostname: '*.convex.cloud',
+      },
     ],
   },
   outputFileTracingRoot: __dirname,


### PR DESCRIPTION
## Summary
- Restore AAC symbol support using Convex file storage and the Global Symbols API
- Users can search for, attach, change, and remove symbols on phrases via add/edit forms
- Phrase tiles display symbols above text when present
- Symbol images are uploaded to Convex storage on selection and cleaned up on phrase delete

## Changes
- **Convex**: Add `symbolStorageId`/`symbolUrl` to phrases schema, `generateUploadUrl`/`deleteSymbol` mutations, update phrase CRUD to handle symbols
- **API routes**: `/api/symbol-search` (Global Symbols proxy), `/api/symbol-proxy` (image download proxy with domain allowlist)
- **UI components**: `SymbolImage`, `SymbolSearchModal` (debounced search, grid results, attribution), `SymbolSelector` (inline add/change/remove)
- **Integration**: PhraseTile renders symbols, add/edit forms include SymbolSelector, usePhraseBoardData maps symbol fields through

Closes #535

## Test plan
- [ ] Add a phrase with a symbol — verify symbol appears on tile
- [ ] Edit a phrase to add/change/remove a symbol
- [ ] Delete a phrase with a symbol — verify storage cleanup
- [ ] Search symbols with various queries, verify debounce and results
- [ ] Verify phrase tiles without symbols are unchanged
- [ ] Test on mobile: symbol search modal, phrase tiles with symbols
- [ ] Verify offline mode still works (symbols unavailable, no crash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and select symbols to associate with phrases via a modal.
  * Symbols display above phrase text in phrase tiles.
  * Add symbols when creating phrases; edit or remove symbols when editing phrases.
  * Selected symbols are downloaded and uploaded to storage automatically for use as persistent previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->