### PR TITLE
Sort TabManagementSheet by most-recently-modified first

### DIFF
--- a/app/components/typing-tabs/TabManagementSheet.tsx
+++ b/app/components/typing-tabs/TabManagementSheet.tsx
@@ -64,6 +64,10 @@ export default function TabManagementSheet({
     onClose();
   };
 
+  // Display the most recently edited tab first. We sort a copy so the caller's
+  // `tabs` array (which drives the TabBar) stays in its original creation order.
+  const sortedTabs = [...tabs].sort((a, b) => b.lastModified - a.lastModified);
+
   return (
     <BottomSheet
       isOpen={isOpen}
@@ -98,7 +102,7 @@ export default function TabManagementSheet({
 
         {/* Tab list */}
         <div className="space-y-1">
-          {tabs.map((tab) => (
+          {sortedTabs.map((tab) => (
             <div
               key={tab.id}
               className={`flex items-center gap-2 p-3 rounded-xl transition-colors ${

--- a/tests/components/typing-tabs/TabManagementSheet.test.tsx
+++ b/tests/components/typing-tabs/TabManagementSheet.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TabManagementSheet from '@/app/components/typing-tabs/TabManagementSheet';
+import { TypingTab } from '@/app/types/typing-tabs';
+
+// Mock nanoid to avoid ESM issues
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(() => 'test-id'),
+}));
+
+const createTab = (overrides: Partial<TypingTab> = {}): TypingTab => ({
+  id: 'test-tab',
+  label: 'Tab',
+  text: '',
+  createdAt: 1_000,
+  lastModified: 1_000,
+  isCustomLabel: false,
+  ...overrides,
+});
+
+describe('TabManagementSheet', () => {
+  const noop = () => {};
+
+  const defaultHandlers = {
+    onClose: noop,
+    onSwitchTab: noop,
+    onCloseTab: noop,
+    onCloseAllTabs: noop,
+    onCreateTab: noop,
+    onRenameTab: noop,
+  };
+
+  describe('ordering', () => {
+    it('lists tabs sorted by lastModified descending (newest edit first)', () => {
+      const tabs: TypingTab[] = [
+        createTab({ id: 'oldest', label: 'Oldest edit', lastModified: 1_000 }),
+        createTab({ id: 'middle', label: 'Middle edit', lastModified: 2_000 }),
+        createTab({ id: 'newest', label: 'Newest edit', lastModified: 3_000 }),
+      ];
+
+      render(
+        <TabManagementSheet
+          isOpen
+          tabs={tabs}
+          activeTabId="oldest"
+          {...defaultHandlers}
+        />
+      );
+
+      const labels = screen
+        .getAllByText(/edit$/)
+        .map((el) => el.textContent);
+
+      expect(labels).toEqual(['Newest edit', 'Middle edit', 'Oldest edit']);
+    });
+
+    it('does not mutate the incoming tabs array', () => {
+      const tabs: TypingTab[] = [
+        createTab({ id: 'a', label: 'A', lastModified: 1_000 }),
+        createTab({ id: 'b', label: 'B', lastModified: 3_000 }),
+        createTab({ id: 'c', label: 'C', lastModified: 2_000 }),
+      ];
+      const originalOrder = tabs.map((t) => t.id);
+
+      render(
+        <TabManagementSheet
+          isOpen
+          tabs={tabs}
+          activeTabId="a"
+          {...defaultHandlers}
+        />
+      );
+
+      expect(tabs.map((t) => t.id)).toEqual(originalOrder);
+    });
+
+    it('still highlights the active tab regardless of position', () => {
+      const tabs: TypingTab[] = [
+        createTab({ id: 'oldest', label: 'Oldest edit', lastModified: 1_000 }),
+        createTab({ id: 'newest', label: 'Newest edit', lastModified: 3_000 }),
+      ];
+
+      render(
+        <TabManagementSheet
+          isOpen
+          tabs={tabs}
+          activeTabId="oldest"
+          {...defaultHandlers}
+        />
+      );
+
+      // The active tab's row carries the primary-500 border class — find the
+      // label and walk up to the row container.
+      const oldestLabel = screen.getByText('Oldest edit');
+      const row = oldestLabel.closest('div.flex.items-center');
+      expect(row?.className).toContain('border-primary-500');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Render the tab list inside `TabManagementSheet` sorted by `lastModified` descending so the most recently edited tab appears first.
- Leave `TabBar` ordering untouched — the composer tabs don't shuffle while typing.
- Sort a local copy; the caller's tabs array is not mutated.

## Test plan
- [x] Added `tests/components/typing-tabs/TabManagementSheet.test.tsx` covering ordering, non-mutation, and that the active-tab highlight still follows `activeTabId`.
- [x] `npm test` — 264/264 passing
- [x] `npm run build` — clean

Fixes #592