### PR TITLE
Place tone button beside speak button in composer sidebar

### DIFF
--- a/app/components/composer/ComposerSidebar.tsx
+++ b/app/components/composer/ComposerSidebar.tsx
@@ -195,7 +195,7 @@ export default function ComposerSidebar({
       {/* Spacer — pushes Speak to the bottom */}
       <div className="flex-1" />
 
-      {/* Speak — full-width square grid cell(s) at the bottom, fixed size */}
+      {/* Speak — at the bottom. When tone control is enabled, tone sits beside speak. */}
       <div className="flex flex-col shrink-0">
         {isSpeaking ? (
           <button
@@ -206,19 +206,17 @@ export default function ComposerSidebar({
           >
             <StopIcon className="w-8 h-8" />
           </button>
-        ) : (
-          <>
-            {enableToneControl && (
-              <button
-                type="button"
-                onClick={() => setShowToneSheet(true)}
-                disabled={speakDisabled}
-                className="w-full aspect-square flex items-center justify-center bg-primary-400 hover:bg-primary-500 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                aria-label="Choose tone"
-              >
-                <AudioWaveform className="w-6 h-6" />
-              </button>
-            )}
+        ) : enableToneControl ? (
+          <div className="grid grid-cols-2">
+            <button
+              type="button"
+              onClick={() => setShowToneSheet(true)}
+              disabled={speakDisabled}
+              className="w-full aspect-square flex items-center justify-center bg-primary-400 hover:bg-primary-500 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Choose tone"
+            >
+              <AudioWaveform className="w-6 h-6" />
+            </button>
             <button
               type="button"
               onClick={onSpeak}
@@ -226,9 +224,19 @@ export default function ComposerSidebar({
               className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
               aria-label="Speak"
             >
-              <SpeakerWaveIcon className="w-8 h-8" />
+              <SpeakerWaveIcon className="w-6 h-6" />
             </button>
-          </>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onSpeak}
+            disabled={speakDisabled}
+            className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            aria-label="Speak"
+          >
+            <SpeakerWaveIcon className="w-8 h-8" />
+          </button>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Moves the tone control from a stacked full-width tile above speak into a shared 2-column row at the bottom of the sidebar, so tone and speak sit side-by-side.
- When `enableToneControl` is false, speak still renders as the original full-width square.
- While speaking, stop continues to replace the row as a full-width square.

Closes #580

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (282/282)
- [x] `npx eslint app/components/composer/ComposerSidebar.tsx` clean
- [ ] Visual check: tone and speak sit side-by-side at the bottom of the composer sidebar
- [ ] Visual check: with tone control disabled, speak still renders full-width
- [ ] Visual check: while speaking, stop fills the full-width row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved composer sidebar organization: the tone selection and speak action tiles now display side-by-side when both features are available, creating a more intuitive layout
  * Fine-tuned speaker icon dimensions for better visual balance when tone control is enabled
  * Simplified the interface when tone control is unavailable by displaying only the speak action

<!-- end of auto-generated comment: release notes by coderabbit.ai -->