### PR TITLE
Hide Gemini voice filters

### DIFF
--- a/app/components/TTSSettings.tsx
+++ b/app/components/TTSSettings.tsx
@@ -126,12 +126,20 @@ export default function TTSSettings() {
     updateSetting,
   ]);
 
+  const showVoiceFilters = displayProvider !== 'browser'
+    && displayProvider !== 'gemini'
+    && providerVoices.length > 0;
+
   const filteredVoices = useMemo(() => {
+    if (!showVoiceFilters) {
+      return providerVoices;
+    }
+
     let result = providerVoices;
     if (genderFilter !== 'All') result = result.filter(v => v.gender === genderFilter);
     if (langFilter !== 'All') result = result.filter(v => v.languageCodes?.some(lc => lc.bcp47 === langFilter));
     return result;
-  }, [providerVoices, genderFilter, langFilter]);
+  }, [providerVoices, genderFilter, langFilter, showVoiceFilters]);
 
   const languageOptions = useMemo(() => {
     const seen = new Set<string>();
@@ -312,7 +320,7 @@ export default function TTSSettings() {
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-foreground">Voice</h3>
         <div className="bg-surface-hover rounded-2xl p-4">
-          {displayProvider !== 'browser' && providerVoices.length > 0 && (
+          {showVoiceFilters && (
             <div className="grid grid-cols-2 gap-2 mb-3">
               <select
                 value={genderFilter}

--- a/tests/components/TTSSettings.test.tsx
+++ b/tests/components/TTSSettings.test.tsx
@@ -29,7 +29,13 @@ const mockLoadGeminiVoices = jest.fn();
 
 const voices: TTSVoice[] = [
   { id: 'browser-voice-1', name: 'Browser Voice', provider: 'browser' },
-  { id: 'eleven-voice-1', name: 'Eleven Voice', provider: 'elevenlabs' },
+  {
+    id: 'eleven-voice-1',
+    name: 'Eleven Voice',
+    provider: 'elevenlabs',
+    gender: 'Female',
+    languageCodes: [{ bcp47: 'en-US', iso639_3: 'eng', display: 'English (US)' }],
+  },
   { id: 'azure-voice-1', name: 'Azure Voice', provider: 'azure' },
   { id: 'gemini-voice-1', name: 'Gemini Voice', provider: 'gemini' },
 ];
@@ -223,6 +229,26 @@ describe('TTSSettings provider dropdown', () => {
     });
 
     expect(screen.getByText(/Gemini 3\.1 Flash uses the selected voice and style instructions in your text\./i)).toBeInTheDocument();
+  });
+
+  it('hides gender and language filters for Gemini voices', () => {
+    renderTTSSettings({
+      settings: { ttsProvider: 'gemini', ttsVoiceId: 'gemini-voice-1' },
+    });
+
+    expect(screen.queryByRole('combobox', { name: /all genders/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /all languages/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('All genders')).not.toBeInTheDocument();
+    expect(screen.queryByText('All languages')).not.toBeInTheDocument();
+  });
+
+  it('keeps gender and language filters visible for ElevenLabs voices', () => {
+    renderTTSSettings({
+      settings: { ttsProvider: 'elevenlabs', ttsVoiceId: 'eleven-voice-1' },
+    });
+
+    expect(screen.getByText('All genders')).toBeInTheDocument();
+    expect(screen.getByText('All languages')).toBeInTheDocument();
   });
 
   it('does not render ElevenLabs Voice Quality for Gemini', () => {


### PR DESCRIPTION
## Summary
- hide gender/language voice filters when Gemini TTS is selected
- keep filters visible for ElevenLabs voices when provider voices are available
- add focused regression coverage for both states

Closes #568

## Tests
- npm test -- --runTestsByPath tests/components/TTSSettings.test.tsx
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed voice filter controls (gender/language) appearing for providers that don't support them. Filters now only display when relevant to the selected TTS provider.

* **Tests**
  * Added test coverage verifying filter controls are correctly hidden/shown based on the TTS provider selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->