### PR TITLE
Move clear button above speak with matching size

### DIFF
--- a/app/components/composer/ComposerSidebar.tsx
+++ b/app/components/composer/ComposerSidebar.tsx
@@ -67,20 +67,8 @@ export default function ComposerSidebar({
 }: ComposerSidebarProps) {
   const [showToneSheet, setShowToneSheet] = useState(false);
   const speakDisabled = !isAvailable || !currentText.trim();
+  const clearDisabled = !currentText.trim();
   const iconButtons: ReactNode[] = [];
-
-  // Clear — always rendered, red tile
-  iconButtons.push(
-    <button
-      key="clear"
-      onClick={onClear}
-      disabled={!currentText.trim()}
-      className={`${TILE_BASE} bg-status-error text-red-400 hover:bg-error hover:text-white`}
-      aria-label="Clear"
-    >
-      <XMarkIcon className="w-5 h-5" />
-    </button>
-  );
 
   // Fix Text — purple tile (offline stub or subscription fallback variants)
   if (enableFixText) {
@@ -195,7 +183,7 @@ export default function ComposerSidebar({
       {/* Spacer — pushes Speak to the bottom */}
       <div className="flex-1" />
 
-      {/* Speak — at the bottom. When tone control is enabled, tone sits beside speak. */}
+      {/* Bottom stack — Clear on top, then Tone + Speak (or just Speak). Stop replaces all while speaking. */}
       <div className="flex flex-col shrink-0">
         {isSpeaking ? (
           <button
@@ -206,37 +194,50 @@ export default function ComposerSidebar({
           >
             <StopIcon className="w-8 h-8" />
           </button>
-        ) : enableToneControl ? (
-          <div className="grid grid-cols-2">
-            <button
-              type="button"
-              onClick={() => setShowToneSheet(true)}
-              disabled={speakDisabled}
-              className="w-full aspect-square flex items-center justify-center bg-primary-400 hover:bg-primary-500 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              aria-label="Choose tone"
-            >
-              <AudioWaveform className="w-6 h-6" />
-            </button>
-            <button
-              type="button"
-              onClick={onSpeak}
-              disabled={speakDisabled}
-              className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              aria-label="Speak"
-            >
-              <SpeakerWaveIcon className="w-6 h-6" />
-            </button>
-          </div>
         ) : (
-          <button
-            type="button"
-            onClick={onSpeak}
-            disabled={speakDisabled}
-            className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-            aria-label="Speak"
-          >
-            <SpeakerWaveIcon className="w-8 h-8" />
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={onClear}
+              disabled={clearDisabled}
+              className="w-full aspect-square flex items-center justify-center bg-status-error text-red-400 hover:bg-error hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Clear"
+            >
+              <XMarkIcon className="w-8 h-8" />
+            </button>
+            {enableToneControl ? (
+              <div className="grid grid-cols-2">
+                <button
+                  type="button"
+                  onClick={() => setShowToneSheet(true)}
+                  disabled={speakDisabled}
+                  className="w-full aspect-square flex items-center justify-center bg-primary-400 hover:bg-primary-500 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="Choose tone"
+                >
+                  <AudioWaveform className="w-6 h-6" />
+                </button>
+                <button
+                  type="button"
+                  onClick={onSpeak}
+                  disabled={speakDisabled}
+                  className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="Speak"
+                >
+                  <SpeakerWaveIcon className="w-6 h-6" />
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={onSpeak}
+                disabled={speakDisabled}
+                className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                aria-label="Speak"
+              >
+                <SpeakerWaveIcon className="w-8 h-8" />
+              </button>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Removes the clear tile from the top icon grid and stacks it directly above the speak (or tone+speak) row at the bottom of the composer sidebar.
- Clear is now a full-width `aspect-square` tile with a larger `w-8 h-8` icon, matching the prominent footprint of the speak button.
- While speaking, the stop button continues to replace the whole bottom stack.

Closes #581

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (282/282)
- [x] `npx eslint app/components/composer/ComposerSidebar.tsx` clean
- [ ] Visual check: clear sits above speak at the bottom of the composer sidebar, full-width, matching speak's size
- [ ] Visual check: clear no longer appears in the top icon grid
- [ ] Visual check: with tone control enabled, layout is clear → tone|speak row
- [ ] Visual check: clear is disabled (opacity-30) when the composer is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized composer controls layout with Clear button repositioned to the bottom
  * Clear button now intelligently enables/disables based on text input
  * Improved arrangement of tone control and speak button placement for enhanced workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->