### PR TITLE
Add Phrase Bar for sentence composition from phrase tiles

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -8,6 +8,7 @@ import { ConvexProviderWithClerk } from 'convex/react-clerk';
 import { AuthProvider, StaticAuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { MobileBottomProvider } from './contexts/MobileBottomContext';
+import { PhraseBarProvider } from './contexts/PhraseBarContext';
 import ConnectivityBanner from './components/navigation/ConnectivityBanner';
 import InstallBanner from './components/navigation/InstallBanner';
 import Sidebar from './components/Sidebar';
@@ -113,7 +114,9 @@ export default function ClientLayout({
         <StaticAuthProvider>
           <SettingsProvider>
             <MobileBottomProvider>
-              <OfflineAppShell mode={offlineMode} />
+              <PhraseBarProvider>
+                <OfflineAppShell mode={offlineMode} />
+              </PhraseBarProvider>
             </MobileBottomProvider>
           </SettingsProvider>
         </StaticAuthProvider>
@@ -127,22 +130,24 @@ export default function ClientLayout({
         <AuthProvider>
           <SettingsProvider>
             <MobileBottomProvider>
-              <OnlineStartupWatch onReady={handleStartupReady}>
-                <OfflineDataSync />
-                <div className="flex h-dvh min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">
-                  <Sidebar />
-                  <div className="flex min-h-0 flex-1 flex-col md:pl-16 lg:pl-16">
-                    <div className="shrink-0">
-                      <ConnectivityBanner />
-                      <InstallBanner />
+              <PhraseBarProvider>
+                <OnlineStartupWatch onReady={handleStartupReady}>
+                  <OfflineDataSync />
+                  <div className="flex h-dvh min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">
+                    <Sidebar />
+                    <div className="flex min-h-0 flex-1 flex-col md:pl-16 lg:pl-16">
+                      <div className="shrink-0">
+                        <ConnectivityBanner />
+                        <InstallBanner />
+                      </div>
+                      <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:overflow-visible">
+                        {children}
+                      </main>
                     </div>
-                    <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:overflow-visible">
-                      {children}
-                    </main>
+                    <MobileBottomStack />
                   </div>
-                  <MobileBottomStack />
-                </div>
-              </OnlineStartupWatch>
+                </OnlineStartupWatch>
+              </PhraseBarProvider>
             </MobileBottomProvider>
           </SettingsProvider>
         </AuthProvider>

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -11,6 +11,7 @@ import { usePhraseBoardData } from '@/lib/hooks/usePhraseBoardData';
 import { useMessageCapture } from '@/lib/hooks/useMessageCapture';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSettings } from '../../contexts/SettingsContext';
+import { usePhraseBar } from '../../contexts/PhraseBarContext';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import type { PhraseSummary } from '../phrases/types';
@@ -23,6 +24,7 @@ export default function PhrasesInterface() {
   const isMobile = useIsMobile();
 
   const boardData = usePhraseBoardData();
+  const phraseBar = usePhraseBar();
   const { captureError, handleCaptureCompletedMessage, localRecentMessages } = useMessageCapture();
 
   const [typingText, setTypingText] = useState('');
@@ -59,6 +61,16 @@ export default function PhrasesInterface() {
   );
 
   const handlePhrasePress = (phrase: PhraseSummary) => {
+    if (settings.usePhraseBar) {
+      // Phrase-bar mode: accumulate chips. Don't clobber Composer text.
+      phraseBar.addItem({ text: phrase.text, symbolUrl: phrase.symbolUrl });
+      if (settings.speakPhrasesOnTap) {
+        setActivePhraseId(phrase.id ?? null);
+        tts.speak(phrase.text);
+      }
+      return;
+    }
+    // Legacy speak-on-tap behavior.
     setActivePhraseId(phrase.id ?? null);
     setTypingText(phrase.text);
     tts.speak(phrase.text);

--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -152,10 +152,10 @@ export default function PhrasesTabContent({
           canEditBoard={canEditCurrentBoard}
         >
           <div className="flex flex-col flex-1 min-h-0">
+            <PhraseBar />
             <div className="p-2 overflow-auto flex-1">
               {phraseGrid}
             </div>
-            <PhraseBar />
           </div>
         </SwipeableBoardNavigator>
       </div>
@@ -177,10 +177,10 @@ export default function PhrasesTabContent({
           embedded={true}
         />
       </div>
+      <PhraseBar />
       <div className="flex-1 overflow-auto p-3">
         {phraseGrid}
       </div>
-      <PhraseBar />
     </div>
   );
 }

--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -4,6 +4,7 @@ import PhraseGrid from '../phrases/PhraseGrid';
 import PhraseTile from '../phrases/PhraseTile';
 import SortablePhraseGrid from '../phrases/SortablePhraseGrid';
 import AnimatedLoading from '../phrases/AnimatedLoading';
+import PhraseBar from '../phrase-bar/PhraseBar';
 import type { BoardSummary, PhraseSummary } from '../phrases/types';
 
 interface PhrasesTabContentProps {
@@ -150,8 +151,11 @@ export default function PhrasesTabContent({
           isEditMode={isEditMode}
           canEditBoard={canEditCurrentBoard}
         >
-          <div className="p-2 overflow-auto flex-1">
-            {phraseGrid}
+          <div className="flex flex-col flex-1 min-h-0">
+            <div className="p-2 overflow-auto flex-1">
+              {phraseGrid}
+            </div>
+            <PhraseBar />
           </div>
         </SwipeableBoardNavigator>
       </div>
@@ -176,6 +180,7 @@ export default function PhrasesTabContent({
       <div className="flex-1 overflow-auto p-3">
         {phraseGrid}
       </div>
+      <PhraseBar />
     </div>
   );
 }

--- a/app/components/phrase-bar/PhraseBar.tsx
+++ b/app/components/phrase-bar/PhraseBar.tsx
@@ -74,7 +74,7 @@ export default function PhraseBar({ className = '' }: PhraseBarProps) {
           )}
         </div>
         {hasItems && (
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex flex-col gap-1 shrink-0">
             <button
               type="button"
               onClick={handleSpeakOrStop}

--- a/app/components/phrase-bar/PhraseBar.tsx
+++ b/app/components/phrase-bar/PhraseBar.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  BackspaceIcon,
+  SpeakerWaveIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import { usePhraseBar } from '@/app/contexts/PhraseBarContext';
+import { useSettings } from '@/app/contexts/SettingsContext';
+import { useTTS } from '@/lib/hooks/useTTS';
+import PhraseBarChip from './PhraseBarChip';
+
+interface PhraseBarProps {
+  className?: string;
+}
+
+/**
+ * PhraseBar — an accumulator below the Phrases grid that collects phrase chips
+ * as the user taps tiles. Controlled by `settings.usePhraseBar`; no-op when off.
+ */
+export default function PhraseBar({ className = '' }: PhraseBarProps) {
+  const { settings } = useSettings();
+  const { items, removeLast, clear, joinedText } = usePhraseBar();
+  const tts = useTTS();
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll to newest chip whenever items change (mirrors augy's ScrollViewReader).
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollLeft = el.scrollWidth;
+  }, [items.length]);
+
+  if (!settings.usePhraseBar) return null;
+
+  const handleSpeakAll = () => {
+    if (!joinedText.trim()) return;
+    tts.speak(joinedText);
+  };
+
+  const hasItems = items.length > 0;
+
+  return (
+    <div
+      className={`shrink-0 border-t border-border bg-surface-hover px-3 py-2 ${className}`}
+      data-testid="phrase-bar"
+      role="region"
+      aria-label="Phrase Bar"
+    >
+      <div className="flex items-center gap-2">
+        <div
+          ref={scrollerRef}
+          className="flex-1 min-w-0 overflow-x-auto flex items-stretch gap-2 py-1"
+        >
+          {hasItems ? (
+            items.map((item) => (
+              <PhraseBarChip
+                key={item.id}
+                item={item}
+                textSizePx={Math.max(14, Math.min(settings.textSize, 24))}
+              />
+            ))
+          ) : (
+            <p className="flex-1 text-center text-text-secondary text-sm py-2">
+              Tap a Phrase to add it to the Phrase Bar
+            </p>
+          )}
+        </div>
+        {hasItems && (
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={handleSpeakAll}
+              aria-label="Speak all phrases in the bar"
+              className="p-3 rounded-full bg-primary-500 text-white hover:bg-primary-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              <SpeakerWaveIcon className="w-5 h-5" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={removeLast}
+              aria-label="Remove the last phrase from the bar"
+              className="p-3 rounded-full bg-surface text-foreground border border-border hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              <BackspaceIcon className="w-5 h-5" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={clear}
+              aria-label="Clear the phrase bar"
+              className="p-3 rounded-full bg-surface text-red-500 border border-border hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              <TrashIcon className="w-5 h-5" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/phrase-bar/PhraseBar.tsx
+++ b/app/components/phrase-bar/PhraseBar.tsx
@@ -43,7 +43,7 @@ export default function PhraseBar({ className = '' }: PhraseBarProps) {
 
   return (
     <div
-      className={`shrink-0 border-t border-border bg-surface-hover px-3 py-2 ${className}`}
+      className={`shrink-0 border-b border-border bg-surface-hover px-3 py-2 ${className}`}
       data-testid="phrase-bar"
       role="region"
       aria-label="Phrase Bar"

--- a/app/components/phrase-bar/PhraseBar.tsx
+++ b/app/components/phrase-bar/PhraseBar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import {
   BackspaceIcon,
   SpeakerWaveIcon,
+  StopIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
 import { usePhraseBar } from '@/app/contexts/PhraseBarContext';
@@ -34,12 +35,17 @@ export default function PhraseBar({ className = '' }: PhraseBarProps) {
 
   if (!settings.usePhraseBar) return null;
 
-  const handleSpeakAll = () => {
+  const handleSpeakOrStop = () => {
+    if (tts.isSpeaking) {
+      tts.stop();
+      return;
+    }
     if (!joinedText.trim()) return;
     tts.speak(joinedText);
   };
 
   const hasItems = items.length > 0;
+  const isSpeaking = tts.isSpeaking;
 
   return (
     <div
@@ -71,11 +77,24 @@ export default function PhraseBar({ className = '' }: PhraseBarProps) {
           <div className="flex items-center gap-1 shrink-0">
             <button
               type="button"
-              onClick={handleSpeakAll}
-              aria-label="Speak all phrases in the bar"
-              className="p-3 rounded-full bg-primary-500 text-white hover:bg-primary-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-colors"
+              onClick={handleSpeakOrStop}
+              aria-label={
+                isSpeaking
+                  ? 'Stop speaking'
+                  : 'Speak all phrases in the bar'
+              }
+              aria-pressed={isSpeaking}
+              className={`p-3 rounded-full text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-colors ${
+                isSpeaking
+                  ? 'bg-warning hover:bg-warning/90 animate-pulse'
+                  : 'bg-primary-500 hover:bg-primary-600'
+              }`}
             >
-              <SpeakerWaveIcon className="w-5 h-5" aria-hidden="true" />
+              {isSpeaking ? (
+                <StopIcon className="w-5 h-5" aria-hidden="true" />
+              ) : (
+                <SpeakerWaveIcon className="w-5 h-5" aria-hidden="true" />
+              )}
             </button>
             <button
               type="button"

--- a/app/components/phrase-bar/PhraseBarChip.tsx
+++ b/app/components/phrase-bar/PhraseBarChip.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import SymbolImage from '../symbols/SymbolImage';
+import type { PhraseBarItem } from './types';
+
+interface PhraseBarChipProps {
+  item: PhraseBarItem;
+  textSizePx: number;
+  className?: string;
+}
+
+export default function PhraseBarChip({ item, textSizePx, className = '' }: PhraseBarChipProps) {
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  return (
+    <motion.div
+      className={`flex flex-col items-center justify-center shrink-0 gap-1 rounded-2xl bg-surface px-3 py-2 border border-border shadow-sm ${className}`}
+      initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.85 }}
+      animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
+      transition={{ duration: 0.15 }}
+      data-testid="phrase-bar-chip"
+    >
+      {item.symbolUrl && (
+        <SymbolImage src={item.symbolUrl} alt={item.text} size="sm" />
+      )}
+      <p
+        className="text-foreground font-semibold leading-tight text-center max-w-[12ch] line-clamp-2"
+        style={{ fontSize: `${textSizePx}px` }}
+      >
+        {item.text}
+      </p>
+    </motion.div>
+  );
+}

--- a/app/components/phrase-bar/types.ts
+++ b/app/components/phrase-bar/types.ts
@@ -1,0 +1,5 @@
+export interface PhraseBarItem {
+  id: string;
+  text: string;
+  symbolUrl?: string;
+}

--- a/app/contexts/PhraseBarContext.tsx
+++ b/app/contexts/PhraseBarContext.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { PhraseBarItem } from '@/app/components/phrase-bar/types';
+
+const STORAGE_KEY = 'phraseBarItems';
+
+interface PhraseBarContextValue {
+  items: PhraseBarItem[];
+  addItem: (item: Omit<PhraseBarItem, 'id'>) => void;
+  removeLast: () => void;
+  clear: () => void;
+  joinedText: string;
+}
+
+const PhraseBarContext = createContext<PhraseBarContextValue | undefined>(undefined);
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (e.g. older jsdom).
+  return `phrasebar-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function readFromSessionStorage(): PhraseBarItem[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is PhraseBarItem =>
+        entry &&
+        typeof entry === 'object' &&
+        typeof entry.id === 'string' &&
+        typeof entry.text === 'string' &&
+        (entry.symbolUrl === undefined || typeof entry.symbolUrl === 'string')
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeToSessionStorage(items: PhraseBarItem[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // sessionStorage can throw in private-mode / full quota — ignore.
+  }
+}
+
+export function PhraseBarProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<PhraseBarItem[]>([]);
+  const hydrated = useRef(false);
+
+  // Rehydrate from sessionStorage once on mount (client only).
+  useEffect(() => {
+    setItems(readFromSessionStorage());
+    hydrated.current = true;
+  }, []);
+
+  // Persist after hydration. Skip the first render so we don't clobber
+  // stored items with an empty default before rehydration completes.
+  useEffect(() => {
+    if (!hydrated.current) return;
+    writeToSessionStorage(items);
+  }, [items]);
+
+  const addItem = useCallback((item: Omit<PhraseBarItem, 'id'>) => {
+    setItems((prev) => [...prev, { ...item, id: generateId() }]);
+  }, []);
+
+  const removeLast = useCallback(() => {
+    setItems((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
+  }, []);
+
+  const clear = useCallback(() => {
+    setItems((prev) => (prev.length === 0 ? prev : []));
+  }, []);
+
+  const joinedText = useMemo(() => items.map((item) => item.text).join(' '), [items]);
+
+  const value = useMemo<PhraseBarContextValue>(
+    () => ({ items, addItem, removeLast, clear, joinedText }),
+    [items, addItem, removeLast, clear, joinedText]
+  );
+
+  return <PhraseBarContext.Provider value={value}>{children}</PhraseBarContext.Provider>;
+}
+
+export function usePhraseBar(): PhraseBarContextValue {
+  const ctx = useContext(PhraseBarContext);
+  if (ctx === undefined) {
+    throw new Error('usePhraseBar must be used within a PhraseBarProvider');
+  }
+  return ctx;
+}

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -32,6 +32,8 @@ interface Settings {
   ttsModelPreference: TTSModelPreference;
   aiReplySuggestionsEnabled: boolean;
   messageCaptureMode: MessageCaptureMode;
+  usePhraseBar: boolean;
+  speakPhrasesOnTap: boolean;
 }
 
 interface UIPreferences {
@@ -71,6 +73,8 @@ const defaultSettings: Settings = {
   ttsModelPreference: 'fast',
   aiReplySuggestionsEnabled: true,
   messageCaptureMode: 'speakOnly',
+  usePhraseBar: false,
+  speakPhrasesOnTap: false,
 };
 
 const defaultUIPreferences: UIPreferences = {
@@ -195,6 +199,8 @@ function saveToLocalStorage(allSettings: AllSettings) {
     ttsModelPreference: allSettings.ttsModelPreference,
     aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
     messageCaptureMode: allSettings.messageCaptureMode,
+    usePhraseBar: allSettings.usePhraseBar,
+    speakPhrasesOnTap: allSettings.speakPhrasesOnTap,
   };
   localStorage.setItem('settings', JSON.stringify(settings));
 
@@ -271,6 +277,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         ttsModelPreference: localSettings.ttsModelPreference,
         aiReplySuggestionsEnabled: localSettings.aiReplySuggestionsEnabled,
         messageCaptureMode: localSettings.messageCaptureMode,
+        usePhraseBar: localSettings.usePhraseBar,
+        speakPhrasesOnTap: localSettings.speakPhrasesOnTap,
         typingAreaVisible: localSettings.typingAreaVisible,
         typingAreaExpanded: localSettings.typingAreaExpanded,
         selectedBoardId: localSettings.selectedBoardId ?? undefined,
@@ -307,6 +315,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         ttsModelPreference: (convexSettings.ttsModelPreference as TTSModelPreference) ?? defaultSettings.ttsModelPreference,
         aiReplySuggestionsEnabled: convexSettings.aiReplySuggestionsEnabled ?? defaultSettings.aiReplySuggestionsEnabled,
         messageCaptureMode: convexSettings.messageCaptureMode ?? defaultSettings.messageCaptureMode,
+        usePhraseBar: convexSettings.usePhraseBar ?? defaultSettings.usePhraseBar,
+        speakPhrasesOnTap: convexSettings.speakPhrasesOnTap ?? defaultSettings.speakPhrasesOnTap,
         typingAreaVisible: convexSettings.typingAreaVisible,
         typingAreaExpanded: convexSettings.typingAreaExpanded,
         selectedBoardId: convexSettings.selectedBoardId ?? null,
@@ -405,6 +415,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     ttsModelPreference: allSettings.ttsModelPreference,
     aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
     messageCaptureMode: allSettings.messageCaptureMode,
+    usePhraseBar: allSettings.usePhraseBar,
+    speakPhrasesOnTap: allSettings.speakPhrasesOnTap,
   };
 
   const uiPreferences: UIPreferences = {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   DocumentTextIcon,
   InformationCircleIcon,
   ChevronRightIcon,
+  RectangleStackIcon,
 } from '@heroicons/react/24/outline';
 import RoleChangeSection from '@/app/components/settings/RoleChangeSection';
 import { useAuth } from '../contexts/AuthContext';
@@ -145,6 +146,15 @@ export default function SettingsPage() {
               onClick={() => setActiveSheet('ai')}
             />
 
+            {/* Phrase Bar */}
+            <SettingsCategory
+              icon={<RectangleStackIcon className="w-6 h-6" />}
+              title="Phrase Bar"
+              description="Build sentences from phrase tiles"
+              onClick={() => setActiveSheet('phraseBar')}
+              value={settings.usePhraseBar ? 'On' : 'Off'}
+            />
+
             {/* Account - only when logged in */}
             {user && (
               <SettingsCategory
@@ -197,6 +207,30 @@ export default function SettingsPage() {
               options={messageCaptureOptions}
               value={settings.messageCaptureMode}
               onChange={(value) => updateSetting('messageCaptureMode', value)}
+            />
+          </div>
+        </BottomSheet>
+
+        {/* Phrase Bar Sheet */}
+        <BottomSheet
+          isOpen={activeSheet === 'phraseBar'}
+          onClose={() => setActiveSheet(null)}
+          title="Phrase Bar"
+          snapPoints={[60, 80]}
+        >
+          <div className="p-4 space-y-6">
+            <Switch
+              label="Phrase Bar"
+              description="When enabled, tapping a phrase adds it to the Phrase Bar instead of speaking immediately."
+              checked={settings.usePhraseBar}
+              onChange={(value) => updateSetting('usePhraseBar', value)}
+            />
+            <Switch
+              label="Speak on tap"
+              description="Also speak each phrase as it's added to the bar."
+              checked={settings.speakPhrasesOnTap}
+              onChange={(value) => updateSetting('speakPhrasesOnTap', value)}
+              disabled={!settings.usePhraseBar}
             />
           </div>
         </BottomSheet>
@@ -472,6 +506,45 @@ export default function SettingsPage() {
                     options={messageCaptureOptions}
                     value={settings.messageCaptureMode}
                     onChange={(value) => updateSetting('messageCaptureMode', value)}
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Phrase Bar Settings */}
+          <section className="space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold text-foreground">Phrase Bar</h2>
+              <p className="text-sm text-text-secondary mt-1">Build sentences from phrase tiles before speaking</p>
+            </div>
+            <div className="bg-surface rounded-3xl shadow-2xl hover:shadow-3xl overflow-hidden transition-all duration-300">
+              <div className="px-8 py-6">
+                <div className="flex items-center space-x-4 mb-6">
+                  <div className="flex-shrink-0 text-primary-500 bg-surface-hover p-3 rounded-3xl">
+                    <RectangleStackIcon className="w-6 h-6" />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-semibold text-foreground">Phrase Bar</h3>
+                    <p className="text-sm text-text-secondary mt-1">
+                      When enabled, tapping a phrase adds a chip to the bar instead of speaking.
+                      Use Speak all to say the whole sentence.
+                    </p>
+                  </div>
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Switch
+                    label="Phrase Bar"
+                    description="Tap a phrase to add it to the bar instead of speaking immediately"
+                    checked={settings.usePhraseBar}
+                    onChange={(value) => updateSetting('usePhraseBar', value)}
+                  />
+                  <Switch
+                    label="Speak on tap"
+                    description="Also speak each phrase as it's added"
+                    checked={settings.speakPhrasesOnTap}
+                    onChange={(value) => updateSetting('speakPhrasesOnTap', value)}
+                    disabled={!settings.usePhraseBar}
                   />
                 </div>
               </div>

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -100,6 +100,8 @@ export default defineSchema({
         v.literal('speakAny')
       )
     ),
+    usePhraseBar: v.optional(v.boolean()),
+    speakPhrasesOnTap: v.optional(v.boolean()),
 
     // UI Preferences (consolidated from various components)
     typingAreaVisible: v.boolean(),

--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -39,6 +39,8 @@ export const initializeSettings = mutation({
     ttsModelPreference: v.optional(v.union(v.literal('fast'), v.literal('high_quality'))),
     aiReplySuggestionsEnabled: v.boolean(),
     messageCaptureMode: v.union(v.literal('disabled'), v.literal('clearOnly'), v.literal('speakOnly'), v.literal('speakAndClearOnly'), v.literal('speakAny')),
+    usePhraseBar: v.optional(v.boolean()),
+    speakPhrasesOnTap: v.optional(v.boolean()),
     typingAreaVisible: v.boolean(),
     typingAreaExpanded: v.boolean(),
     selectedBoardId: v.optional(v.string()),
@@ -108,6 +110,8 @@ export const initializeSettings = mutation({
       ttsModelPreference: args.ttsModelPreference,
       aiReplySuggestionsEnabled: args.aiReplySuggestionsEnabled,
       messageCaptureMode: args.messageCaptureMode,
+      usePhraseBar: args.usePhraseBar,
+      speakPhrasesOnTap: args.speakPhrasesOnTap,
       typingAreaVisible: args.typingAreaVisible,
       typingAreaExpanded: args.typingAreaExpanded,
       selectedBoardId: args.selectedBoardId,
@@ -140,6 +144,8 @@ export const updateSettings = mutation({
     ttsModelPreference: v.optional(v.union(v.literal('fast'), v.literal('high_quality'))),
     aiReplySuggestionsEnabled: v.optional(v.boolean()),
     messageCaptureMode: v.optional(v.union(v.literal('disabled'), v.literal('clearOnly'), v.literal('speakOnly'), v.literal('speakAndClearOnly'), v.literal('speakAny'))),
+    usePhraseBar: v.optional(v.boolean()),
+    speakPhrasesOnTap: v.optional(v.boolean()),
     typingAreaVisible: v.optional(v.boolean()),
     typingAreaExpanded: v.optional(v.boolean()),
     selectedBoardId: v.optional(v.string()),
@@ -236,6 +242,8 @@ export const updateSettings = mutation({
     if (updates.ttsModelPreference !== undefined) updateData.ttsModelPreference = updates.ttsModelPreference;
     if (updates.aiReplySuggestionsEnabled !== undefined) updateData.aiReplySuggestionsEnabled = updates.aiReplySuggestionsEnabled;
     if (updates.messageCaptureMode !== undefined) updateData.messageCaptureMode = updates.messageCaptureMode;
+    if (updates.usePhraseBar !== undefined) updateData.usePhraseBar = updates.usePhraseBar;
+    if (updates.speakPhrasesOnTap !== undefined) updateData.speakPhrasesOnTap = updates.speakPhrasesOnTap;
     if (updates.typingAreaVisible !== undefined) updateData.typingAreaVisible = updates.typingAreaVisible;
     if (updates.typingAreaExpanded !== undefined) updateData.typingAreaExpanded = updates.typingAreaExpanded;
     if (updates.selectedBoardId !== undefined) updateData.selectedBoardId = updates.selectedBoardId;

--- a/tests/components/phrase-bar/PhraseBar.test.tsx
+++ b/tests/components/phrase-bar/PhraseBar.test.tsx
@@ -5,11 +5,13 @@ import PhraseBar from '@/app/components/phrase-bar/PhraseBar';
 import { PhraseBarProvider } from '@/app/contexts/PhraseBarContext';
 
 const mockSpeak = jest.fn();
+const mockStop = jest.fn();
 const mockSettings = {
   textSize: 18,
   usePhraseBar: true,
   speakPhrasesOnTap: false,
 };
+const mockTTSState = { isSpeaking: false };
 
 jest.mock('@/app/contexts/SettingsContext', () => ({
   useSettings: jest.fn(() => ({
@@ -20,8 +22,8 @@ jest.mock('@/app/contexts/SettingsContext', () => ({
 jest.mock('@/lib/hooks/useTTS', () => ({
   useTTS: jest.fn(() => ({
     speak: mockSpeak,
-    stop: jest.fn(),
-    isSpeaking: false,
+    stop: mockStop,
+    isSpeaking: mockTTSState.isSpeaking,
     isAvailable: true,
   })),
 }));
@@ -34,7 +36,9 @@ describe('PhraseBar', () => {
   beforeEach(() => {
     window.sessionStorage.clear();
     mockSpeak.mockClear();
+    mockStop.mockClear();
     mockSettings.usePhraseBar = true;
+    mockTTSState.isSpeaking = false;
   });
 
   it('renders nothing when the master toggle is off', () => {
@@ -171,6 +175,33 @@ describe('PhraseBar', () => {
     );
 
     await user.click(screen.getByLabelText(/Speak all phrases/i));
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('shows a Stop button while TTS is speaking and stops on click', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      'phraseBarItems',
+      JSON.stringify([
+        { id: 'a', text: 'I' },
+        { id: 'b', text: 'need' },
+      ])
+    );
+    mockTTSState.isSpeaking = true;
+
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+
+    // While speaking, the primary button is a Stop control.
+    expect(screen.queryByLabelText(/Speak all phrases/i)).toBeNull();
+    const stopButton = screen.getByLabelText(/Stop speaking/i);
+    expect(stopButton).toBeInTheDocument();
+
+    await user.click(stopButton);
+    expect(mockStop).toHaveBeenCalledTimes(1);
     expect(mockSpeak).not.toHaveBeenCalled();
   });
 });

--- a/tests/components/phrase-bar/PhraseBar.test.tsx
+++ b/tests/components/phrase-bar/PhraseBar.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import PhraseBar from '@/app/components/phrase-bar/PhraseBar';
+import { PhraseBarProvider } from '@/app/contexts/PhraseBarContext';
+
+const mockSpeak = jest.fn();
+const mockSettings = {
+  textSize: 18,
+  usePhraseBar: true,
+  speakPhrasesOnTap: false,
+};
+
+jest.mock('@/app/contexts/SettingsContext', () => ({
+  useSettings: jest.fn(() => ({
+    settings: mockSettings,
+  })),
+}));
+
+jest.mock('@/lib/hooks/useTTS', () => ({
+  useTTS: jest.fn(() => ({
+    speak: mockSpeak,
+    stop: jest.fn(),
+    isSpeaking: false,
+    isAvailable: true,
+  })),
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <PhraseBarProvider>{children}</PhraseBarProvider>;
+}
+
+describe('PhraseBar', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockSpeak.mockClear();
+    mockSettings.usePhraseBar = true;
+  });
+
+  it('renders nothing when the master toggle is off', () => {
+    mockSettings.usePhraseBar = false;
+    const { container } = render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the empty-state hint when enabled but no items exist', () => {
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+    expect(
+      screen.getByText(/Tap a Phrase to add it to the Phrase Bar/i)
+    ).toBeInTheDocument();
+    // No control buttons when empty
+    expect(screen.queryByLabelText(/Speak all phrases/i)).toBeNull();
+    expect(screen.queryByLabelText(/Remove the last phrase/i)).toBeNull();
+    expect(screen.queryByLabelText(/Clear the phrase bar/i)).toBeNull();
+  });
+
+  it('renders chips and control buttons when items exist (hydrated from sessionStorage)', () => {
+    window.sessionStorage.setItem(
+      'phraseBarItems',
+      JSON.stringify([
+        { id: 'a', text: 'I' },
+        { id: 'b', text: 'need' },
+        { id: 'c', text: 'water' },
+      ])
+    );
+
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('I')).toBeInTheDocument();
+    expect(screen.getByText('need')).toBeInTheDocument();
+    expect(screen.getByText('water')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Speak all phrases/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Remove the last phrase/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Clear the phrase bar/i)).toBeInTheDocument();
+    // Empty-state hint should not be visible when chips are present.
+    expect(
+      screen.queryByText(/Tap a Phrase to add it to the Phrase Bar/i)
+    ).toBeNull();
+  });
+
+  it('Speak all invokes TTS with the joined text', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      'phraseBarItems',
+      JSON.stringify([
+        { id: 'a', text: 'I' },
+        { id: 'b', text: 'need' },
+        { id: 'c', text: 'water' },
+      ])
+    );
+
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByLabelText(/Speak all phrases/i));
+    expect(mockSpeak).toHaveBeenCalledWith('I need water');
+  });
+
+  it('Remove last pops the newest chip', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      'phraseBarItems',
+      JSON.stringify([
+        { id: 'a', text: 'one' },
+        { id: 'b', text: 'two' },
+      ])
+    );
+
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('two')).toBeInTheDocument();
+    await user.click(screen.getByLabelText(/Remove the last phrase/i));
+    expect(screen.queryByText('two')).toBeNull();
+    expect(screen.getByText('one')).toBeInTheDocument();
+  });
+
+  it('Clear empties the bar and reveals the empty-state hint', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      'phraseBarItems',
+      JSON.stringify([
+        { id: 'a', text: 'one' },
+        { id: 'b', text: 'two' },
+      ])
+    );
+
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByLabelText(/Clear the phrase bar/i));
+    expect(screen.queryByText('one')).toBeNull();
+    expect(screen.queryByText('two')).toBeNull();
+    expect(
+      screen.getByText(/Tap a Phrase to add it to the Phrase Bar/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does nothing when Speak all is pressed on whitespace-only content', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      'phraseBarItems',
+      JSON.stringify([{ id: 'a', text: '   ' }])
+    );
+
+    render(
+      <Wrapper>
+        <PhraseBar />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByLabelText(/Speak all phrases/i));
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/phrase-bar/PhraseBarChip.test.tsx
+++ b/tests/components/phrase-bar/PhraseBarChip.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import PhraseBarChip from '@/app/components/phrase-bar/PhraseBarChip';
+
+describe('PhraseBarChip', () => {
+  it('renders the phrase text', () => {
+    render(
+      <PhraseBarChip
+        item={{ id: 'chip-1', text: 'Hello' }}
+        textSizePx={18}
+      />
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('renders a symbol when symbolUrl is provided', () => {
+    render(
+      <PhraseBarChip
+        item={{
+          id: 'chip-2',
+          text: 'Water',
+          symbolUrl: 'https://example.com/water.png',
+        }}
+        textSizePx={18}
+      />
+    );
+
+    const image = screen.getByAltText('Water');
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', expect.stringContaining('water.png'));
+  });
+
+  it('does not render an image when symbolUrl is absent', () => {
+    render(
+      <PhraseBarChip
+        item={{ id: 'chip-3', text: 'Silent' }}
+        textSizePx={18}
+      />
+    );
+
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  it('applies the configured text size', () => {
+    render(
+      <PhraseBarChip
+        item={{ id: 'chip-4', text: 'Sized' }}
+        textSizePx={32}
+      />
+    );
+
+    expect(screen.getByText('Sized')).toHaveStyle({ fontSize: '32px' });
+  });
+});

--- a/tests/contexts/PhraseBarContext.test.tsx
+++ b/tests/contexts/PhraseBarContext.test.tsx
@@ -1,0 +1,155 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { PhraseBarProvider, usePhraseBar } from '@/app/contexts/PhraseBarContext';
+
+const STORAGE_KEY = 'phraseBarItems';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <PhraseBarProvider>{children}</PhraseBarProvider>;
+}
+
+describe('PhraseBarContext', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('starts empty when sessionStorage is empty', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.joinedText).toBe('');
+  });
+
+  it('addItem appends a chip with a generated id', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ text: 'Hello' });
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0]).toEqual(
+      expect.objectContaining({ text: 'Hello' })
+    );
+    expect(typeof result.current.items[0].id).toBe('string');
+    expect(result.current.items[0].id.length).toBeGreaterThan(0);
+  });
+
+  it('preserves symbolUrl on added chips', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ text: 'Water', symbolUrl: 'https://example.com/water.png' });
+    });
+
+    expect(result.current.items[0].symbolUrl).toBe('https://example.com/water.png');
+  });
+
+  it('joinedText concatenates all chip texts with spaces', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ text: 'I' });
+      result.current.addItem({ text: 'need' });
+      result.current.addItem({ text: 'water' });
+    });
+
+    expect(result.current.joinedText).toBe('I need water');
+  });
+
+  it('removeLast pops the newest chip', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ text: 'one' });
+      result.current.addItem({ text: 'two' });
+      result.current.addItem({ text: 'three' });
+    });
+
+    act(() => {
+      result.current.removeLast();
+    });
+
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items.map((i) => i.text)).toEqual(['one', 'two']);
+  });
+
+  it('removeLast on an empty bar is a no-op', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.removeLast();
+    });
+
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('clear empties the bar', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ text: 'one' });
+      result.current.addItem({ text: 'two' });
+    });
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.joinedText).toBe('');
+  });
+
+  it('persists items to sessionStorage after mutations', () => {
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ text: 'Hello' });
+    });
+
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual(
+      expect.objectContaining({ text: 'Hello' })
+    );
+  });
+
+  it('rehydrates from sessionStorage on mount', () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { id: 'a', text: 'pre', symbolUrl: 'https://example.com/pre.png' },
+        { id: 'b', text: 'existing' },
+      ])
+    );
+
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    expect(result.current.items).toEqual([
+      { id: 'a', text: 'pre', symbolUrl: 'https://example.com/pre.png' },
+      { id: 'b', text: 'existing' },
+    ]);
+    expect(result.current.joinedText).toBe('pre existing');
+  });
+
+  it('tolerates malformed sessionStorage payloads', () => {
+    window.sessionStorage.setItem(STORAGE_KEY, 'not valid json{');
+
+    const { result } = renderHook(() => usePhraseBar(), { wrapper });
+
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('throws if usePhraseBar is called outside the provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      expect(() => renderHook(() => usePhraseBar())).toThrow(
+        /usePhraseBar must be used within a PhraseBarProvider/
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Ports augy-ios's Phrase Bar to SayIt web: tapping a phrase tile on the Phrases tab accumulates a chip in a horizontally-scrolling bar with Speak all / Remove last / Clear controls.
- Adds two user settings: `usePhraseBar` (master toggle, default off) and `speakPhrasesOnTap` (also speak each chip as it's added). Both are `v.optional(v.boolean())` in the Convex schema — no migration required.
- Symbols render on chips (parity with augy). Bar state persists to `sessionStorage` so it survives a refresh but clears on tab close. Scoped to the Phrases tab; Composer tab is unchanged.

## Architecture
- New `PhraseBarProvider` / `usePhraseBar` context (`app/contexts/PhraseBarContext.tsx`) owns the items array and rehydrates from sessionStorage. Mirrors augy's `PhraseBarManager.shared`.
- Branching happens in exactly one place: `handlePhrasePress` in `PhrasesInterface.tsx`. When the master toggle is off, today's behavior is unchanged.
- New components: `PhraseBar`, `PhraseBarChip` under `app/components/phrase-bar/`. Reuses `SymbolImage`, `useTTS`, the existing `Switch` primitive.
- Settings UI adds a new 'Phrase Bar' category (mobile sheet) and section (desktop).

## Test plan
- [x] 22 new unit tests (Context reducer + hydration, Chip rendering, Bar UX — empty state, Speak all, Remove last, Clear, disabled toggle)
- [x] Full suite: 286/286 passing
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Run `npx convex dev` once to push the schema change + new `updateSettings` args
- [ ] Manual — feature off (default): tapping a phrase speaks immediately (no regression)
- [ ] Manual — master toggle ON, speak-on-tap OFF: chips accumulate silently; Speak all joins with spaces
- [ ] Manual — speak-on-tap ON: chip appears AND speaks
- [ ] Manual — persistence: refresh rehydrates chips; closing the tab clears them
- [ ] Manual — symbols: phrases with symbols render with an icon on the chip

Closes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phrase Bar UI: build custom phrase sequences with scrollable chips, speak-all, remove-last, and clear actions; available in both offline and online boot modes

* **Settings**
  * New toggles to enable the Phrase Bar and optionally speak phrases on tap; preferences are persisted and synced

* **Behavior & Accessibility**
  * Auto-scrolls to new phrases; animations respect reduced-motion; tap behavior and TTS follow settings; ARIA labeling added

* **Tests**
  * Component and context tests added for Phrase Bar behavior and persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->