### PR TITLE
Fix symbol buttons submitting parent form on mobile

### DIFF
--- a/app/components/symbols/SymbolSearchModal.tsx
+++ b/app/components/symbols/SymbolSearchModal.tsx
@@ -121,6 +121,7 @@ export default function SymbolSearchModal({ isOpen, onClose, onSelect, initialQu
               <div className="flex items-center justify-between px-4 py-3 border-b border-border">
                 <h2 className="text-lg font-semibold text-foreground">Search Symbols</h2>
                 <button
+                  type="button"
                   onClick={onClose}
                   className="p-2 min-h-[44px] min-w-[44px] rounded-full hover:bg-surface-hover transition-colors flex items-center justify-center"
                   aria-label="Close"
@@ -170,6 +171,7 @@ export default function SymbolSearchModal({ isOpen, onClose, onSelect, initialQu
                   <div className="grid grid-cols-4 sm:grid-cols-5 gap-3">
                     {results.map((symbol) => (
                       <button
+                        type="button"
                         key={symbol.id}
                         onClick={() => onSelect(symbol)}
                         className="flex flex-col items-center gap-1 p-2 rounded-xl hover:bg-surface-hover transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"

--- a/app/components/symbols/SymbolSelector.tsx
+++ b/app/components/symbols/SymbolSelector.tsx
@@ -62,6 +62,7 @@ export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText =
           <div className="relative">
             <SymbolImage src={symbolUrl} alt="Selected symbol" size="lg" />
             <button
+              type="button"
               onClick={handleClear}
               className="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-red-500 flex items-center justify-center hover:bg-red-600 transition-colors"
               aria-label="Remove symbol"
@@ -71,6 +72,7 @@ export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText =
           </div>
         ) : (
           <button
+            type="button"
             onClick={() => setIsSearchOpen(true)}
             disabled={isUploading}
             className="w-16 h-16 rounded-lg border-2 border-dashed border-border flex items-center justify-center hover:bg-surface-hover transition-colors disabled:opacity-50"
@@ -88,6 +90,7 @@ export default function SymbolSelector({ symbolUrl, onSymbolChange, phraseText =
             <span className="text-red-400">{uploadError}</span>
           ) : symbolUrl ? (
             <button
+              type="button"
               onClick={() => setIsSearchOpen(true)}
               className="text-primary-500 hover:underline"
             >


### PR DESCRIPTION
## Summary
- Add `type="button"` to all buttons in `SymbolSelector` and `SymbolSearchModal`
- Without this, buttons default to `type="submit"` inside the add/edit phrase `<form>`, causing the form to submit and navigate away on tap

## Test plan
- [ ] Open add phrase page on mobile, tap "Add symbol" — modal opens without navigating away
- [ ] Tap search field in modal — stays open, keyboard appears
- [ ] Select a symbol — uploads without form submission
- [ ] On edit page, tap "Change symbol" — same behavior
- [ ] Tap "Remove symbol" (x button) — clears without form submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button behavior in symbol selection components to prevent unintended form submissions. Buttons now explicitly declare their type to ensure they function as regular buttons rather than form submission triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->