### PR TITLE
Fix composer textarea not scrolling on mobile

### DIFF
--- a/app/components/composer/ComposerTextarea.tsx
+++ b/app/components/composer/ComposerTextarea.tsx
@@ -24,7 +24,7 @@ export default function ComposerTextarea({
   onBlur,
 }: ComposerTextareaProps) {
   return (
-    <div className="flex-1 min-h-0 overflow-hidden md:min-h-[120px]">
+    <div className="relative flex-1 min-h-0 overflow-hidden md:min-h-[120px]">
       <textarea
         ref={textareaRef}
         value={currentText}
@@ -35,7 +35,7 @@ export default function ComposerTextarea({
         onBlur={onBlur}
         onKeyDown={onKeyDown}
         placeholder="What do you want to say?"
-        className="w-full h-full overflow-y-auto bg-transparent text-foreground placeholder:text-text-tertiary px-6 py-5 resize-none focus:outline-none"
+        className="absolute inset-0 overflow-y-auto bg-transparent text-foreground placeholder:text-text-tertiary px-6 py-5 resize-none focus:outline-none"
         style={{ fontSize: `${textSizePx}px`, lineHeight: '1.6' }}
       />
     </div>

--- a/app/components/composer/useTextareaScroll.ts
+++ b/app/components/composer/useTextareaScroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { TextareaScrollIntent, TextareaScrollSnapshot } from './types';
 
 export function useTextareaScroll(
@@ -8,6 +8,7 @@ export function useTextareaScroll(
   const pendingRef = useRef<TextareaScrollIntent | null>(null);
   const previousTextRef = useRef('');
   const snapshotRef = useRef<TextareaScrollSnapshot | null>(null);
+  const needsScrollRef = useRef(false);
 
   const captureSnapshot = useCallback((value?: string) => {
     const textarea = textareaRef.current;
@@ -74,6 +75,8 @@ export function useTextareaScroll(
       && !!snapshot
       && (snapshot.wasAtEnd || snapshot.wasNearBottom);
 
+    let didScroll = false;
+
     if (pending && document.activeElement === textarea) {
       const selectionStart = Math.min(pending.selectionStart, currentText.length);
       const selectionEnd = Math.min(pending.selectionEnd, currentText.length);
@@ -81,16 +84,32 @@ export function useTextareaScroll(
 
       if (pending.shouldScrollToEnd) {
         textarea.scrollTop = textarea.scrollHeight;
+        didScroll = true;
       }
     } else if (wasExternalAppend) {
       textarea.setSelectionRange(currentText.length, currentText.length);
       textarea.scrollTop = textarea.scrollHeight;
+      didScroll = true;
     }
 
+    needsScrollRef.current = didScroll;
     previousTextRef.current = currentText;
     pendingRef.current = null;
     captureSnapshot(currentText);
   }, [captureSnapshot, currentText, textareaRef]);
+
+  // Re-apply scroll after paint for mobile browsers where scrollHeight
+  // isn't fully resolved during useLayoutEffect
+  useEffect(() => {
+    if (!needsScrollRef.current) return;
+    needsScrollRef.current = false;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const id = requestAnimationFrame(() => {
+      textarea.scrollTop = textarea.scrollHeight;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [currentText, textareaRef]);
 
   const scrollToEnd = useCallback(() => {
     pendingRef.current = {

--- a/tests/components/Composer.test.tsx
+++ b/tests/components/Composer.test.tsx
@@ -224,7 +224,7 @@ describe('Composer', () => {
     const textarea = screen.getByRole('textbox');
     expect(textarea.parentElement?.parentElement).toHaveClass('overflow-hidden');
     expect(textarea.parentElement).toHaveClass('flex-1', 'min-h-0', 'overflow-hidden', 'md:min-h-[120px]');
-    expect(textarea).toHaveClass('h-full', 'overflow-y-auto', 'resize-none');
+    expect(textarea).toHaveClass('absolute', 'inset-0', 'overflow-y-auto', 'resize-none');
     expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Use `absolute inset-0` on the textarea instead of `w-full h-full` so it reliably fills its parent on mobile regardless of flex height resolution
- Add a post-paint `requestAnimationFrame` fallback for scroll-to-end to handle mobile browsers where `scrollHeight` isn't resolved during `useLayoutEffect`

Closes #540

## Test plan
- [ ] On mobile Safari: type enough text to fill the textarea — should auto-scroll to keep cursor visible
- [ ] On mobile Chrome: same test
- [ ] Verify editing earlier text does NOT force scroll to bottom
- [ ] Verify desktop behavior unchanged
- [ ] Verify external text append (e.g., phrase tap) scrolls to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea scrolling behavior in the composer component for more reliable scroll-to-end positioning.

* **Tests**
  * Updated test expectations to reflect component layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->