### PR TITLE
release: v3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.53",
         "@clerk/nextjs": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Release v3.13.0. Closes milestone [v3.13.0](https://github.com/enaboapps/sayit-web/milestone/107).

### Changes
- #580 — Composer sidebar: tone button placed beside the speak button (PR #582)
- #581 — Composer sidebar: clear button moved above speak, sized to match (PR #583)

## Test plan
- [x] `npm test` passes (282/282)
- [x] `npx eslint . --fix` clean (no changes needed)
- [x] Version bumped to 3.13.0 in package.json + lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version**
  * Version bumped to 3.13.0.

---

**Note:** This release contains no functional changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->