### PR TITLE
release: v3.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.53",
         "@clerk/nextjs": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Release v3.14.0. Closes milestone [v3.14.0](https://github.com/enaboapps/sayit-web/milestone/108).

### Changes
- #585 — Composer UI consolidated to mobile-only for tone, suggestions, and live-typing share (PR #586)
- #587 — Tab bar unified with 5-tab cap on desktop; `MobileTabList` renamed to `TabManagementSheet`; `TabManagementDialog` deleted (PR #588)
- #589 — `TabManagementSheet` action buttons moved to the top (PR #590)

## Test plan
- [x] `npm test` passes (28 suites / 261 tests)
- [x] `npx eslint . --fix` clean (no changes needed)
- [x] Version bumped to 3.14.0 in package.json + lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 3.14.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->