### PR TITLE
Compute square phrase tile grid

### DIFF
--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -1,5 +1,6 @@
 import BoardSelector from '../phrases/BoardSelector';
 import SwipeableBoardNavigator from '../phrases/SwipeableBoardNavigator';
+import PhraseGrid from '../phrases/PhraseGrid';
 import PhraseTile from '../phrases/PhraseTile';
 import SortablePhraseGrid from '../phrases/SortablePhraseGrid';
 import AnimatedLoading from '../phrases/AnimatedLoading';
@@ -73,7 +74,7 @@ export default function PhrasesTabContent({
       textSizePx={textSizePx}
     />
   ) : (
-    <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
+    <PhraseGrid textSizePx={textSizePx}>
       {phrases.map((phrase) => (
         <PhraseTile
           key={phrase.id}
@@ -85,7 +86,7 @@ export default function PhrasesTabContent({
           textSizePx={textSizePx}
         />
       ))}
-    </div>
+    </PhraseGrid>
   );
 
   if (showAuthPrompt) {

--- a/app/components/offline/OfflineAppShell.tsx
+++ b/app/components/offline/OfflineAppShell.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import AACTabs from '@/app/components/home/AACTabs';
 import Composer from '@/app/components/composer';
 import BoardSelector from '@/app/components/phrases/BoardSelector';
+import PhraseGrid from '@/app/components/phrases/PhraseGrid';
 import PhraseTile from '@/app/components/phrases/PhraseTile';
 import { useSettings } from '@/app/contexts/SettingsContext';
 import type { BoardSummary, PhraseSummary } from '@/app/components/phrases/types';
@@ -167,7 +168,7 @@ export default function OfflineAppShell({
         />
       </div>
       <div className="flex-1 overflow-auto p-3 pt-4">
-        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
+        <PhraseGrid textSizePx={settings.textSize}>
           {phrases.map((phrase) => (
             <PhraseTile
               key={phrase.id}
@@ -178,7 +179,7 @@ export default function OfflineAppShell({
               textSizePx={settings.textSize}
             />
           ))}
-        </div>
+        </PhraseGrid>
       </div>
     </div>
   );

--- a/app/components/phrases/PhraseGrid.tsx
+++ b/app/components/phrases/PhraseGrid.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const DEFAULT_GAP_PX = 8;
+const DEFAULT_MIN_COLUMNS = 2;
+const DEFAULT_MAX_COLUMNS = 8;
+const BASE_MIN_TILE_PX = 96;
+const TEXT_SIZE_TILE_MULTIPLIER = 4.5;
+
+export function computePhraseGridColumns({
+  containerWidth,
+  gapPx,
+  textSizePx,
+  minColumns,
+  maxColumns,
+}: {
+  containerWidth: number;
+  gapPx: number;
+  textSizePx: number;
+  minColumns: number;
+  maxColumns: number;
+}): number {
+  if (containerWidth <= 0) {
+    return minColumns;
+  }
+
+  const textAwareMinTilePx = Math.max(
+    BASE_MIN_TILE_PX,
+    Math.ceil(textSizePx * TEXT_SIZE_TILE_MULTIPLIER)
+  );
+  const rawColumns = Math.floor((containerWidth + gapPx) / (textAwareMinTilePx + gapPx));
+
+  return Math.max(minColumns, Math.min(maxColumns, rawColumns));
+}
+
+interface PhraseGridProps {
+  children: React.ReactNode;
+  className?: string;
+  textSizePx: number;
+  minColumns?: number;
+  maxColumns?: number;
+}
+
+export default function PhraseGrid({
+  children,
+  className = '',
+  textSizePx,
+  minColumns = DEFAULT_MIN_COLUMNS,
+  maxColumns = DEFAULT_MAX_COLUMNS,
+}: PhraseGridProps) {
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const gridElement = gridRef.current;
+    if (!gridElement || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const updateWidth = (width: number) => {
+      setContainerWidth((currentWidth) => currentWidth === width ? currentWidth : width);
+    };
+
+    updateWidth(gridElement.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver((entries) => {
+      const nextWidth = entries[0]?.contentRect.width;
+      if (typeof nextWidth === 'number') {
+        updateWidth(nextWidth);
+      }
+    });
+
+    observer.observe(gridElement);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const columns = computePhraseGridColumns({
+    containerWidth,
+    gapPx: DEFAULT_GAP_PX,
+    textSizePx,
+    minColumns,
+    maxColumns,
+  });
+
+  return (
+    <div
+      ref={gridRef}
+      className={`grid gap-2 ${className}`}
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/components/phrases/PhraseTile.tsx
+++ b/app/components/phrases/PhraseTile.tsx
@@ -91,7 +91,7 @@ export default function PhraseTile({
   return (
     <motion.div
       className={`relative bg-surface rounded-xl shadow-md cursor-pointer
-        flex flex-col items-center justify-center min-h-[52px]
+        flex flex-col items-center justify-center min-h-[52px] aspect-square overflow-hidden
         focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
         ${onEdit ? 'border-l-4 border-blue-400' : isSpeaking ? 'border-2 border-warning' : ''}
         ${className}`}
@@ -124,7 +124,7 @@ export default function PhraseTile({
           <StopIcon className="w-2.5 h-2.5 text-white" />
         </div>
       )}
-      <div className="flex flex-col items-center justify-center w-full h-full p-2 gap-1">
+      <div className="flex flex-col items-center justify-center w-full h-full min-h-0 p-2 gap-1">
         {phrase.symbolUrl && (
           <SymbolImage src={phrase.symbolUrl} alt={phrase.text} size="md" />
         )}

--- a/app/components/phrases/SortablePhraseGrid.tsx
+++ b/app/components/phrases/SortablePhraseGrid.tsx
@@ -15,6 +15,7 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import PhraseGrid from './PhraseGrid';
 import PhraseTile from './PhraseTile';
 import type { PhraseSummary } from './types';
 
@@ -100,7 +101,7 @@ export default function SortablePhraseGrid({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={ids} strategy={rectSortingStrategy}>
-        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
+        <PhraseGrid textSizePx={textSizePx}>
           {phrases.map((phrase) => (
             <SortablePhraseTile
               key={phrase.id}
@@ -113,7 +114,7 @@ export default function SortablePhraseGrid({
             />
           ))}
           {extraTile}
-        </div>
+        </PhraseGrid>
       </SortableContext>
     </DndContext>
   );

--- a/tests/components/phrases/PhraseGrid.test.tsx
+++ b/tests/components/phrases/PhraseGrid.test.tsx
@@ -1,0 +1,68 @@
+import { computePhraseGridColumns } from '@/app/components/phrases/PhraseGrid';
+
+describe('computePhraseGridColumns', () => {
+  const defaults = {
+    gapPx: 8,
+    minColumns: 2,
+    maxColumns: 8,
+  };
+
+  it('returns the minimum columns for zero or unknown width', () => {
+    expect(computePhraseGridColumns({
+      ...defaults,
+      containerWidth: 0,
+      textSizePx: 16,
+    })).toBe(2);
+  });
+
+  it('computes mobile-sized columns from available width', () => {
+    expect(computePhraseGridColumns({
+      ...defaults,
+      containerWidth: 344,
+      textSizePx: 16,
+    })).toBe(3);
+  });
+
+  it('caps wide layouts at the maximum columns', () => {
+    expect(computePhraseGridColumns({
+      ...defaults,
+      containerWidth: 1000,
+      textSizePx: 16,
+    })).toBe(8);
+  });
+
+  it('reduces grid density for larger text sizes', () => {
+    const normalTextColumns = computePhraseGridColumns({
+      ...defaults,
+      containerWidth: 1000,
+      textSizePx: 16,
+    });
+    const largeTextColumns = computePhraseGridColumns({
+      ...defaults,
+      containerWidth: 1000,
+      textSizePx: 32,
+    });
+
+    expect(largeTextColumns).toBeLessThan(normalTextColumns);
+  });
+
+  it('never exceeds the provided maximum columns', () => {
+    expect(computePhraseGridColumns({
+      gapPx: 8,
+      minColumns: 2,
+      maxColumns: 5,
+      containerWidth: 2000,
+      textSizePx: 16,
+    })).toBe(5);
+  });
+
+  it('never drops below the provided minimum columns', () => {
+    expect(computePhraseGridColumns({
+      gapPx: 8,
+      minColumns: 3,
+      maxColumns: 8,
+      containerWidth: 120,
+      textSizePx: 16,
+    })).toBe(3);
+  });
+});

--- a/tests/components/phrases/PhraseTile.test.tsx
+++ b/tests/components/phrases/PhraseTile.test.tsx
@@ -12,6 +12,8 @@ describe('PhraseTile', () => {
     );
 
     expect(screen.getByText('Hello')).toHaveStyle({ fontSize: '24px' });
-    expect(screen.getByRole('button', { name: 'Speak phrase: Hello' })).toBeInTheDocument();
+    const tile = screen.getByRole('button', { name: 'Speak phrase: Hello' });
+    expect(tile).toBeInTheDocument();
+    expect(tile).toHaveClass('aspect-square', 'overflow-hidden');
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable measured PhraseGrid for square phrase tile layouts
- replace fixed responsive phrase grid classes in normal, sortable, and offline board views
- make PhraseTile square and overflow-safe while preserving text size behavior
- add focused column computation and tile class coverage

Closes #574

## Tests
- npm test -- --runTestsByPath tests/components/phrases/PhraseGrid.test.tsx tests/components/phrases/PhraseTile.test.tsx
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Phrase tiles now render as squares with improved content containment.
  * Grid layout dynamically adjusts column count based on available space and text size.

* **Tests**
  * Added tests for grid column calculation and tile layout behavior.
  * Updated existing tests to validate tile styling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->