### PR TITLE
Apply text size setting to phrase tiles

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -143,6 +143,7 @@ export default function PhrasesInterface() {
               onSelectBoard={boardData.handleSelectBoard}
               onOpenBoardPicker={() => boardData.setIsBoardPickerOpen(true)}
               onEditBoard={boardData.handleEditBoard}
+              textSizePx={settings.textSize}
             />
           }
           typeContent={

--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -30,6 +30,7 @@ interface PhrasesTabContentProps {
   onSelectBoard: (board: BoardSummary | string) => void;
   onOpenBoardPicker: () => void;
   onEditBoard: (boardId: string) => void;
+  textSizePx: number;
 }
 
 // onEditBoard already guards isOnline internally (from usePhraseBoardData)
@@ -58,6 +59,7 @@ export default function PhrasesTabContent({
   onSelectBoard,
   onOpenBoardPicker,
   onEditBoard,
+  textSizePx,
 }: PhrasesTabContentProps) {
   const phraseGrid = isEditMode && canEditCurrentBoard ? (
     <SortablePhraseGrid
@@ -68,6 +70,7 @@ export default function PhrasesTabContent({
       onPhraseStop={onPhraseStop}
       onPhraseEdit={onEditPhrase}
       onReorder={onReorderPhrases}
+      textSizePx={textSizePx}
     />
   ) : (
     <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
@@ -79,6 +82,7 @@ export default function PhrasesTabContent({
           onStop={onPhraseStop}
           isSpeaking={activePhraseId === phrase.id && isSpeaking}
           onLongPress={canEditCurrentBoard ? () => onEditPhrase(phrase) : undefined}
+          textSizePx={textSizePx}
         />
       ))}
     </div>

--- a/app/components/offline/OfflineAppShell.tsx
+++ b/app/components/offline/OfflineAppShell.tsx
@@ -5,6 +5,7 @@ import AACTabs from '@/app/components/home/AACTabs';
 import Composer from '@/app/components/composer';
 import BoardSelector from '@/app/components/phrases/BoardSelector';
 import PhraseTile from '@/app/components/phrases/PhraseTile';
+import { useSettings } from '@/app/contexts/SettingsContext';
 import type { BoardSummary, PhraseSummary } from '@/app/components/phrases/types';
 import { useLocalMessageHistory } from '@/lib/hooks/useLocalMessageHistory';
 import { useOfflineTTS } from '@/lib/hooks/useOfflineTTS';
@@ -61,6 +62,7 @@ export default function OfflineAppShell({
   const [syncStatus, setSyncStatus] = useState<OfflineSyncStatus>(() => readOfflineBootstrap().syncStatus);
   const tts = useOfflineTTS();
   const { messages, recordMessage } = useLocalMessageHistory();
+  const { settings } = useSettings();
 
   useEffect(() => {
     let isMounted = true;
@@ -173,6 +175,7 @@ export default function OfflineAppShell({
               onPress={() => handlePhrasePress(phrase)}
               onStop={tts.stop}
               isSpeaking={activePhraseId === phrase.id && tts.isSpeaking}
+              textSizePx={settings.textSize}
             />
           ))}
         </div>

--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -17,9 +17,19 @@ interface PhraseTileProps {
   onLongPress?: () => void;
   isSpeaking?: boolean;
   className?: string;
+  textSizePx: number;
 }
 
-export default function PhraseTile({ phrase, onPress, onStop, onEdit, onLongPress, isSpeaking = false, className = '' }: PhraseTileProps) {
+export default function PhraseTile({
+  phrase,
+  onPress,
+  onStop,
+  onEdit,
+  onLongPress,
+  isSpeaking = false,
+  className = '',
+  textSizePx,
+}: PhraseTileProps) {
   const [isPressed, setIsPressed] = useState(false);
   const longPressTimer = useRef<NodeJS.Timeout | null>(null);
   const isLongPress = useRef(false);
@@ -118,7 +128,10 @@ export default function PhraseTile({ phrase, onPress, onStop, onEdit, onLongPres
         {phrase.symbolUrl && (
           <SymbolImage src={phrase.symbolUrl} alt={phrase.text} size="md" />
         )}
-        <p className="text-foreground text-sm sm:text-base font-semibold line-clamp-2 leading-tight text-center w-full">
+        <p
+          className="text-foreground font-semibold line-clamp-2 leading-tight text-center w-full"
+          style={{ fontSize: `${textSizePx}px` }}
+        >
           {phrase.text}
         </p>
       </div>

--- a/app/components/phrases/SortablePhraseGrid.tsx
+++ b/app/components/phrases/SortablePhraseGrid.tsx
@@ -24,9 +24,10 @@ interface SortablePhraseTileProps {
   onStop?: () => void;
   onEdit?: () => void;
   isSpeaking?: boolean;
+  textSizePx: number;
 }
 
-function SortablePhraseTile({ phrase, onPress, onStop, onEdit, isSpeaking }: SortablePhraseTileProps) {
+function SortablePhraseTile({ phrase, onPress, onStop, onEdit, isSpeaking, textSizePx }: SortablePhraseTileProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: phrase.id ?? phrase.text,
   });
@@ -46,6 +47,7 @@ function SortablePhraseTile({ phrase, onPress, onStop, onEdit, isSpeaking }: Sor
         onStop={onStop}
         onEdit={onEdit}
         isSpeaking={isSpeaking}
+        textSizePx={textSizePx}
       />
     </div>
   );
@@ -60,6 +62,7 @@ interface SortablePhraseGridProps {
   onPhraseEdit: (phrase: PhraseSummary) => void;
   onReorder: (orderedIds: string[]) => void;
   extraTile?: React.ReactNode;
+  textSizePx: number;
 }
 
 export default function SortablePhraseGrid({
@@ -71,6 +74,7 @@ export default function SortablePhraseGrid({
   onPhraseEdit,
   onReorder,
   extraTile,
+  textSizePx,
 }: SortablePhraseGridProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -105,6 +109,7 @@ export default function SortablePhraseGrid({
               onStop={onPhraseStop}
               onEdit={() => onPhraseEdit(phrase)}
               isSpeaking={activePhraseId === phrase.id && isSpeaking}
+              textSizePx={textSizePx}
             />
           ))}
           {extraTile}

--- a/tests/components/phrases/PhraseTile.test.tsx
+++ b/tests/components/phrases/PhraseTile.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import PhraseTile from '@/app/components/phrases/PhraseTile';
+
+describe('PhraseTile', () => {
+  it('uses the configured text size for phrase text', () => {
+    render(
+      <PhraseTile
+        phrase={{ id: 'phrase-1', text: 'Hello' }}
+        onPress={jest.fn()}
+        textSizePx={24}
+      />
+    );
+
+    expect(screen.getByText('Hello')).toHaveStyle({ fontSize: '24px' });
+    expect(screen.getByRole('button', { name: 'Speak phrase: Hello' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- apply the existing text size setting to phrase tile text
- thread the configured size through normal board, sortable edit, and offline phrase tile render paths
- add focused PhraseTile coverage for exact font sizing and accessible label

Closes #571

## Tests
- npm test -- --runTestsByPath tests/components/phrases/PhraseTile.test.tsx
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phrase tiles now dynamically respond to user text size settings throughout the app, including both the main interface and offline mode, for a more responsive and customizable experience.

* **Tests**
  * Added test coverage to verify phrase tiles render correctly with configured text sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->