### PR TITLE
Fix Gemini voice filtering with real language codes

### DIFF
--- a/app/api/gemini/voices/route.ts
+++ b/app/api/gemini/voices/route.ts
@@ -1,15 +1,36 @@
+import { GeminiTTSClient } from 'js-tts-wrapper';
 import { NextResponse } from 'next/server';
-import { GEMINI_VOICES } from '@/lib/gemini-voices';
+import { GEMINI_FLASH_TTS_MODEL } from '@/lib/gemini-voices';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const apiKey = process.env.GEMINI_API_KEY?.replace(/^\uFEFF/, '').trim();
+  try {
+    const apiKey = process.env.GEMINI_API_KEY?.replace(/^﻿/, '').trim();
 
-  if (!apiKey) {
+    if (!apiKey) {
+      return NextResponse.json({ voices: [], available: false });
+    }
+
+    const client = new GeminiTTSClient({
+      apiKey,
+      model: GEMINI_FLASH_TTS_MODEL,
+    });
+
+    const unifiedVoices = await client.getVoices();
+
+    const voices = unifiedVoices.map((voice) => ({
+      voice_id: voice.id,
+      name: voice.name,
+      style: typeof voice.metadata?.style === 'string' ? voice.metadata.style : '',
+      gender: voice.gender,
+      languageCodes: voice.languageCodes ?? [],
+    }));
+
+    return NextResponse.json({ voices, available: voices.length > 0 });
+  } catch (error) {
+    console.error('Error loading Gemini voices:', error);
     return NextResponse.json({ voices: [], available: false });
   }
-
-  return NextResponse.json({ voices: GEMINI_VOICES, available: true });
 }


### PR DESCRIPTION
## Summary

- Replaces static `GEMINI_VOICES` (all had `languageCodes: []`) with live `GeminiTTSClient.getVoices()` from `js-tts-wrapper`
- Maps unified voices into the `GeminiVoice` shape expected by `lib/gemini-tts.ts`
- Adds proper error handling with try/catch around the API call

Closes #561

## Test plan

- [ ] Verify Gemini voices load in TTS Settings
- [ ] Verify language filter now correctly shows/hides Gemini voices
- [ ] Verify voice selection and playback still works
- [ ] Verify fallback behavior when `GEMINI_API_KEY` is not set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice selection now dynamically retrieves available voice options from the service with expanded metadata including style, gender, and supported languages for each voice.

* **Bug Fixes**
  * Improved error handling for voice retrieval failures, with graceful fallback when the service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->