### PR TITLE
Hide bottom nav when keyboard is open on mobile

### DIFF
--- a/app/components/navigation/MobileBottomStack.tsx
+++ b/app/components/navigation/MobileBottomStack.tsx
@@ -2,10 +2,12 @@
 
 import { useRef, useEffect } from 'react';
 import { useMobileBottom } from '@/app/contexts/MobileBottomContext';
+import { useKeyboardOpen } from '@/lib/hooks/useKeyboardOpen';
 import BottomTabBar from './BottomTabBar';
 
 export default function MobileBottomStack() {
   const { registerDockContainer } = useMobileBottom();
+  const keyboardOpen = useKeyboardOpen();
   const stackRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
 
@@ -62,8 +64,8 @@ export default function MobileBottomStack() {
     <div ref={stackRef} className="fixed bottom-keyboard-aware left-0 right-0 z-50 md:hidden flex flex-col">
       {/* Dock content slot - portal target */}
       <div ref={dockRef} className="bg-surface" />
-      {/* Tab bar */}
-      <BottomTabBar />
+      {/* Tab bar — hidden when keyboard is open to maximize content space */}
+      {!keyboardOpen && <BottomTabBar />}
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -121,9 +121,9 @@ body {
     bottom: calc(var(--bottom-stack-height) + 16px);
   }
 
-  /* Dynamic viewport height utilities */
+  /* Dynamic viewport height utilities — subtract keyboard inset so content resizes */
   .h-dvh {
-    height: 100dvh;
+    height: calc(100dvh - var(--keyboard-inset, 0px));
   }
   .min-h-dvh {
     min-height: 100dvh;

--- a/lib/hooks/useKeyboardOpen.ts
+++ b/lib/hooks/useKeyboardOpen.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRef } from 'react';
+import { useVisualViewport } from './useVisualViewport';
+
+const KEYBOARD_OPEN_THRESHOLD_PX = 80;
+
+const TEXT_INPUT_TYPES = new Set([
+  'email',
+  'number',
+  'password',
+  'search',
+  'tel',
+  'text',
+  'url',
+]);
+
+function isEditableElement(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  if (element.isContentEditable) return true;
+  if (element instanceof HTMLTextAreaElement) return !element.disabled && !element.readOnly;
+  if (element instanceof HTMLInputElement) {
+    return !element.disabled && !element.readOnly && TEXT_INPUT_TYPES.has(element.type.toLowerCase());
+  }
+  return false;
+}
+
+export function useKeyboardOpen(): boolean {
+  const layoutHeightRef = useRef<number | null>(null);
+  const viewport = useVisualViewport();
+
+  if (typeof window === 'undefined') return false;
+
+  const viewportHeight = viewport.height ?? window.innerHeight;
+  const currentLayoutHeight = viewport.innerHeight ?? window.innerHeight;
+  const previousLayoutHeight = layoutHeightRef.current ?? currentLayoutHeight;
+  const layoutHeight = Math.max(previousLayoutHeight, currentLayoutHeight, viewportHeight);
+  const keyboardInset = Math.max(0, layoutHeight - ((viewport.top ?? 0) + viewportHeight));
+  const isOpen = isEditableElement(document.activeElement) && keyboardInset > KEYBOARD_OPEN_THRESHOLD_PX;
+
+  layoutHeightRef.current = isOpen ? layoutHeight : currentLayoutHeight;
+
+  return isOpen;
+}


### PR DESCRIPTION
## Summary
- New `useKeyboardOpen` hook reuses `useVisualViewport` to detect keyboard state
- `MobileBottomStack` hides `BottomTabBar` when keyboard is open
- Dock slot stays visible for banners (undo/error)
- `pb-bottom-stack` padding shrinks automatically via existing ResizeObserver

Fixes #546

## Test plan
- [ ] Mobile (390x844): tap Type tab textarea → keyboard opens → bottom nav hides
- [ ] Phrases/Type segmented control stays visible at top
- [ ] Textarea fills space between segmented control and keyboard
- [ ] Dismiss keyboard → bottom nav returns
- [ ] Phrases tab unaffected
- [ ] Undo/error banners still appear in dock when keyboard open