### PR TITLE
Action tiles: navigate-to-board, back stack, polymorphic boardTiles

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -9,6 +9,7 @@ import { AuthProvider, StaticAuthProvider } from './contexts/AuthContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { MobileBottomProvider } from './contexts/MobileBottomContext';
 import { PhraseBarProvider } from './contexts/PhraseBarContext';
+import { BoardNavStackProvider } from './contexts/BoardNavStackContext';
 import ConnectivityBanner from './components/navigation/ConnectivityBanner';
 import InstallBanner from './components/navigation/InstallBanner';
 import Sidebar from './components/Sidebar';
@@ -115,7 +116,9 @@ export default function ClientLayout({
           <SettingsProvider>
             <MobileBottomProvider>
               <PhraseBarProvider>
-                <OfflineAppShell mode={offlineMode} />
+                <BoardNavStackProvider>
+                  <OfflineAppShell mode={offlineMode} />
+                </BoardNavStackProvider>
               </PhraseBarProvider>
             </MobileBottomProvider>
           </SettingsProvider>
@@ -131,22 +134,24 @@ export default function ClientLayout({
           <SettingsProvider>
             <MobileBottomProvider>
               <PhraseBarProvider>
-                <OnlineStartupWatch onReady={handleStartupReady}>
-                  <OfflineDataSync />
-                  <div className="flex h-dvh min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">
-                    <Sidebar />
-                    <div className="flex min-h-0 flex-1 flex-col md:pl-16 lg:pl-16">
-                      <div className="shrink-0">
-                        <ConnectivityBanner />
-                        <InstallBanner />
+                <BoardNavStackProvider>
+                  <OnlineStartupWatch onReady={handleStartupReady}>
+                    <OfflineDataSync />
+                    <div className="flex h-dvh min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">
+                      <Sidebar />
+                      <div className="flex min-h-0 flex-1 flex-col md:pl-16 lg:pl-16">
+                        <div className="shrink-0">
+                          <ConnectivityBanner />
+                          <InstallBanner />
+                        </div>
+                        <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:overflow-visible">
+                          {children}
+                        </main>
                       </div>
-                      <main className="min-h-0 flex-1 overflow-y-auto pb-bottom-stack md:overflow-visible">
-                        {children}
-                      </main>
+                      <MobileBottomStack />
                     </div>
-                    <MobileBottomStack />
-                  </div>
-                </OnlineStartupWatch>
+                  </OnlineStartupWatch>
+                </BoardNavStackProvider>
               </PhraseBarProvider>
             </MobileBottomProvider>
           </SettingsProvider>

--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -14,7 +14,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { usePhraseBar } from '../../contexts/PhraseBarContext';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
-import type { PhraseSummary } from '../phrases/types';
+import type { BoardTileSummary, PhraseSummary } from '../phrases/types';
 
 export default function PhrasesInterface() {
   const tts = useTTS();
@@ -132,7 +132,7 @@ export default function PhrasesInterface() {
           phrasesContent={
             <PhrasesTabContent
               boards={boardData.boards}
-              phrases={boardData.phrases}
+              tiles={boardData.tiles}
               selectedBoard={boardData.selectedBoard}
               validBoardIndex={boardData.validBoardIndex}
               loading={boardData.loading}
@@ -144,12 +144,19 @@ export default function PhrasesInterface() {
               isOnline={isOnline}
               isSpeaking={tts.isSpeaking}
               activePhraseId={activePhraseId}
+              canNavigateBack={boardData.canNavigateBack}
               onPhrasePress={handlePhrasePress}
               onPhraseStop={handlePhraseStop}
               onEditPhrase={boardData.handleEditPhrase}
+              onNavigateTap={(tile: Extract<BoardTileSummary, { kind: 'navigate' }>) =>
+                boardData.handleNavigateToBoard(tile.targetBoardId)
+              }
+              onNavigateEdit={boardData.handleEditNavigateTile}
+              onNavigateBack={boardData.handleNavigateBack}
               onAddPhrase={isOnline && boardData.canEditCurrentBoard ? boardData.handleAddPhrase : undefined}
+              onAddNavigateTile={isOnline && boardData.canEditCurrentBoard ? boardData.handleAddNavigateTile : undefined}
               onAddBoard={boardData.handleAddBoard}
-              onReorderPhrases={boardData.handleReorderPhrases}
+              onReorderTiles={boardData.handleReorderTiles}
               onBoardIndexChange={boardData.handleBoardIndexChange}
               onToggleEditMode={boardData.handleToggleEditMode}
               onSelectBoard={boardData.handleSelectBoard}

--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -1,15 +1,16 @@
 import BoardSelector from '../phrases/BoardSelector';
 import SwipeableBoardNavigator from '../phrases/SwipeableBoardNavigator';
 import PhraseGrid from '../phrases/PhraseGrid';
-import PhraseTile from '../phrases/PhraseTile';
 import SortablePhraseGrid from '../phrases/SortablePhraseGrid';
+import BoardTileRenderer from '../phrases/tiles/BoardTileRenderer';
 import AnimatedLoading from '../phrases/AnimatedLoading';
 import PhraseBar from '../phrase-bar/PhraseBar';
-import type { BoardSummary, PhraseSummary } from '../phrases/types';
+import { ArrowUturnLeftIcon } from '@heroicons/react/24/outline';
+import type { BoardSummary, BoardTileSummary, PhraseSummary } from '../phrases/types';
 
 interface PhrasesTabContentProps {
   boards: BoardSummary[];
-  phrases: PhraseSummary[];
+  tiles: BoardTileSummary[];
   selectedBoard: BoardSummary | null;
   validBoardIndex: number;
   loading: boolean;
@@ -21,12 +22,17 @@ interface PhrasesTabContentProps {
   isOnline: boolean;
   isSpeaking: boolean;
   activePhraseId: string | null;
+  canNavigateBack: boolean;
   onPhrasePress: (phrase: PhraseSummary) => void;
   onPhraseStop: () => void;
   onEditPhrase: (phrase: PhraseSummary) => void;
+  onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  onNavigateEdit: (tileId: string) => void;
+  onNavigateBack: () => void;
   onAddPhrase: (() => void) | undefined;
+  onAddNavigateTile: (() => void) | undefined;
   onAddBoard: () => void;
-  onReorderPhrases: (orderedIds: string[]) => void;
+  onReorderTiles: (orderedTileIds: string[]) => void;
   onBoardIndexChange: (index: number) => void;
   onToggleEditMode: () => void;
   onSelectBoard: (board: BoardSummary | string) => void;
@@ -38,7 +44,7 @@ interface PhrasesTabContentProps {
 // onEditBoard already guards isOnline internally (from usePhraseBoardData)
 export default function PhrasesTabContent({
   boards,
-  phrases,
+  tiles,
   selectedBoard,
   validBoardIndex,
   loading,
@@ -50,12 +56,17 @@ export default function PhrasesTabContent({
   isOnline,
   isSpeaking,
   activePhraseId,
+  canNavigateBack,
   onPhrasePress,
   onPhraseStop,
   onEditPhrase,
+  onNavigateTap,
+  onNavigateEdit,
+  onNavigateBack,
   onAddPhrase,
+  onAddNavigateTile,
   onAddBoard,
-  onReorderPhrases,
+  onReorderTiles,
   onBoardIndexChange,
   onToggleEditMode,
   onSelectBoard,
@@ -63,32 +74,65 @@ export default function PhrasesTabContent({
   onEditBoard,
   textSizePx,
 }: PhrasesTabContentProps) {
+  const handleNavigateEditTile = (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => {
+    onNavigateEdit(tile.id);
+  };
+
+  // Defensive: parents should always pass an array, but a transient HMR / data
+  // race could leak an undefined into the prop. Default here so we render an
+  // empty grid instead of crashing the tree.
+  const safeTiles = tiles ?? [];
+
   const phraseGrid = isEditMode && canEditCurrentBoard ? (
     <SortablePhraseGrid
-      phrases={phrases}
+      tiles={safeTiles}
       activePhraseId={activePhraseId}
       isSpeaking={isSpeaking}
       onPhrasePress={onPhrasePress}
       onPhraseStop={onPhraseStop}
       onPhraseEdit={onEditPhrase}
-      onReorder={onReorderPhrases}
+      onNavigateTap={onNavigateTap}
+      onNavigateEdit={handleNavigateEditTile}
+      onReorder={onReorderTiles}
       textSizePx={textSizePx}
     />
   ) : (
     <PhraseGrid textSizePx={textSizePx}>
-      {phrases.map((phrase) => (
-        <PhraseTile
-          key={phrase.id}
-          phrase={phrase}
-          onPress={() => onPhrasePress(phrase)}
-          onStop={onPhraseStop}
-          isSpeaking={activePhraseId === phrase.id && isSpeaking}
-          onLongPress={canEditCurrentBoard ? () => onEditPhrase(phrase) : undefined}
-          textSizePx={textSizePx}
-        />
-      ))}
+      {safeTiles.map((tile) => {
+        const isPhraseSpeaking = tile.kind === 'phrase'
+          && activePhraseId === tile.phrase.id
+          && isSpeaking;
+        return (
+          <BoardTileRenderer
+            key={tile.id}
+            tile={tile}
+            textSizePx={textSizePx}
+            onPhrasePress={onPhrasePress}
+            onPhraseStop={onPhraseStop}
+            onPhraseEdit={canEditCurrentBoard ? onEditPhrase : undefined}
+            isPhraseSpeaking={isPhraseSpeaking}
+            onNavigateTap={onNavigateTap}
+            onNavigateEdit={canEditCurrentBoard ? handleNavigateEditTile : undefined}
+            isEditMode={false}
+          />
+        );
+      })}
     </PhraseGrid>
   );
+
+  const backRow = canNavigateBack ? (
+    <div className="px-2 pt-2">
+      <button
+        type="button"
+        onClick={onNavigateBack}
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 px-2 py-1 rounded-md hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+        aria-label="Back to previous board"
+      >
+        <ArrowUturnLeftIcon className="w-4 h-4" aria-hidden="true" />
+        <span>Back</span>
+      </button>
+    </div>
+  ) : null;
 
   if (showAuthPrompt) {
     return (
@@ -145,6 +189,7 @@ export default function PhrasesTabContent({
           onBoardChange={onBoardIndexChange}
           onOpenBoardPicker={onOpenBoardPicker}
           onAddPhrase={isOnline && canEditCurrentBoard ? onAddPhrase : undefined}
+          onAddNavigateTile={isOnline && canEditCurrentBoard ? onAddNavigateTile : undefined}
           onAddBoard={isOnline ? onAddBoard : undefined}
           onEdit={onToggleEditMode}
           onEditBoard={isOnline && selectedBoard && canEditCurrentBoard ? () => onEditBoard(selectedBoard.id) : undefined}
@@ -153,6 +198,7 @@ export default function PhrasesTabContent({
         >
           <div className="flex flex-col flex-1 min-h-0">
             <PhraseBar />
+            {backRow}
             <div className="p-2 overflow-auto flex-1">
               {phraseGrid}
             </div>
@@ -172,12 +218,14 @@ export default function PhrasesTabContent({
           onSelectBoard={onSelectBoard}
           onEditBoard={onEditBoard}
           onAddPhrase={isOnline && canEditCurrentBoard ? onAddPhrase : undefined}
+          onAddNavigateTile={isOnline && canEditCurrentBoard ? onAddNavigateTile : undefined}
           onAddBoard={isOnline ? onAddBoard : undefined}
           onEdit={onToggleEditMode}
           embedded={true}
         />
       </div>
       <PhraseBar />
+      {backRow}
       <div className="flex-1 overflow-auto p-3">
         {phraseGrid}
       </div>

--- a/app/components/phrases/BoardActionButtons.tsx
+++ b/app/components/phrases/BoardActionButtons.tsx
@@ -7,10 +7,13 @@ import {
   EllipsisHorizontalIcon,
   PencilIcon,
   CheckIcon,
+  ChatBubbleLeftIcon,
+  ArrowRightCircleIcon,
 } from '@heroicons/react/24/outline';
 
 interface BoardActionButtonsProps {
   onAddPhrase?: () => void;
+  onAddNavigateTile?: () => void;
   onAddBoard?: () => void;
   onEdit?: () => void;
   onEditBoard?: () => void;
@@ -20,6 +23,7 @@ interface BoardActionButtonsProps {
 
 export default function BoardActionButtons({
   onAddPhrase,
+  onAddNavigateTile,
   onAddBoard,
   onEdit,
   onEditBoard,
@@ -27,7 +31,9 @@ export default function BoardActionButtons({
   canEditBoard = true,
 }: BoardActionButtonsProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const addMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -40,15 +46,67 @@ export default function BoardActionButtons({
     return () => document.removeEventListener('mousedown', handler);
   }, [menuOpen]);
 
+  useEffect(() => {
+    if (!addMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
+        setAddMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [addMenuOpen]);
+
   const showAddPhrase = canEditBoard && !!onAddPhrase;
+  const showAddNavigate = canEditBoard && !!onAddNavigateTile;
+  // If both add-options are present, render them as a single "Add Tile" menu;
+  // if only one is present, fall back to the legacy single button.
+  const showAddTileMenu = showAddPhrase && showAddNavigate;
   const showAddBoard = !!onAddBoard;
   const showMenu = !!onEdit || !!onEditBoard;
 
-  if (!showAddPhrase && !showAddBoard && !showMenu) return null;
+  if (!showAddPhrase && !showAddNavigate && !showAddBoard && !showMenu) return null;
 
   return (
     <div className="flex items-center justify-center gap-2 py-2 bg-surface">
-      {showAddPhrase && (
+      {showAddTileMenu ? (
+        <div className="relative" ref={addMenuRef}>
+          <button
+            onClick={() => setAddMenuOpen((o) => !o)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-primary-500 hover:bg-primary-600 text-white transition-colors font-medium"
+            aria-haspopup="menu"
+            aria-expanded={addMenuOpen}
+            aria-label="Add tile"
+          >
+            <PlusIcon className="w-4 h-4" />
+            <span>Add Tile</span>
+          </button>
+
+          {addMenuOpen && (
+            <div
+              role="menu"
+              className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 w-52 bg-surface border border-border rounded-2xl shadow-xl overflow-hidden z-50"
+            >
+              <button
+                role="menuitem"
+                onClick={() => { onAddPhrase?.(); setAddMenuOpen(false); }}
+                className="w-full flex items-center gap-2.5 px-4 py-3 text-sm hover:bg-surface-hover transition-colors"
+              >
+                <ChatBubbleLeftIcon className="w-4 h-4 text-text-secondary" />
+                <span className="text-foreground">Phrase</span>
+              </button>
+              <button
+                role="menuitem"
+                onClick={() => { onAddNavigateTile?.(); setAddMenuOpen(false); }}
+                className="w-full flex items-center gap-2.5 px-4 py-3 text-sm hover:bg-surface-hover transition-colors border-t border-border"
+              >
+                <ArrowRightCircleIcon className="w-4 h-4 text-text-secondary" />
+                <span className="text-foreground">Navigate to board</span>
+              </button>
+            </div>
+          )}
+        </div>
+      ) : showAddPhrase ? (
         <button
           onClick={onAddPhrase}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-primary-500 hover:bg-primary-600 text-white transition-colors font-medium"
@@ -57,7 +115,16 @@ export default function BoardActionButtons({
           <PlusIcon className="w-4 h-4" />
           <span>Add Phrase</span>
         </button>
-      )}
+      ) : showAddNavigate ? (
+        <button
+          onClick={onAddNavigateTile}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-primary-500 hover:bg-primary-600 text-white transition-colors font-medium"
+          aria-label="Add navigate tile"
+        >
+          <PlusIcon className="w-4 h-4" />
+          <span>Add Navigate Tile</span>
+        </button>
+      ) : null}
 
       {showAddBoard && (
         <button

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -12,6 +12,7 @@ interface BoardSelectorProps {
   onSelectBoard: (board: BoardSummary) => void;
   onEditBoard?: (boardId: string) => void;
   onAddPhrase?: () => void;
+  onAddNavigateTile?: () => void;
   onAddBoard?: () => void;
   onEdit?: () => void;
   embedded?: boolean;
@@ -24,6 +25,7 @@ export default function BoardSelector({
   onSelectBoard,
   onEditBoard,
   onAddPhrase,
+  onAddNavigateTile,
   onAddBoard,
   onEdit,
   embedded = false,
@@ -87,6 +89,7 @@ export default function BoardSelector({
         </div>
         <BoardActionButtons
           onAddPhrase={onAddPhrase}
+          onAddNavigateTile={onAddNavigateTile}
           onAddBoard={onAddBoard}
           onEdit={onEdit}
           onEditBoard={editSelectedBoard}
@@ -123,6 +126,7 @@ export default function BoardSelector({
         </div>
         <BoardActionButtons
           onAddPhrase={onAddPhrase}
+          onAddNavigateTile={onAddNavigateTile}
           onAddBoard={onAddBoard}
           onEdit={onEdit}
           onEditBoard={editSelectedBoard}

--- a/app/components/phrases/SortablePhraseGrid.tsx
+++ b/app/components/phrases/SortablePhraseGrid.tsx
@@ -16,63 +16,74 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import PhraseGrid from './PhraseGrid';
-import PhraseTile from './PhraseTile';
-import type { PhraseSummary } from './types';
+import BoardTileRenderer from './tiles/BoardTileRenderer';
+import type { BoardTileSummary, PhraseSummary } from './types';
 
-interface SortablePhraseTileProps {
-  phrase: PhraseSummary;
-  onPress: () => void;
-  onStop?: () => void;
-  onEdit?: () => void;
-  isSpeaking?: boolean;
+interface SortableTileItemProps {
+  tile: BoardTileSummary;
   textSizePx: number;
+  onPhrasePress: (phrase: PhraseSummary) => void;
+  onPhraseStop?: () => void;
+  onPhraseEdit: (phrase: PhraseSummary) => void;
+  isPhraseSpeaking: boolean;
+  onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  onNavigateEdit: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
 }
 
-function SortablePhraseTile({ phrase, onPress, onStop, onEdit, isSpeaking, textSizePx }: SortablePhraseTileProps) {
+function SortableTileItem(props: SortableTileItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: phrase.id ?? phrase.text,
+    id: props.tile.id,
   });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    touchAction: 'none',
+    touchAction: 'none' as const,
   };
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <PhraseTile
-        phrase={phrase}
-        onPress={onPress}
-        onStop={onStop}
-        onEdit={onEdit}
-        isSpeaking={isSpeaking}
-        textSizePx={textSizePx}
+      <BoardTileRenderer
+        tile={props.tile}
+        textSizePx={props.textSizePx}
+        onPhrasePress={props.onPhrasePress}
+        onPhraseStop={props.onPhraseStop}
+        onPhraseEdit={props.onPhraseEdit}
+        isPhraseSpeaking={props.isPhraseSpeaking}
+        onNavigateTap={props.onNavigateTap}
+        onNavigateEdit={props.onNavigateEdit}
+        isEditMode
       />
     </div>
   );
 }
 
 interface SortablePhraseGridProps {
-  phrases: PhraseSummary[];
+  /** Polymorphic tiles ordered by position. */
+  tiles: BoardTileSummary[];
   activePhraseId: string | null;
   isSpeaking: boolean;
   onPhrasePress: (phrase: PhraseSummary) => void;
   onPhraseStop: () => void;
   onPhraseEdit: (phrase: PhraseSummary) => void;
-  onReorder: (orderedIds: string[]) => void;
+  onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  onNavigateEdit: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  /** Receives ordered boardTile ids; caller should call api.boardTiles.reorderTiles. */
+  onReorder: (orderedTileIds: string[]) => void;
   extraTile?: React.ReactNode;
   textSizePx: number;
 }
 
 export default function SortablePhraseGrid({
-  phrases,
+  tiles,
   activePhraseId,
   isSpeaking,
   onPhrasePress,
   onPhraseStop,
   onPhraseEdit,
+  onNavigateTap,
+  onNavigateEdit,
   onReorder,
   extraTile,
   textSizePx,
@@ -82,7 +93,10 @@ export default function SortablePhraseGrid({
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
   );
 
-  const ids = phrases.map((p) => p.id ?? p.text);
+  // Defensive: tolerate transient undefined during HMR / data load, so the
+  // grid can mount empty rather than crash the whole tab.
+  const safeTiles = tiles ?? [];
+  const ids = safeTiles.map((t) => t.id);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -102,17 +116,24 @@ export default function SortablePhraseGrid({
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={ids} strategy={rectSortingStrategy}>
         <PhraseGrid textSizePx={textSizePx}>
-          {phrases.map((phrase) => (
-            <SortablePhraseTile
-              key={phrase.id}
-              phrase={phrase}
-              onPress={() => onPhrasePress(phrase)}
-              onStop={onPhraseStop}
-              onEdit={() => onPhraseEdit(phrase)}
-              isSpeaking={activePhraseId === phrase.id && isSpeaking}
-              textSizePx={textSizePx}
-            />
-          ))}
+          {safeTiles.map((tile) => {
+            const isPhraseSpeaking = tile.kind === 'phrase'
+              && activePhraseId === tile.phrase.id
+              && isSpeaking;
+            return (
+              <SortableTileItem
+                key={tile.id}
+                tile={tile}
+                textSizePx={textSizePx}
+                onPhrasePress={onPhrasePress}
+                onPhraseStop={onPhraseStop}
+                onPhraseEdit={onPhraseEdit}
+                isPhraseSpeaking={isPhraseSpeaking}
+                onNavigateTap={onNavigateTap}
+                onNavigateEdit={onNavigateEdit}
+              />
+            );
+          })}
           {extraTile}
         </PhraseGrid>
       </SortableContext>

--- a/app/components/phrases/SwipeableBoardNavigator.tsx
+++ b/app/components/phrases/SwipeableBoardNavigator.tsx
@@ -14,6 +14,7 @@ interface SwipeableBoardNavigatorProps {
   children: React.ReactNode;
   // Action button props
   onAddPhrase?: () => void;
+  onAddNavigateTile?: () => void;
   onAddBoard?: () => void;
   onEdit?: () => void;
   onEditBoard?: () => void;
@@ -28,6 +29,7 @@ export default function SwipeableBoardNavigator({
   onOpenBoardPicker,
   children,
   onAddPhrase,
+  onAddNavigateTile,
   onAddBoard,
   onEdit,
   onEditBoard,
@@ -136,6 +138,7 @@ export default function SwipeableBoardNavigator({
       {/* Action Buttons Row */}
       <BoardActionButtons
         onAddPhrase={onAddPhrase}
+        onAddNavigateTile={onAddNavigateTile}
         onAddBoard={onAddBoard}
         onEdit={onEdit}
         onEditBoard={onEditBoard}

--- a/app/components/phrases/tiles/BoardTileRenderer.tsx
+++ b/app/components/phrases/tiles/BoardTileRenderer.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import PhraseTile from '../PhraseTile';
+import NavigateTile from './NavigateTile';
+import type { BoardTileSummary, PhraseSummary } from '../types';
+
+interface BoardTileRendererProps {
+  tile: BoardTileSummary;
+  textSizePx: number;
+  // Phrase-tile handlers
+  onPhrasePress: (phrase: PhraseSummary) => void;
+  onPhraseStop?: () => void;
+  onPhraseEdit?: (phrase: PhraseSummary) => void;
+  isPhraseSpeaking?: boolean;
+  // Navigate-tile handlers
+  onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  onNavigateEdit?: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  // True when the parent grid is in edit mode (long-press → edit on phrase tiles
+  // is replaced by tap-to-edit). Both kinds use the same affordance.
+  isEditMode?: boolean;
+  className?: string;
+}
+
+/**
+ * Polymorphic tile dispatcher. The single `switch (tile.kind)` is the
+ * extension point for new action kinds — add a new branch and the rest of
+ * the grid plumbing keeps working.
+ */
+export default function BoardTileRenderer({
+  tile,
+  textSizePx,
+  onPhrasePress,
+  onPhraseStop,
+  onPhraseEdit,
+  isPhraseSpeaking = false,
+  onNavigateTap,
+  onNavigateEdit,
+  isEditMode = false,
+  className,
+}: BoardTileRendererProps) {
+  switch (tile.kind) {
+  case 'phrase': {
+    const phrase = tile.phrase;
+    return (
+      <PhraseTile
+        phrase={phrase}
+        onPress={() => onPhrasePress(phrase)}
+        onStop={onPhraseStop}
+        isSpeaking={isPhraseSpeaking}
+        // In edit mode, tap performs the edit. Outside edit mode, long-press
+        // opens edit (when `onPhraseEdit` is supplied).
+        onEdit={isEditMode && onPhraseEdit ? () => onPhraseEdit(phrase) : undefined}
+        onLongPress={!isEditMode && onPhraseEdit ? () => onPhraseEdit(phrase) : undefined}
+        textSizePx={textSizePx}
+        className={className}
+      />
+    );
+  }
+  case 'navigate': {
+    return (
+      <NavigateTile
+        tile={tile}
+        onTap={() => onNavigateTap(tile)}
+        onEdit={isEditMode && onNavigateEdit ? () => onNavigateEdit(tile) : undefined}
+        onLongPress={!isEditMode && onNavigateEdit ? () => onNavigateEdit(tile) : undefined}
+        textSizePx={textSizePx}
+        className={className}
+      />
+    );
+  }
+  }
+}

--- a/app/components/phrases/tiles/NavigateTile.tsx
+++ b/app/components/phrases/tiles/NavigateTile.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { ArrowRightCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/solid';
+
+interface NavigateTileProps {
+  tile: {
+    id: string;
+    targetBoardId: string;
+    /** Live target board name; null = target missing/deleted (broken state). */
+    targetBoardName: string | null;
+  };
+  onTap: () => void;
+  onEdit?: () => void;
+  onLongPress?: () => void;
+  className?: string;
+  textSizePx: number;
+}
+
+const BROKEN_LABEL = 'Target removed';
+
+/**
+ * A tile whose tap navigates to another board.
+ *
+ * - Live label: receives `targetBoardName` from the polymorphic query result;
+ *   when the target board is renamed, the parent re-renders with a new value.
+ * - Broken state: when `targetBoardName === null` the tile renders disabled
+ *   and tap is a no-op (the parent surfaces a toast).
+ * - Edit affordance: long-press mirrors PhraseTile (500ms) when an `onLongPress`
+ *   handler is supplied. Tap-to-edit takes precedence when `onEdit` is set
+ *   (i.e. the board is in edit mode).
+ */
+export default function NavigateTile({
+  tile,
+  onTap,
+  onEdit,
+  onLongPress,
+  className = '',
+  textSizePx,
+}: NavigateTileProps) {
+  const [isPressed, setIsPressed] = useState(false);
+  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const isLongPress = useRef(false);
+
+  const isBroken = tile.targetBoardName === null;
+
+  const handleTouchStart = useCallback(() => {
+    if (isBroken && !onEdit) return;
+    isLongPress.current = false;
+    setIsPressed(true);
+
+    if (onLongPress && !onEdit) {
+      longPressTimer.current = setTimeout(() => {
+        isLongPress.current = true;
+        setIsPressed(false);
+        if (typeof navigator !== 'undefined' && navigator.vibrate) {
+          navigator.vibrate(50);
+        }
+        onLongPress();
+      }, 500);
+    }
+  }, [onLongPress, onEdit, isBroken]);
+
+  const handleTouchEnd = useCallback(() => {
+    setIsPressed(false);
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+      }
+    };
+  }, []);
+
+  const handleClick = () => {
+    if (isLongPress.current) {
+      isLongPress.current = false;
+      return;
+    }
+    if (onEdit) {
+      onEdit();
+      return;
+    }
+    if (isBroken) {
+      // No-op on broken target. Parent surfaces a toast via its own listener
+      // if desired; here we silently ignore so screen readers announce
+      // aria-disabled instead of triggering navigation.
+      return;
+    }
+    onTap();
+  };
+
+  const prefersReducedMotion = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const labelText = isBroken ? BROKEN_LABEL : (tile.targetBoardName ?? '');
+  const ariaLabel = onEdit
+    ? `Edit navigate tile: ${labelText}`
+    : isBroken
+      ? `${labelText} (tile is disabled because the target board no longer exists)`
+      : `Go to board: ${labelText}`;
+
+  return (
+    <motion.div
+      data-testid="navigate-tile"
+      data-tile-kind="navigate"
+      data-broken={isBroken ? 'true' : undefined}
+      className={`relative rounded-xl shadow-md cursor-pointer
+        flex flex-col items-center justify-center min-h-[52px] aspect-square overflow-hidden
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+        ${onEdit
+      ? 'bg-surface border-l-4 border-blue-400'
+      : isBroken
+        ? 'bg-surface border-2 border-dashed border-border opacity-60 cursor-not-allowed'
+        : 'bg-primary-50 dark:bg-primary-950/40 border-2 border-primary-400'}
+        ${className}`}
+      onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+      onMouseDown={handleTouchStart}
+      onMouseUp={handleTouchEnd}
+      onMouseLeave={handleTouchEnd}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      whileTap={prefersReducedMotion || isBroken ? undefined : { scale: 0.95 }}
+      animate={prefersReducedMotion ? undefined : {
+        scale: isPressed ? 0.95 : 1,
+      }}
+      transition={{ duration: 0.15 }}
+      role="button"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      aria-disabled={isBroken && !onEdit}
+    >
+      <div className="absolute top-1 right-1">
+        {isBroken
+          ? <ExclamationTriangleIcon className="w-4 h-4 text-warning" aria-hidden="true" />
+          : <ArrowRightCircleIcon className="w-4 h-4 text-primary-500" aria-hidden="true" />}
+      </div>
+      <div className="flex flex-col items-center justify-center w-full h-full min-h-0 p-2 gap-1">
+        <p
+          className={`font-semibold line-clamp-2 leading-tight text-center w-full ${
+            isBroken ? 'text-text-secondary italic' : 'text-foreground'
+          }`}
+          style={{ fontSize: `${textSizePx}px` }}
+        >
+          {labelText}
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/app/components/phrases/types.ts
+++ b/app/components/phrases/types.ts
@@ -5,11 +5,38 @@ export interface PhraseSummary {
   symbolStorageId?: string;
 }
 
+/**
+ * Polymorphic UI representation of a single tile placed on a board.
+ *
+ * Mirrors the shape returned by `convex/phraseBoards.getPhraseBoard` /
+ * `convex/boardTiles.listByBoard` but decoupled from Convex Id types so
+ * presentational components stay framework-agnostic.
+ *
+ * Adding a new tile kind: add a member to this union, add a render branch
+ * in BoardTileRenderer, add a form for creating/editing it.
+ */
+export type BoardTileSummary =
+  | {
+      id: string;
+      kind: 'phrase';
+      position: number;
+      phrase: PhraseSummary;
+    }
+  | {
+      id: string;
+      kind: 'navigate';
+      position: number;
+      targetBoardId: string;
+      /** Live name of the target board; null when target is missing/deleted. */
+      targetBoardName: string | null;
+    };
+
 export interface BoardSummary {
   id: string;
   name: string;
   position?: number;
   phrases: PhraseSummary[];
+  tiles?: BoardTileSummary[];
   isShared?: boolean;
   isOwner?: boolean;
   accessLevel?: 'view' | 'edit';

--- a/app/contexts/BoardNavStackContext.tsx
+++ b/app/contexts/BoardNavStackContext.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * In-memory board navigation stack.
+ *
+ * Records the chain of source boards a user reached the current board *from*
+ * via navigate-tile taps. The current board is NOT in the stack; the stack
+ * holds the boards we'd return to in order, most-recent on top.
+ *
+ * Reset semantics (per spec):
+ * - `push(sourceBoardId)`: called by NavigateTile right before switching the
+ *   selected board to its target.
+ * - `pop()`: called by the board-header back button. Returns the popped id
+ *   so the caller can switch the selected board to it.
+ * - `clear()`: called by `usePhraseBoardData.handleSelectBoard` whenever a
+ *   board is picked through any non-tile path (sidebar, dropdown, swipe).
+ *
+ * Not persisted — survives in-tab navigation only. A reload starts fresh.
+ */
+interface BoardNavStackContextValue {
+  stack: string[];
+  canPop: boolean;
+  push: (sourceBoardId: string) => void;
+  pop: () => string | null;
+  clear: () => void;
+}
+
+const BoardNavStackContext = createContext<BoardNavStackContextValue | undefined>(undefined);
+
+export function BoardNavStackProvider({ children }: { children: ReactNode }) {
+  const [stack, setStack] = useState<string[]>([]);
+
+  const push = useCallback((sourceBoardId: string) => {
+    setStack((prev) => {
+      // Cap stack depth to guard against runaway A↔B↔A cycles.
+      const MAX_DEPTH = 32;
+      const next = [...prev, sourceBoardId];
+      return next.length > MAX_DEPTH ? next.slice(next.length - MAX_DEPTH) : next;
+    });
+  }, []);
+
+  // Read current `stack` directly so callers reliably get the popped id back
+  // (avoids the strict-mode/concurrent-updater pitfall of mutating an outer
+  // variable from inside a setState updater).
+  const pop = useCallback((): string | null => {
+    if (stack.length === 0) return null;
+    const popped = stack[stack.length - 1];
+    setStack((prev) => prev.slice(0, -1));
+    return popped;
+  }, [stack]);
+
+  const clear = useCallback(() => {
+    setStack((prev) => (prev.length === 0 ? prev : []));
+  }, []);
+
+  const value = useMemo<BoardNavStackContextValue>(
+    () => ({
+      stack,
+      canPop: stack.length > 0,
+      push,
+      pop,
+      clear,
+    }),
+    [stack, push, pop, clear]
+  );
+
+  return (
+    <BoardNavStackContext.Provider value={value}>
+      {children}
+    </BoardNavStackContext.Provider>
+  );
+}
+
+export function useBoardNavStack(): BoardNavStackContextValue {
+  const ctx = useContext(BoardNavStackContext);
+  if (ctx === undefined) {
+    throw new Error('useBoardNavStack must be used within a BoardNavStackProvider');
+  }
+  return ctx;
+}
+
+/** Safe variant — returns null when used outside a provider. */
+export function useBoardNavStackOptional(): BoardNavStackContextValue | null {
+  return useContext(BoardNavStackContext) ?? null;
+}

--- a/app/contexts/BoardNavStackContext.tsx
+++ b/app/contexts/BoardNavStackContext.tsx
@@ -4,7 +4,9 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -38,28 +40,36 @@ const BoardNavStackContext = createContext<BoardNavStackContextValue | undefined
 
 export function BoardNavStackProvider({ children }: { children: ReactNode }) {
   const [stack, setStack] = useState<string[]>([]);
-
-  const push = useCallback((sourceBoardId: string) => {
-    setStack((prev) => {
-      // Cap stack depth to guard against runaway A↔B↔A cycles.
-      const MAX_DEPTH = 32;
-      const next = [...prev, sourceBoardId];
-      return next.length > MAX_DEPTH ? next.slice(next.length - MAX_DEPTH) : next;
-    });
-  }, []);
-
-  // Read current `stack` directly so callers reliably get the popped id back
-  // (avoids the strict-mode/concurrent-updater pitfall of mutating an outer
-  // variable from inside a setState updater).
-  const pop = useCallback((): string | null => {
-    if (stack.length === 0) return null;
-    const popped = stack[stack.length - 1];
-    setStack((prev) => prev.slice(0, -1));
-    return popped;
+  // Mirror state in a ref so synchronous calls (e.g. two rapid back-taps in
+  // the same render frame) read up-to-date data instead of a stale closure
+  // capture.
+  const stackRef = useRef<string[]>([]);
+  useEffect(() => {
+    stackRef.current = stack;
   }, [stack]);
 
+  const push = useCallback((sourceBoardId: string) => {
+    // Cap stack depth to guard against runaway A↔B↔A cycles.
+    const MAX_DEPTH = 32;
+    const next = [...stackRef.current, sourceBoardId];
+    const trimmed = next.length > MAX_DEPTH ? next.slice(next.length - MAX_DEPTH) : next;
+    stackRef.current = trimmed;
+    setStack(trimmed);
+  }, []);
+
+  const pop = useCallback((): string | null => {
+    if (stackRef.current.length === 0) return null;
+    const popped = stackRef.current[stackRef.current.length - 1];
+    const next = stackRef.current.slice(0, -1);
+    stackRef.current = next;
+    setStack(next);
+    return popped;
+  }, []);
+
   const clear = useCallback(() => {
-    setStack((prev) => (prev.length === 0 ? prev : []));
+    if (stackRef.current.length === 0) return;
+    stackRef.current = [];
+    setStack([]);
   }, []);
 
   const value = useMemo<BoardNavStackContextValue>(

--- a/app/phrases/boards/[boardId]/tiles/navigate/[tileId]/edit/page.tsx
+++ b/app/phrases/boards/[boardId]/tiles/navigate/[tileId]/edit/page.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import { Button } from '@/app/components/ui/Button';
+import BackButton from '@/app/components/ui/BackButton';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+import { ChevronDownIcon, UserGroupIcon, CheckIcon } from '@heroicons/react/24/outline';
+
+function EditNavigateTileForm() {
+  const router = useRouter();
+  const params = useParams<{ boardId: string; tileId: string }>();
+  const sourceBoardId = params?.boardId ?? null;
+  const tileId = params?.tileId ?? null;
+
+  const [targetBoardId, setTargetBoardId] = useState<string | null>(null);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Hydrate the existing tile via the source board's tile list. Cheaper than
+  // adding a "getTile" query and keeps the data path consistent with the grid.
+  const sourceBoardData = useQuery(
+    api.phraseBoards.getPhraseBoard,
+    sourceBoardId ? { id: sourceBoardId as Id<'phraseBoards'> } : 'skip'
+  );
+
+  const existingTile = useMemo(() => {
+    if (!sourceBoardData || !tileId) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tiles = (sourceBoardData.tiles ?? []) as any[];
+    return tiles.find((t) => String(t._id) === tileId && t.kind === 'navigate') ?? null;
+  }, [sourceBoardData, tileId]);
+
+  // Initialize state from the existing tile once it loads.
+  useEffect(() => {
+    if (existingTile && targetBoardId === null) {
+      setTargetBoardId(String(existingTile.targetBoardId));
+    }
+  }, [existingTile, targetBoardId]);
+
+  const boards = useQuery(api.phraseBoards.getPhraseBoards);
+  const updateNavigateTile = useMutation(api.boardTiles.updateNavigateTile);
+  const deleteTile = useMutation(api.boardTiles.deleteTile);
+
+  const eligibleTargets = useMemo(() => {
+    if (!boards) return [];
+    return boards.filter((b) => b._id !== sourceBoardId);
+  }, [boards, sourceBoardId]);
+
+  const selectedTarget = eligibleTargets.find((b) => b._id === targetBoardId) ?? null;
+
+  const handleSelectTarget = (id: string) => {
+    setTargetBoardId(id);
+    setIsPickerOpen(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!tileId || !targetBoardId) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      await updateNavigateTile({
+        tileId: tileId as Id<'boardTiles'>,
+        targetBoardId: targetBoardId as Id<'phraseBoards'>,
+      });
+      router.back();
+    } catch (err) {
+      console.error('Error updating navigate tile:', err);
+      setError(err instanceof Error ? err.message : 'Failed to update navigate tile');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!tileId) return;
+    if (!confirm('Delete this navigate tile?')) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteTile({ tileId: tileId as Id<'boardTiles'> });
+      router.back();
+    } catch (err) {
+      console.error('Error deleting tile:', err);
+      setError(err instanceof Error ? err.message : 'Failed to delete tile');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24">
+        <BackButton />
+        <h1 className="text-3xl font-bold text-foreground mt-4">Edit Navigate Tile</h1>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-surface shadow-2xl hover:shadow-3xl transition-all duration-300 rounded-3xl p-8 mt-6"
+        >
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-text-secondary mb-2">
+              Target Board
+            </label>
+            {boards === undefined || sourceBoardData === undefined ? (
+              <div className="text-text-tertiary">Loading...</div>
+            ) : !existingTile ? (
+              <div className="text-amber-600 bg-status-warning px-4 py-3 rounded-2xl">
+                Tile not found. It may have been deleted.
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsPickerOpen(true)}
+                className="w-full flex items-center justify-between bg-surface-hover text-foreground rounded-2xl px-4 py-4 border border-border focus:outline-none focus:ring-2 focus:ring-primary-500 transition-all"
+              >
+                <div className="flex flex-col items-start">
+                  <span className={selectedTarget ? 'font-medium' : 'text-text-tertiary'}>
+                    {selectedTarget?.name || 'Select a target board'}
+                  </span>
+                </div>
+                <ChevronDownIcon className="w-5 h-5 text-text-tertiary" />
+              </button>
+            )}
+          </div>
+
+          {error && (
+            <div className="mb-4 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-between items-center">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleDelete}
+              disabled={deleting || !existingTile}
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading || !targetBoardId || !existingTile}
+            >
+              {loading ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </div>
+
+      <BottomSheet
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        title="Select Target Board"
+        snapPoints={[50, 80]}
+      >
+        <div className="p-4 space-y-2">
+          {eligibleTargets.map((board) => {
+            const isSelected = board._id === targetBoardId;
+            return (
+              <button
+                key={board._id}
+                onClick={() => handleSelectTarget(board._id)}
+                className={`w-full flex items-center justify-between p-4 rounded-2xl transition-all ${
+                  isSelected
+                    ? 'bg-surface-hover border-2 border-primary-500'
+                    : 'bg-surface-hover hover:bg-surface border-2 border-transparent'
+                }`}
+              >
+                <div className="flex flex-col items-start">
+                  <span className="font-medium text-foreground">{board.name}</span>
+                  {board.isShared && board.sharedBy && (
+                    <div className="flex items-center gap-1 mt-1">
+                      <UserGroupIcon className="w-3 h-3 text-primary-400" />
+                      <span className="text-xs text-primary-400">Shared by {board.sharedBy}</span>
+                    </div>
+                  )}
+                  {board.isOwner && board.forClientName && (
+                    <div className="flex items-center gap-1 mt-1">
+                      <UserGroupIcon className="w-3 h-3 text-blue-400" />
+                      <span className="text-xs text-blue-400">For {board.forClientName}</span>
+                    </div>
+                  )}
+                </div>
+                {isSelected && <CheckIcon className="w-5 h-5 text-primary-500" />}
+              </button>
+            );
+          })}
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}
+
+export default function EditNavigateTilePage() {
+  return (
+    <Suspense fallback={<div className="text-foreground">Loading...</div>}>
+      <EditNavigateTileForm />
+    </Suspense>
+  );
+}

--- a/app/phrases/boards/[boardId]/tiles/navigate/add/page.tsx
+++ b/app/phrases/boards/[boardId]/tiles/navigate/add/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { Suspense, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import { Button } from '@/app/components/ui/Button';
+import BackButton from '@/app/components/ui/BackButton';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+import { ChevronDownIcon, UserGroupIcon, CheckIcon } from '@heroicons/react/24/outline';
+
+function AddNavigateTileForm() {
+  const router = useRouter();
+  const params = useParams<{ boardId: string }>();
+  const sourceBoardId = params?.boardId ?? null;
+  const [targetBoardId, setTargetBoardId] = useState<string | null>(null);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const boards = useQuery(api.phraseBoards.getPhraseBoards);
+  const addNavigateTile = useMutation(api.boardTiles.addNavigateTile);
+
+  // Eligible targets: any board the user can read, except the source board.
+  const eligibleTargets = useMemo(() => {
+    if (!boards) return [];
+    return boards.filter((b) => b._id !== sourceBoardId);
+  }, [boards, sourceBoardId]);
+
+  const selectedTarget = eligibleTargets.find((b) => b._id === targetBoardId) ?? null;
+
+  const handleSelectTarget = (id: string) => {
+    setTargetBoardId(id);
+    setIsPickerOpen(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!sourceBoardId || !targetBoardId) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      await addNavigateTile({
+        boardId: sourceBoardId as Id<'phraseBoards'>,
+        targetBoardId: targetBoardId as Id<'phraseBoards'>,
+      });
+      router.back();
+    } catch (err) {
+      console.error('Error adding navigate tile:', err);
+      setError(err instanceof Error ? err.message : 'Failed to add navigate tile');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24">
+        <BackButton />
+        <h1 className="text-3xl font-bold text-foreground mt-4">Add Navigate Tile</h1>
+        <p className="text-text-secondary mt-2">
+          A navigate tile takes the user to another board when tapped. The tile&apos;s label
+          stays in sync with the target board&apos;s name.
+        </p>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-surface shadow-2xl hover:shadow-3xl transition-all duration-300 rounded-3xl p-8 mt-6"
+        >
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-text-secondary mb-2">
+              Target Board
+            </label>
+            {boards === undefined ? (
+              <div className="text-text-tertiary">Loading boards...</div>
+            ) : eligibleTargets.length === 0 ? (
+              <div className="text-amber-600 bg-status-warning px-4 py-3 rounded-2xl">
+                You need at least one other board before you can add a navigate tile.
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsPickerOpen(true)}
+                className="w-full flex items-center justify-between bg-surface-hover text-foreground rounded-2xl px-4 py-4 border border-border focus:outline-none focus:ring-2 focus:ring-primary-500 transition-all"
+              >
+                <div className="flex flex-col items-start">
+                  <span className={selectedTarget ? 'font-medium' : 'text-text-tertiary'}>
+                    {selectedTarget?.name || 'Select a target board'}
+                  </span>
+                </div>
+                <ChevronDownIcon className="w-5 h-5 text-text-tertiary" />
+              </button>
+            )}
+          </div>
+
+          {error && (
+            <div className="mb-4 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={loading || !targetBoardId}
+            >
+              {loading ? 'Adding...' : 'Add Navigate Tile'}
+            </Button>
+          </div>
+        </form>
+      </div>
+
+      <BottomSheet
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        title="Select Target Board"
+        snapPoints={[50, 80]}
+      >
+        <div className="p-4 space-y-2">
+          {eligibleTargets.map((board) => {
+            const isSelected = board._id === targetBoardId;
+            return (
+              <button
+                key={board._id}
+                onClick={() => handleSelectTarget(board._id)}
+                className={`w-full flex items-center justify-between p-4 rounded-2xl transition-all ${
+                  isSelected
+                    ? 'bg-surface-hover border-2 border-primary-500'
+                    : 'bg-surface-hover hover:bg-surface border-2 border-transparent'
+                }`}
+              >
+                <div className="flex flex-col items-start">
+                  <span className="font-medium text-foreground">{board.name}</span>
+                  {board.isShared && board.sharedBy && (
+                    <div className="flex items-center gap-1 mt-1">
+                      <UserGroupIcon className="w-3 h-3 text-primary-400" />
+                      <span className="text-xs text-primary-400">Shared by {board.sharedBy}</span>
+                    </div>
+                  )}
+                  {board.isOwner && board.forClientName && (
+                    <div className="flex items-center gap-1 mt-1">
+                      <UserGroupIcon className="w-3 h-3 text-blue-400" />
+                      <span className="text-xs text-blue-400">For {board.forClientName}</span>
+                    </div>
+                  )}
+                </div>
+                {isSelected && <CheckIcon className="w-5 h-5 text-primary-500" />}
+              </button>
+            );
+          })}
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}
+
+export default function AddNavigateTilePage() {
+  return (
+    <Suspense fallback={<div className="text-foreground">Loading...</div>}>
+      <AddNavigateTileForm />
+    </Suspense>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as boardTiles from "../boardTiles.js";
 import type * as caregiverClients from "../caregiverClients.js";
 import type * as connectionRequests from "../connectionRequests.js";
 import type * as conversationHistory from "../conversationHistory.js";
@@ -27,6 +28,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  boardTiles: typeof boardTiles;
   caregiverClients: typeof caregiverClients;
   connectionRequests: typeof connectionRequests;
   conversationHistory: typeof conversationHistory;

--- a/convex/boardTiles.ts
+++ b/convex/boardTiles.ts
@@ -1,0 +1,317 @@
+import { v } from 'convex/values';
+import { mutation, query, type QueryCtx } from './_generated/server';
+import type { Doc, Id } from './_generated/dataModel';
+import { getUserIdentity } from './users';
+
+// ---------------------------------------------------------------------------
+// Access helpers
+// ---------------------------------------------------------------------------
+
+type BoardAccess = {
+  board: Doc<'phraseBoards'>;
+  isOwner: boolean;
+  canEdit: boolean;
+  canRead: boolean;
+};
+
+async function getBoardAccess(
+  ctx: QueryCtx,
+  boardId: Id<'phraseBoards'>,
+  userId: string
+): Promise<BoardAccess | null> {
+  const board = await ctx.db.get(boardId);
+  if (!board) return null;
+
+  const isOwner = board.userId === userId;
+  const isAssignedClient = board.forClientId === userId;
+  const canEdit =
+    isOwner || (isAssignedClient && board.clientAccessLevel === 'edit');
+  const canRead = isOwner || isAssignedClient;
+
+  return { board, isOwner, canEdit, canRead };
+}
+
+// ---------------------------------------------------------------------------
+// Query: list tiles on a board (polymorphic, hydrated)
+// ---------------------------------------------------------------------------
+
+export type ListedBoardTile =
+  | {
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'phrase';
+      phrase: Doc<'phrases'> | null;
+    }
+  | {
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'navigate';
+      targetBoardId: Id<'phraseBoards'>;
+      targetBoardName: string | null;
+    };
+
+export const listByBoard = query({
+  args: { boardId: v.id('phraseBoards') },
+  handler: async (ctx, args): Promise<ListedBoardTile[]> => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) return [];
+
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access || !access.canRead) return [];
+
+    const rows = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
+      .collect();
+
+    const sorted = [...rows].sort((a, b) => a.position - b.position);
+
+    const hydrated: ListedBoardTile[] = await Promise.all(
+      sorted.map(async (row): Promise<ListedBoardTile> => {
+        if (row.kind === 'phrase') {
+          const phrase = row.phraseId ? await ctx.db.get(row.phraseId) : null;
+          return {
+            _id: row._id,
+            boardId: row.boardId,
+            position: row.position,
+            kind: 'phrase',
+            phrase: phrase ?? null,
+          };
+        }
+        // kind === 'navigate'
+        const targetBoardId = row.targetBoardId;
+        if (!targetBoardId) {
+          // Defensive: shouldn't happen given mutation guards, but treat as broken.
+          return {
+            _id: row._id,
+            boardId: row.boardId,
+            position: row.position,
+            kind: 'navigate',
+            targetBoardId: row.boardId, // self-ref to satisfy id type; renderer treats null name as broken
+            targetBoardName: null,
+          };
+        }
+        const target = await ctx.db.get(targetBoardId);
+        return {
+          _id: row._id,
+          boardId: row.boardId,
+          position: row.position,
+          kind: 'navigate',
+          targetBoardId,
+          targetBoardName: target?.name ?? null,
+        };
+      })
+    );
+
+    return hydrated;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: add a phrase-kind tile
+// ---------------------------------------------------------------------------
+
+export const addPhraseTile = mutation({
+  args: {
+    boardId: v.id('phraseBoards'),
+    phraseId: v.id('phrases'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    // Verify phrase ownership.
+    const phrase = await ctx.db.get(args.phraseId);
+    if (!phrase || phrase.userId !== identity.subject) {
+      throw new Error('Unauthorized - phrase');
+    }
+
+    // Verify board edit access.
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access) throw new Error('Board not found');
+    if (!access.canEdit) throw new Error('Unauthorized - board');
+
+    // Reject duplicate phrase text on the same board (preserves prior UX rule).
+    const existingTiles = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
+      .collect();
+
+    for (const tile of existingTiles) {
+      if (tile.kind !== 'phrase' || !tile.phraseId) continue;
+      const existing = await ctx.db.get(tile.phraseId);
+      if (existing && existing.text === phrase.text) {
+        throw new Error('A phrase with this text already exists on this board');
+      }
+    }
+
+    const position = existingTiles.length;
+    return await ctx.db.insert('boardTiles', {
+      boardId: args.boardId,
+      position,
+      kind: 'phrase',
+      phraseId: args.phraseId,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: add a navigate-kind tile
+// ---------------------------------------------------------------------------
+
+export const addNavigateTile = mutation({
+  args: {
+    boardId: v.id('phraseBoards'),
+    targetBoardId: v.id('phraseBoards'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    if (args.boardId === args.targetBoardId) {
+      throw new Error('A navigate tile cannot point at its own board');
+    }
+
+    // Verify edit access on the source board.
+    const sourceAccess = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!sourceAccess) throw new Error('Board not found');
+    if (!sourceAccess.canEdit) throw new Error('Unauthorized - board');
+
+    // Verify the target exists and the creator can read it. (Runtime viewers
+    // who lack access will see a broken-state tile; that's the documented v1
+    // behavior.)
+    const targetAccess = await getBoardAccess(ctx, args.targetBoardId, identity.subject);
+    if (!targetAccess) throw new Error('Target board not found');
+    if (!targetAccess.canRead) throw new Error('Unauthorized - target board');
+
+    const existingTiles = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
+      .collect();
+
+    const position = existingTiles.length;
+    return await ctx.db.insert('boardTiles', {
+      boardId: args.boardId,
+      position,
+      kind: 'navigate',
+      targetBoardId: args.targetBoardId,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: change the destination of an existing navigate tile
+// ---------------------------------------------------------------------------
+
+export const updateNavigateTile = mutation({
+  args: {
+    tileId: v.id('boardTiles'),
+    targetBoardId: v.id('phraseBoards'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const tile = await ctx.db.get(args.tileId);
+    if (!tile) throw new Error('Tile not found');
+    if (tile.kind !== 'navigate') throw new Error('Tile is not a navigate tile');
+
+    if (tile.boardId === args.targetBoardId) {
+      throw new Error('A navigate tile cannot point at its own board');
+    }
+
+    const sourceAccess = await getBoardAccess(ctx, tile.boardId, identity.subject);
+    if (!sourceAccess || !sourceAccess.canEdit) throw new Error('Unauthorized');
+
+    const targetAccess = await getBoardAccess(ctx, args.targetBoardId, identity.subject);
+    if (!targetAccess) throw new Error('Target board not found');
+    if (!targetAccess.canRead) throw new Error('Unauthorized - target board');
+
+    await ctx.db.patch(args.tileId, { targetBoardId: args.targetBoardId });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: reorder tiles on a board
+// ---------------------------------------------------------------------------
+
+export const reorderTiles = mutation({
+  args: {
+    boardId: v.id('phraseBoards'),
+    orderedTileIds: v.array(v.id('boardTiles')),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access) throw new Error('Board not found');
+    if (!access.canEdit) throw new Error('Unauthorized');
+
+    // Only patch tiles that actually belong to this board.
+    const tilesById = new Map<string, Doc<'boardTiles'>>();
+    const existing = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
+      .collect();
+    for (const tile of existing) {
+      tilesById.set(tile._id.toString(), tile);
+    }
+
+    await Promise.all(
+      args.orderedTileIds.map((tileId, index) => {
+        const tile = tilesById.get(tileId.toString());
+        if (!tile) return undefined;
+        return ctx.db.patch(tile._id, { position: index });
+      })
+    );
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: delete a tile (does not delete the underlying phrase)
+// ---------------------------------------------------------------------------
+
+export const deleteTile = mutation({
+  args: { tileId: v.id('boardTiles') },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const tile = await ctx.db.get(args.tileId);
+    if (!tile) return;
+
+    const access = await getBoardAccess(ctx, tile.boardId, identity.subject);
+    if (!access || !access.canEdit) throw new Error('Unauthorized');
+
+    await ctx.db.delete(args.tileId);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: remove a phrase tile by phraseId (compat for existing flows)
+// ---------------------------------------------------------------------------
+
+export const removePhraseTileFromBoard = mutation({
+  args: {
+    phraseId: v.id('phrases'),
+    boardId: v.id('phraseBoards'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access || !access.canEdit) throw new Error('Unauthorized');
+
+    const tile = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_phrase', (q) => q.eq('phraseId', args.phraseId))
+      .filter((q) => q.eq(q.field('boardId'), args.boardId))
+      .first();
+
+    if (tile) await ctx.db.delete(tile._id);
+  },
+});

--- a/convex/boardTiles.ts
+++ b/convex/boardTiles.ts
@@ -94,13 +94,19 @@ export const listByBoard = query({
           };
         }
         const target = await ctx.db.get(targetBoardId);
+        // Only expose the name when the viewer can actually read the target.
+        // Otherwise return null (renderer shows broken state) so we don't leak
+        // names of boards the viewer has no access to.
+        const canRead = target
+          ? target.userId === identity.subject || target.forClientId === identity.subject
+          : false;
         return {
           _id: row._id,
           boardId: row.boardId,
           position: row.position,
           kind: 'navigate',
           targetBoardId,
-          targetBoardName: target?.name ?? null,
+          targetBoardName: canRead ? (target?.name ?? null) : null,
         };
       })
     );

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -24,11 +24,21 @@ export const migrateToBoardTiles = internalMutation({
 
     let inserted = 0;
     let skipped = 0;
+    let skippedOrphan = 0;
 
     for (const link of links) {
       const key = `${link.boardId.toString()}::${link.phraseId.toString()}`;
       if (existingKeys.has(key)) {
         skipped++;
+        continue;
+      }
+      // Skip orphans: a phraseBoardPhrases row whose phraseId or boardId no
+      // longer resolves to a real row would create a permanently broken
+      // boardTile. Drop them on the floor instead of carrying garbage forward.
+      const phrase = await ctx.db.get(link.phraseId);
+      const board = await ctx.db.get(link.boardId);
+      if (!phrase || !board) {
+        skippedOrphan++;
         continue;
       }
 
@@ -42,7 +52,7 @@ export const migrateToBoardTiles = internalMutation({
       inserted++;
     }
 
-    return { inserted, skipped, totalLinks: links.length };
+    return { inserted, skipped, skippedOrphan, totalLinks: links.length };
   },
 });
 

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,5 +1,51 @@
 import { internalMutation } from './_generated/server';
 
+// Migration: Backfill boardTiles from phraseBoardPhrases.
+//
+// Run AFTER deploying the additive schema change that adds the boardTiles
+// table, and BEFORE deploying the cutover that removes phraseBoardPhrases:
+//   npx convex run migrations:migrateToBoardTiles
+//
+// Idempotent: a boardTile (kind='phrase') is only inserted if no tile already
+// exists for the same (boardId, phraseId) pair.
+export const migrateToBoardTiles = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const links = await ctx.db.query('phraseBoardPhrases').collect();
+
+    // Pre-load all existing boardTiles per (boardId, phraseId) for O(1) lookup.
+    const existingKeys = new Set<string>();
+    const existingTiles = await ctx.db.query('boardTiles').collect();
+    for (const tile of existingTiles) {
+      if (tile.kind === 'phrase' && tile.phraseId) {
+        existingKeys.add(`${tile.boardId.toString()}::${tile.phraseId.toString()}`);
+      }
+    }
+
+    let inserted = 0;
+    let skipped = 0;
+
+    for (const link of links) {
+      const key = `${link.boardId.toString()}::${link.phraseId.toString()}`;
+      if (existingKeys.has(key)) {
+        skipped++;
+        continue;
+      }
+
+      await ctx.db.insert('boardTiles', {
+        boardId: link.boardId,
+        phraseId: link.phraseId,
+        position: link.position ?? 0,
+        kind: 'phrase',
+      });
+      existingKeys.add(key);
+      inserted++;
+    }
+
+    return { inserted, skipped, totalLinks: links.length };
+  },
+});
+
 // Migration: Convert textSize from enum strings to numbers
 // Run this once via Convex dashboard before deploying schema changes
 export const migrateTextSizeToNumber = internalMutation({

--- a/convex/phraseBoards.ts
+++ b/convex/phraseBoards.ts
@@ -37,9 +37,18 @@ type PolymorphicBoardTile =
       targetBoardName: string | null;
     };
 
+function viewerCanReadBoard(
+  board: Doc<'phraseBoards'> | null,
+  viewerSubject: string
+): boolean {
+  if (!board) return false;
+  return board.userId === viewerSubject || board.forClientId === viewerSubject;
+}
+
 async function loadHydratedBoardTiles(
   ctx: QueryCtx,
   boardId: Id<'phraseBoards'>,
+  viewerSubject: string,
   getCachedPhrase: (phraseId: Id<'phrases'>) => Promise<Doc<'phrases'> | null>,
   getCachedBoard: (boardId: Id<'phraseBoards'>) => Promise<Doc<'phraseBoards'> | null>
 ): Promise<{ tiles: PolymorphicBoardTile[]; phraseLinks: LegacyPhraseLink[] }> {
@@ -89,13 +98,18 @@ async function loadHydratedBoardTiles(
       continue;
     }
     const target = await getCachedBoard(row.targetBoardId);
+    // Only expose the target name when the viewer can actually read the
+    // target board. Otherwise fall back to the broken-state shape so we
+    // don't leak names of boards the viewer has no access to (e.g. a
+    // caregiver's private board referenced from a client-shared board).
+    const canRead = viewerCanReadBoard(target, viewerSubject);
     tiles.push({
       _id: row._id,
       boardId: row.boardId,
       position: row.position,
       kind: 'navigate',
       targetBoardId: row.targetBoardId,
-      targetBoardName: target?.name ?? null,
+      targetBoardName: canRead ? (target?.name ?? null) : null,
     });
   }
 
@@ -164,7 +178,7 @@ export const getPhraseBoards = query({
     const ownedBoardsWithInfo = await Promise.all(
       ownedBoards.map(async (board) => {
         const { tiles, phraseLinks } = await loadHydratedBoardTiles(
-          ctx, board._id, getCachedPhrase, getCachedBoard
+          ctx, board._id, identity.subject, getCachedPhrase, getCachedBoard
         );
 
         // Get client name if this board is for a client
@@ -191,7 +205,7 @@ export const getPhraseBoards = query({
     const assignedBoardsWithInfo = await Promise.all(
       assignedBoards.map(async (board) => {
         const { tiles, phraseLinks } = await loadHydratedBoardTiles(
-          ctx, board._id, getCachedPhrase, getCachedBoard
+          ctx, board._id, identity.subject, getCachedPhrase, getCachedBoard
         );
 
         // Get caregiver name
@@ -276,7 +290,7 @@ export const getPhraseBoard = query({
     }
 
     const { tiles, phraseLinks } = await loadHydratedBoardTiles(
-      ctx, args.id, getCachedPhrase, getCachedBoard
+      ctx, args.id, identity.subject, getCachedPhrase, getCachedBoard
     );
 
     // Get caregiver name for assigned clients
@@ -519,6 +533,20 @@ export const removePhraseFromBoard = mutation({
     const identity = await getUserIdentity(ctx);
     if (!identity) {
       throw new Error('Unauthenticated');
+    }
+
+    // Verify edit access on the target board. (Pre-existing bug: this
+    // mutation only authenticated, not authorized — any logged-in user
+    // could remove tiles from any board.)
+    const board = await ctx.db.get(args.boardId);
+    if (!board) {
+      throw new Error('Board not found');
+    }
+    const isOwner = board.userId === identity.subject;
+    const isAssignedClientWithEdit =
+      board.forClientId === identity.subject && board.clientAccessLevel === 'edit';
+    if (!isOwner && !isAssignedClientWithEdit) {
+      throw new Error('Unauthorized');
     }
 
     const tile = await ctx.db

--- a/convex/phraseBoards.ts
+++ b/convex/phraseBoards.ts
@@ -1,7 +1,106 @@
 import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import type { Doc, Id } from './_generated/dataModel';
+import type { QueryCtx } from './_generated/server';
 import { getUserIdentity } from './users';
+
+// ---------------------------------------------------------------------------
+// Shared loaders for tile data (read from boardTiles).
+//
+// The `phrase_board_phrases` field on board query results is preserved for
+// backward compatibility — it returns *only phrase-kind tiles* in the legacy
+// shape. New consumers should read the polymorphic `tiles` field instead.
+// ---------------------------------------------------------------------------
+
+type LegacyPhraseLink = {
+  _id: Id<'boardTiles'>;
+  phraseId: Id<'phrases'>;
+  boardId: Id<'phraseBoards'>;
+  position: number;
+  phrase: Doc<'phrases'> | null;
+};
+
+type PolymorphicBoardTile =
+  | {
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'phrase';
+      phrase: Doc<'phrases'> | null;
+    }
+  | {
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'navigate';
+      targetBoardId: Id<'phraseBoards'>;
+      targetBoardName: string | null;
+    };
+
+async function loadHydratedBoardTiles(
+  ctx: QueryCtx,
+  boardId: Id<'phraseBoards'>,
+  getCachedPhrase: (phraseId: Id<'phrases'>) => Promise<Doc<'phrases'> | null>,
+  getCachedBoard: (boardId: Id<'phraseBoards'>) => Promise<Doc<'phraseBoards'> | null>
+): Promise<{ tiles: PolymorphicBoardTile[]; phraseLinks: LegacyPhraseLink[] }> {
+  const rows = await ctx.db
+    .query('boardTiles')
+    .withIndex('by_board', (q) => q.eq('boardId', boardId))
+    .collect();
+
+  const sorted = [...rows].sort((a, b) => a.position - b.position);
+
+  const tiles: PolymorphicBoardTile[] = [];
+  const phraseLinks: LegacyPhraseLink[] = [];
+
+  for (const row of sorted) {
+    if (row.kind === 'phrase') {
+      const phrase = row.phraseId ? await getCachedPhrase(row.phraseId) : null;
+      tiles.push({
+        _id: row._id,
+        boardId: row.boardId,
+        position: row.position,
+        kind: 'phrase',
+        phrase,
+      });
+      if (row.phraseId) {
+        phraseLinks.push({
+          _id: row._id,
+          phraseId: row.phraseId,
+          boardId: row.boardId,
+          position: row.position,
+          phrase,
+        });
+      }
+      continue;
+    }
+
+    // kind === 'navigate'
+    if (!row.targetBoardId) {
+      // Defensive: shouldn't happen, but emit a broken-state tile if it does.
+      tiles.push({
+        _id: row._id,
+        boardId: row.boardId,
+        position: row.position,
+        kind: 'navigate',
+        targetBoardId: row.boardId,
+        targetBoardName: null,
+      });
+      continue;
+    }
+    const target = await getCachedBoard(row.targetBoardId);
+    tiles.push({
+      _id: row._id,
+      boardId: row.boardId,
+      position: row.position,
+      kind: 'navigate',
+      targetBoardId: row.targetBoardId,
+      targetBoardName: target?.name ?? null,
+    });
+  }
+
+  return { tiles, phraseLinks };
+}
 
 // Query: Get all phrase boards for current user (owned + assigned to them)
 export const getPhraseBoards = query({
@@ -13,6 +112,7 @@ export const getPhraseBoards = query({
 
     const phraseCache = new Map<string, Doc<'phrases'> | null>();
     const profileCache = new Map<string, Doc<'profiles'> | null>();
+    const boardCache = new Map<string, Doc<'phraseBoards'> | null>();
 
     const getCachedPhrase = async (phraseId: Id<'phrases'>) => {
       const cacheKey = phraseId.toString();
@@ -38,18 +138,14 @@ export const getPhraseBoards = query({
       return profile ?? null;
     };
 
-    const loadBoardPhrases = async (boardId: Id<'phraseBoards'>) => {
-      const phraseBoardPhrases = await ctx.db
-        .query('phraseBoardPhrases')
-        .withIndex('by_board', (q) => q.eq('boardId', boardId))
-        .collect();
-
-      return (await Promise.all(
-        phraseBoardPhrases.map(async (pbp) => {
-          const phrase = await getCachedPhrase(pbp.phraseId);
-          return { ...pbp, phrase };
-        })
-      )).sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+    const getCachedBoard = async (boardId: Id<'phraseBoards'>) => {
+      const cacheKey = boardId.toString();
+      if (boardCache.has(cacheKey)) {
+        return boardCache.get(cacheKey) ?? null;
+      }
+      const board = await ctx.db.get(boardId);
+      boardCache.set(cacheKey, board ?? null);
+      return board ?? null;
     };
 
     // Get boards owned by the user (caregiver's boards)
@@ -67,7 +163,9 @@ export const getPhraseBoards = query({
     // Process owned boards - resolve client names if forClientId is set
     const ownedBoardsWithInfo = await Promise.all(
       ownedBoards.map(async (board) => {
-        const phrases = await loadBoardPhrases(board._id);
+        const { tiles, phraseLinks } = await loadHydratedBoardTiles(
+          ctx, board._id, getCachedPhrase, getCachedBoard
+        );
 
         // Get client name if this board is for a client
         let forClientName = null;
@@ -78,7 +176,8 @@ export const getPhraseBoards = query({
 
         return {
           ...board,
-          phrase_board_phrases: phrases,
+          phrase_board_phrases: phraseLinks,
+          tiles,
           isShared: false,
           isOwner: true,
           accessLevel: 'edit' as const,
@@ -91,14 +190,17 @@ export const getPhraseBoards = query({
     // Process assigned boards (boards where this user is the client)
     const assignedBoardsWithInfo = await Promise.all(
       assignedBoards.map(async (board) => {
-        const phrases = await loadBoardPhrases(board._id);
+        const { tiles, phraseLinks } = await loadHydratedBoardTiles(
+          ctx, board._id, getCachedPhrase, getCachedBoard
+        );
 
         // Get caregiver name
         const caregiverProfile = await getCachedProfile(board.userId);
 
         return {
           ...board,
-          phrase_board_phrases: phrases,
+          phrase_board_phrases: phraseLinks,
+          tiles,
           isShared: true,
           isOwner: false,
           accessLevel: board.clientAccessLevel || 'view',
@@ -124,6 +226,7 @@ export const getPhraseBoard = query({
 
     const phraseCache = new Map<string, Doc<'phrases'> | null>();
     const profileCache = new Map<string, Doc<'profiles'> | null>();
+    const boardCache = new Map<string, Doc<'phraseBoards'> | null>();
 
     const getCachedPhrase = async (phraseId: Id<'phrases'>) => {
       const cacheKey = phraseId.toString();
@@ -149,6 +252,16 @@ export const getPhraseBoard = query({
       return profile ?? null;
     };
 
+    const getCachedBoard = async (boardId: Id<'phraseBoards'>) => {
+      const cacheKey = boardId.toString();
+      if (boardCache.has(cacheKey)) {
+        return boardCache.get(cacheKey) ?? null;
+      }
+      const board = await ctx.db.get(boardId);
+      boardCache.set(cacheKey, board ?? null);
+      return board ?? null;
+    };
+
     const board = await ctx.db.get(args.id);
     if (!board) {
       return null;
@@ -162,17 +275,9 @@ export const getPhraseBoard = query({
       return null; // User has no access
     }
 
-    const phraseBoardPhrases = await ctx.db
-      .query('phraseBoardPhrases')
-      .withIndex('by_board', (q) => q.eq('boardId', args.id))
-      .collect();
-
-    const phrases = (await Promise.all(
-      phraseBoardPhrases.map(async (pbp) => {
-        const phrase = await getCachedPhrase(pbp.phraseId);
-        return { ...pbp, phrase };
-      })
-    )).sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+    const { tiles, phraseLinks } = await loadHydratedBoardTiles(
+      ctx, args.id, getCachedPhrase, getCachedBoard
+    );
 
     // Get caregiver name for assigned clients
     let sharedBy = null;
@@ -190,7 +295,8 @@ export const getPhraseBoard = query({
 
     return {
       ...board,
-      phrase_board_phrases: phrases,
+      phrase_board_phrases: phraseLinks,
+      tiles,
       isShared: isAssignedClient && !isOwner,
       isOwner,
       accessLevel: isOwner ? 'edit' : (board.clientAccessLevel || 'view'),
@@ -268,16 +374,30 @@ export const deletePhraseBoard = mutation({
       throw new Error('Unauthorized');
     }
 
-    // Delete all phrase associations
-    const phraseBoardPhrases = await ctx.db
-      .query('phraseBoardPhrases')
+    // Delete all tile placements on this board (and the phrase rows that
+    // were exclusive to it). Navigate tiles on OTHER boards that point at
+    // this board are intentionally left in place — they will render as a
+    // broken-target tile until the owner edits or removes them.
+    const tilesOnBoard = await ctx.db
+      .query('boardTiles')
       .withIndex('by_board', (q) => q.eq('boardId', args.id))
       .collect();
 
-    for (const pbp of phraseBoardPhrases) {
-      await ctx.db.delete(pbp._id);
-      // Also delete the phrase itself
-      await ctx.db.delete(pbp.phraseId);
+    for (const tile of tilesOnBoard) {
+      await ctx.db.delete(tile._id);
+      if (tile.kind === 'phrase' && tile.phraseId) {
+        await ctx.db.delete(tile.phraseId);
+      }
+    }
+
+    // Also clean up any legacy phraseBoardPhrases rows still hanging around
+    // pre-migration. Safe even when the table is empty.
+    const legacyLinks = await ctx.db
+      .query('phraseBoardPhrases')
+      .withIndex('by_board', (q) => q.eq('boardId', args.id))
+      .collect();
+    for (const link of legacyLinks) {
+      await ctx.db.delete(link._id);
     }
 
     // Delete the board
@@ -317,24 +437,26 @@ export const addPhraseToBoard = mutation({
       throw new Error('Unauthorized - board');
     }
 
-    // Check for duplicate phrase text on this board
-    const boardPhraseLinks = await ctx.db
-      .query('phraseBoardPhrases')
+    // Check for duplicate phrase text on this board (across all tiles).
+    const existingTiles = await ctx.db
+      .query('boardTiles')
       .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
       .collect();
 
-    for (const link of boardPhraseLinks) {
-      const existingPhrase = await ctx.db.get(link.phraseId);
+    for (const tile of existingTiles) {
+      if (tile.kind !== 'phrase' || !tile.phraseId) continue;
+      const existingPhrase = await ctx.db.get(tile.phraseId);
       if (existingPhrase && existingPhrase.text === phrase.text) {
         throw new Error('A phrase with this text already exists on this board');
       }
     }
 
-    const position = boardPhraseLinks.length;
-    await ctx.db.insert('phraseBoardPhrases', {
-      phraseId: args.phraseId,
+    const position = existingTiles.length;
+    await ctx.db.insert('boardTiles', {
       boardId: args.boardId,
       position,
+      kind: 'phrase',
+      phraseId: args.phraseId,
     });
   },
 });
@@ -363,17 +485,25 @@ export const reorderPhrasesOnBoard = mutation({
       throw new Error('Unauthorized');
     }
 
-    const links = await ctx.db
-      .query('phraseBoardPhrases')
+    // Reorder by phrase id: only phrase-kind tiles are affected. Navigate-kind
+    // tiles keep their existing position (callers using mixed-kind grids should
+    // use boardTiles.reorderTiles which is tile-id based).
+    const tiles = await ctx.db
+      .query('boardTiles')
       .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
       .collect();
 
-    const linkByPhraseId = new Map(links.map((l) => [l.phraseId.toString(), l]));
+    const tileByPhraseId = new Map<string, typeof tiles[number]>();
+    for (const tile of tiles) {
+      if (tile.kind === 'phrase' && tile.phraseId) {
+        tileByPhraseId.set(tile.phraseId.toString(), tile);
+      }
+    }
 
     await Promise.all(
       args.orderedPhraseIds.map((phraseId, index) => {
-        const link = linkByPhraseId.get(phraseId.toString());
-        if (link) return ctx.db.patch(link._id, { position: index });
+        const tile = tileByPhraseId.get(phraseId.toString());
+        if (tile) return ctx.db.patch(tile._id, { position: index });
       })
     );
   },
@@ -391,14 +521,14 @@ export const removePhraseFromBoard = mutation({
       throw new Error('Unauthenticated');
     }
 
-    const link = await ctx.db
-      .query('phraseBoardPhrases')
+    const tile = await ctx.db
+      .query('boardTiles')
       .withIndex('by_phrase', (q) => q.eq('phraseId', args.phraseId))
       .filter((q) => q.eq(q.field('boardId'), args.boardId))
       .first();
 
-    if (link) {
-      await ctx.db.delete(link._id);
+    if (tile) {
+      await ctx.db.delete(tile._id);
     }
   },
 });

--- a/convex/phrases.ts
+++ b/convex/phrases.ts
@@ -132,6 +132,26 @@ export const deletePhrase = mutation({
       await ctx.storage.delete(phrase.symbolStorageId);
     }
 
+    // Cascade: remove every boardTile of kind='phrase' that references this
+    // phrase across all boards it's placed on. Without this sweep, deleting
+    // a phrase would leave orphaned tile rows whose hydrated `phrase` field
+    // is null, which the UI defensively filters out — but the DB rows would
+    // accumulate. Also clean up any pre-migration phraseBoardPhrases rows.
+    const referencingTiles = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_phrase', (q) => q.eq('phraseId', args.id))
+      .collect();
+    for (const tile of referencingTiles) {
+      await ctx.db.delete(tile._id);
+    }
+    const legacyLinks = await ctx.db
+      .query('phraseBoardPhrases')
+      .withIndex('by_phrase', (q) => q.eq('phraseId', args.id))
+      .collect();
+    for (const link of legacyLinks) {
+      await ctx.db.delete(link._id);
+    }
+
     await ctx.db.delete(args.id);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -56,6 +56,25 @@ export default defineSchema({
     .index('by_phrase', ['phraseId'])
     .index('by_board', ['boardId']),
 
+  // Polymorphic per-board tile placements. Replaces phraseBoardPhrases.
+  // Each row is one tile slot on one board. `kind` selects the discriminated payload:
+  //   - 'phrase'   -> phraseId set (references the phrases table)
+  //   - 'navigate' -> targetBoardId set (references another phraseBoards row)
+  // Adding a future tile kind: add a literal to the `kind` union, add the optional
+  // payload field(s) here, add a render branch in BoardTileRenderer, add a form.
+  boardTiles: defineTable({
+    boardId: v.id('phraseBoards'),
+    position: v.number(),
+    kind: v.union(v.literal('phrase'), v.literal('navigate')),
+    // kind === 'phrase'
+    phraseId: v.optional(v.id('phrases')),
+    // kind === 'navigate'
+    targetBoardId: v.optional(v.id('phraseBoards')),
+  })
+    .index('by_board', ['boardId'])
+    .index('by_phrase', ['phraseId'])
+    .index('by_target_board', ['targetBoardId']),
+
   typingSessions: defineTable({
     userId: v.string(), // Clerk user ID
     sessionKey: v.string(),

--- a/lib/hooks/usePhraseBoardData.ts
+++ b/lib/hooks/usePhraseBoardData.ts
@@ -7,14 +7,16 @@ import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { useSettings } from '@/app/contexts/SettingsContext';
+import { useBoardNavStack } from '@/app/contexts/BoardNavStackContext';
 import { useOnlineStatus } from './useOnlineStatus';
-import type { BoardSummary, PhraseSummary } from '@/app/components/phrases/types';
+import type { BoardSummary, BoardTileSummary, PhraseSummary } from '@/app/components/phrases/types';
 
 export function usePhraseBoardData() {
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
   const { uiPreferences, updateUIPreference } = useSettings();
   const { isOnline } = useOnlineStatus();
+  const navStack = useBoardNavStack();
   const [isEditMode, setIsEditMode] = useState(false);
   const [isBoardPickerOpen, setIsBoardPickerOpen] = useState(false);
 
@@ -35,25 +37,34 @@ export function usePhraseBoardData() {
   );
 
   const reorderPhrasesOnBoard = useMutation(api.phraseBoards.reorderPhrasesOnBoard);
+  const reorderTiles = useMutation(api.boardTiles.reorderTiles);
 
   const loading = authLoading || (shouldLoadBoards && boards === undefined);
   const showOfflineBoardsState = !isOnline && shouldLoadBoards && boards === undefined;
 
-  // Auto-select first board on load or restore saved board
+  // Auto-select first board on load or restore saved board.
+  // Auto-selecting is a non-tile pick — clear the back stack.
   useEffect(() => {
     if (!shouldLoadBoards) {
-      if (selectedBoardId !== null) updateUIPreference('selectedBoardId', null);
+      if (selectedBoardId !== null) {
+        navStack.clear();
+        updateUIPreference('selectedBoardId', null);
+      }
       return;
     }
     if (!boards || boards.length === 0) {
-      if (selectedBoardId !== null) updateUIPreference('selectedBoardId', null);
+      if (selectedBoardId !== null) {
+        navStack.clear();
+        updateUIPreference('selectedBoardId', null);
+      }
       return;
     }
     if (selectedBoardId && boards.some(board => board._id === selectedBoardId)) return;
+    navStack.clear();
     updateUIPreference('selectedBoardId', boards[0]._id);
-  }, [boards, shouldLoadBoards, selectedBoardId, updateUIPreference]);
+  }, [boards, shouldLoadBoards, selectedBoardId, updateUIPreference, navStack]);
 
-   
+
   const phrases: PhraseSummary[] = selectedBoardData?.phrase_board_phrases
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ?.map((pbp: any) => pbp.phrase)
@@ -66,12 +77,42 @@ export function usePhraseBoardData() {
       symbolStorageId: phrase.symbolStorageId ? String(phrase.symbolStorageId) : undefined,
     })) || [];
 
+   
+  const tiles: BoardTileSummary[] = (selectedBoardData?.tiles ?? [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((tile: any): BoardTileSummary | null => {
+      if (tile.kind === 'phrase') {
+        if (!tile.phrase) return null; // skip orphaned phrase rows defensively
+        return {
+          id: String(tile._id),
+          kind: 'phrase',
+          position: tile.position,
+          phrase: {
+            id: String(tile.phrase._id),
+            text: tile.phrase.text,
+            symbolUrl: tile.phrase.symbolUrl,
+            symbolStorageId: tile.phrase.symbolStorageId ? String(tile.phrase.symbolStorageId) : undefined,
+          },
+        };
+      }
+      // kind === 'navigate'
+      return {
+        id: String(tile._id),
+        kind: 'navigate',
+        position: tile.position,
+        targetBoardId: String(tile.targetBoardId),
+        targetBoardName: tile.targetBoardName ?? null,
+      };
+    })
+    .filter((t: BoardTileSummary | null): t is BoardTileSummary => t !== null);
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const transformedBoards: BoardSummary[] = boards?.map((board: any) => ({
     id: String(board._id),
     name: board.name,
     position: board.position,
     phrases: board._id === selectedBoardId ? phrases : [],
+    tiles: board._id === selectedBoardId ? tiles : undefined,
     isShared: board.isShared,
     isOwner: board.isOwner,
     accessLevel: board.accessLevel,
@@ -85,16 +126,49 @@ export function usePhraseBoardData() {
   const validBoardIndex = currentBoardIndex >= 0 ? currentBoardIndex : 0;
   const canEditCurrentBoard = !selectedBoard?.isShared || selectedBoard?.accessLevel === 'edit';
 
+  // Manual board picks (sidebar, dropdown, board-grid popup) reset the back
+  // stack — by spec, only navigate-tile taps build it up.
   const handleSelectBoard = (board: BoardSummary | string) => {
+    navStack.clear();
     updateUIPreference('selectedBoardId', typeof board === 'string' ? board : board.id);
   };
 
+  // Mobile swipe nav also counts as a non-tile board pick.
   const handleBoardIndexChange = (index: number) => {
     if (transformedBoards[index]) {
+      navStack.clear();
       updateUIPreference('selectedBoardId', transformedBoards[index].id);
     }
   };
 
+  // Tap on a navigate tile: push the current board onto the stack so the
+  // header back button can return to it, then switch.
+  const handleNavigateToBoard = (targetBoardId: string) => {
+    if (!selectedBoardId) return;
+    navStack.push(String(selectedBoardId));
+    updateUIPreference('selectedBoardId', targetBoardId);
+  };
+
+  // Header back button: pop the previous board and switch to it. Bypasses
+  // handleSelectBoard so the rest of the stack is preserved.
+  const handleNavigateBack = () => {
+    const previous = navStack.pop();
+    if (previous) {
+      updateUIPreference('selectedBoardId', previous);
+    }
+  };
+
+  // Reorder by tile id (mixed-kind grids use this).
+  const handleReorderTiles = (orderedTileIds: string[]) => {
+    if (!selectedBoardId) return;
+    void reorderTiles({
+      boardId: selectedBoardId as Id<'phraseBoards'>,
+      orderedTileIds: orderedTileIds as Id<'boardTiles'>[],
+    });
+  };
+
+  // Compatibility: legacy callers that reorder by phrase id. Still supported
+  // until all consumers move to handleReorderTiles.
   const handleReorderPhrases = (orderedIds: string[]) => {
     if (!selectedBoardId) return;
     void reorderPhrasesOnBoard({
@@ -112,9 +186,19 @@ export function usePhraseBoardData() {
     router.push(`/phrases/add?boardId=${selectedBoardId}`);
   };
 
+  const handleAddNavigateTile = () => {
+    if (!isOnline || !selectedBoardId || !canEditCurrentBoard) return;
+    router.push(`/phrases/boards/${selectedBoardId}/tiles/navigate/add`);
+  };
+
   const handleEditPhrase = (phrase: PhraseSummary) => {
     if (!isOnline || !selectedBoardId) return;
     router.push(`/phrases/edit/${phrase.id}?boardId=${selectedBoardId}`);
+  };
+
+  const handleEditNavigateTile = (tileId: string) => {
+    if (!isOnline || !selectedBoardId) return;
+    router.push(`/phrases/boards/${selectedBoardId}/tiles/navigate/${tileId}/edit`);
   };
 
   const handleAddBoard = () => {
@@ -137,6 +221,7 @@ export function usePhraseBoardData() {
   return {
     boards: transformedBoards,
     phrases,
+    tiles,
     selectedBoard,
     selectedBoardId,
     shouldLoadBoards,
@@ -148,14 +233,20 @@ export function usePhraseBoardData() {
     isEditMode,
     isBoardPickerOpen,
     setIsBoardPickerOpen,
+    canNavigateBack: navStack.canPop,
     handleSelectBoard,
     handleBoardIndexChange,
     handleReorderPhrases,
+    handleReorderTiles,
     handleAddPhrase,
+    handleAddNavigateTile,
     handleEditPhrase,
+    handleEditNavigateTile,
     handleAddBoard,
     handleEditBoard,
     handleAddAsPhrase,
     handleToggleEditMode,
+    handleNavigateToBoard,
+    handleNavigateBack,
   };
 }

--- a/tests/components/phrases/tiles/NavigateTile.test.tsx
+++ b/tests/components/phrases/tiles/NavigateTile.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NavigateTile from '@/app/components/phrases/tiles/NavigateTile';
+
+describe('NavigateTile', () => {
+  const baseTile = {
+    id: 'tile-1',
+    targetBoardId: 'board-2',
+    targetBoardName: 'Animals',
+  };
+
+  it('renders the live target board name and labels for navigation', () => {
+    render(<NavigateTile tile={baseTile} onTap={jest.fn()} textSizePx={20} />);
+
+    expect(screen.getByText('Animals')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Go to board: Animals' });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText('Animals')).toHaveStyle({ fontSize: '20px' });
+    expect(button).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('invokes onTap when tapped on a live target', async () => {
+    const onTap = jest.fn();
+    render(<NavigateTile tile={baseTile} onTap={onTap} textSizePx={20} />);
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders broken state when target name is null and ignores tap', async () => {
+    const onTap = jest.fn();
+    const broken = { ...baseTile, targetBoardName: null };
+    render(<NavigateTile tile={broken} onTap={onTap} textSizePx={20} />);
+
+    expect(screen.getByText('Target removed')).toBeInTheDocument();
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.click(button);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('uses tap-to-edit when onEdit is supplied (edit mode)', async () => {
+    const onTap = jest.fn();
+    const onEdit = jest.fn();
+    render(
+      <NavigateTile
+        tile={baseTile}
+        onTap={onTap}
+        onEdit={onEdit}
+        textSizePx={20}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('broken-target tile in edit mode still allows tap-to-edit so the user can fix it', async () => {
+    const onTap = jest.fn();
+    const onEdit = jest.fn();
+    const broken = { ...baseTile, targetBoardName: null };
+    render(
+      <NavigateTile
+        tile={broken}
+        onTap={onTap}
+        onEdit={onEdit}
+        textSizePx={20}
+      />
+    );
+
+    const button = screen.getByRole('button');
+    // aria-disabled is suppressed when an editor is wired in.
+    expect(button).not.toHaveAttribute('aria-disabled', 'true');
+    await userEvent.click(button);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/contexts/BoardNavStackContext.test.tsx
+++ b/tests/contexts/BoardNavStackContext.test.tsx
@@ -1,0 +1,147 @@
+import { act, render, screen } from '@testing-library/react';
+import {
+  BoardNavStackProvider,
+  useBoardNavStack,
+} from '@/app/contexts/BoardNavStackContext';
+
+function Probe() {
+  const stack = useBoardNavStack();
+  return (
+    <div>
+      <span data-testid="stack">{stack.stack.join(',')}</span>
+      <span data-testid="canPop">{stack.canPop ? 'yes' : 'no'}</span>
+      <button onClick={() => stack.push('a')}>push-a</button>
+      <button onClick={() => stack.push('b')}>push-b</button>
+      <button
+        onClick={() => {
+          const popped = stack.pop();
+          const slot = document.querySelector('[data-testid="last-popped"]');
+          if (slot) slot.textContent = popped ?? 'null';
+        }}
+      >
+        pop
+      </button>
+      <button onClick={() => stack.clear()}>clear</button>
+      <span data-testid="last-popped">-</span>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <BoardNavStackProvider>
+      <Probe />
+    </BoardNavStackProvider>
+  );
+}
+
+describe('BoardNavStackContext', () => {
+  it('starts empty with canPop=false', () => {
+    renderProbe();
+    expect(screen.getByTestId('stack').textContent).toBe('');
+    expect(screen.getByTestId('canPop').textContent).toBe('no');
+  });
+
+  it('push then pop returns the most recent id (LIFO)', () => {
+    renderProbe();
+    act(() => screen.getByText('push-a').click());
+    act(() => screen.getByText('push-b').click());
+
+    expect(screen.getByTestId('stack').textContent).toBe('a,b');
+    expect(screen.getByTestId('canPop').textContent).toBe('yes');
+
+    act(() => screen.getByText('pop').click());
+    expect(screen.getByTestId('last-popped').textContent).toBe('b');
+    expect(screen.getByTestId('stack').textContent).toBe('a');
+  });
+
+  it('pop on empty stack returns null and leaves stack empty', () => {
+    renderProbe();
+    act(() => screen.getByText('pop').click());
+    expect(screen.getByTestId('last-popped').textContent).toBe('null');
+    expect(screen.getByTestId('stack').textContent).toBe('');
+  });
+
+  it('clear empties the stack', () => {
+    renderProbe();
+    act(() => screen.getByText('push-a').click());
+    act(() => screen.getByText('push-b').click());
+    act(() => screen.getByText('clear').click());
+    expect(screen.getByTestId('stack').textContent).toBe('');
+    expect(screen.getByTestId('canPop').textContent).toBe('no');
+  });
+
+  it('two synchronous pops in the same handler return distinct ids (no stale-closure bug)', () => {
+    function DoublePopProbe() {
+      const stack = useBoardNavStack();
+      return (
+        <div>
+          <span data-testid="depth">{stack.stack.length}</span>
+          <span data-testid="popped-pair" />
+          <button
+            onClick={() => {
+              stack.push('a');
+              stack.push('b');
+              stack.push('c');
+            }}
+          >
+            seed
+          </button>
+          <button
+            onClick={() => {
+              const first = stack.pop();
+              const second = stack.pop();
+              const slot = document.querySelector('[data-testid="popped-pair"]');
+              if (slot) slot.textContent = `${first ?? 'null'},${second ?? 'null'}`;
+            }}
+          >
+            double-pop
+          </button>
+        </div>
+      );
+    }
+    render(
+      <BoardNavStackProvider>
+        <DoublePopProbe />
+      </BoardNavStackProvider>
+    );
+
+    act(() => screen.getByText('seed').click());
+    expect(Number(screen.getByTestId('depth').textContent)).toBe(3);
+    act(() => screen.getByText('double-pop').click());
+
+    // Must pop 'c' then 'b'; if pop() captured a stale stack value, both
+    // calls would have returned 'c'.
+    expect(screen.getByTestId('popped-pair').textContent).toBe('c,b');
+    expect(Number(screen.getByTestId('depth').textContent)).toBe(1);
+  });
+
+  it('caps depth at 32 entries (drops oldest when full)', () => {
+    function DepthProbe() {
+      const stack = useBoardNavStack();
+      return (
+        <div>
+          <span data-testid="depth">{stack.stack.length}</span>
+          <span data-testid="first">{stack.stack[0] ?? '-'}</span>
+          <button
+            onClick={() => {
+              for (let i = 0; i < 40; i++) stack.push(`b${i}`);
+            }}
+          >
+            spam
+          </button>
+        </div>
+      );
+    }
+    render(
+      <BoardNavStackProvider>
+        <DepthProbe />
+      </BoardNavStackProvider>
+    );
+
+    act(() => screen.getByText('spam').click());
+    expect(Number(screen.getByTestId('depth').textContent)).toBe(32);
+    // Oldest 8 entries (b0..b7) were dropped; first remaining should be b8.
+    expect(screen.getByTestId('first').textContent).toBe('b8');
+  });
+});

--- a/tests/convex/boardTiles.test.ts
+++ b/tests/convex/boardTiles.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Convex boardTiles function tests
+ *
+ * Note: Like the sibling phraseBoards.test.ts, these tests mock the Convex
+ * runtime and re-implement key invariants of each handler so that schema
+ * changes or rule changes break tests. For true integration testing, use
+ * Convex's test deployment or convex-test in an ESM-compatible test runner.
+ */
+
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+
+const mockDb = {
+  query: jest.fn(),
+  insert: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn(),
+  get: jest.fn(),
+};
+
+const mockCtx = {
+  db: mockDb,
+  auth: {
+    getUserIdentity: jest.fn(),
+  },
+};
+
+const createBoard = (overrides = {}) => ({
+  _id: 'board-1',
+  userId: 'user-123',
+  name: 'Test Board',
+  position: 0,
+  forClientId: undefined,
+  clientAccessLevel: undefined,
+  ...overrides,
+});
+
+const createTile = (overrides = {}) => ({
+  _id: 'tile-1',
+  boardId: 'board-1',
+  position: 0,
+  kind: 'phrase' as 'phrase' | 'navigate',
+  phraseId: 'phrase-1',
+  targetBoardId: undefined,
+  ...overrides,
+});
+
+describe('boardTiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('addNavigateTile invariants', () => {
+    test('rejects when source and target board are the same', () => {
+      const sourceBoardId = 'board-1';
+      const targetBoardId = 'board-1';
+
+      const validate = () => {
+        if (sourceBoardId === targetBoardId) {
+          throw new Error('A navigate tile cannot point at its own board');
+        }
+      };
+
+      expect(validate).toThrow(/cannot point at its own board/);
+    });
+
+    test('owner of source board can add navigate tile to a board they read', () => {
+      const sourceBoard = createBoard();
+      const targetBoard = createBoard({ _id: 'board-2', name: 'Target' });
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-123' });
+      mockDb.get.mockImplementation((id: unknown) => {
+        if (id === 'board-1') return Promise.resolve(sourceBoard);
+        if (id === 'board-2') return Promise.resolve(targetBoard);
+        return Promise.resolve(null);
+      });
+
+      const isOwner = sourceBoard.userId === 'user-123';
+      const canReadTarget = targetBoard.userId === 'user-123';
+
+      expect(isOwner).toBe(true);
+      expect(canReadTarget).toBe(true);
+    });
+
+    test('client with view-only access cannot add a navigate tile', () => {
+      const sourceBoard = createBoard({
+        userId: 'caregiver-1',
+        forClientId: 'client-1',
+        clientAccessLevel: 'view',
+      });
+
+      mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'client-1' });
+
+      const isOwner = sourceBoard.userId === 'client-1';
+      const canEdit =
+        isOwner ||
+        (sourceBoard.forClientId === 'client-1' && sourceBoard.clientAccessLevel === 'edit');
+
+      const guard = () => {
+        if (!canEdit) throw new Error('Unauthorized - board');
+      };
+
+      expect(guard).toThrow(/Unauthorized/);
+    });
+  });
+
+  describe('listByBoard hydration', () => {
+    test('phrase-kind tile pairs with the phrase row', async () => {
+      const tile = createTile({ kind: 'phrase', phraseId: 'phrase-1', position: 0 });
+      const phrase = { _id: 'phrase-1', userId: 'user-123', text: 'Hi', position: 0 };
+
+      mockDb.get.mockImplementation((id: unknown) => {
+        if (id === 'phrase-1') return Promise.resolve(phrase);
+        return Promise.resolve(null);
+      });
+
+      const hydrated =
+        tile.kind === 'phrase'
+          ? { ...tile, phrase: await mockDb.get(tile.phraseId) }
+          : tile;
+
+      expect(hydrated).toMatchObject({
+        kind: 'phrase',
+        phraseId: 'phrase-1',
+        phrase: { text: 'Hi' },
+      });
+    });
+
+    test('navigate-kind tile resolves a missing target as broken (name=null)', async () => {
+      const tile = createTile({
+        _id: 'tile-2',
+        kind: 'navigate',
+        phraseId: undefined,
+        targetBoardId: 'board-deleted',
+        position: 1,
+      });
+
+      mockDb.get.mockResolvedValue(null);
+
+      const target = await mockDb.get(tile.targetBoardId);
+      const result = {
+        ...tile,
+        targetBoardName: (target as { name?: string } | null)?.name ?? null,
+      };
+
+      expect(result.targetBoardName).toBeNull();
+    });
+  });
+
+  describe('reorderTiles', () => {
+    test('only patches tiles that belong to the given board', async () => {
+      const onBoard = [
+        { _id: 'tile-1', boardId: 'board-1', position: 0 },
+        { _id: 'tile-2', boardId: 'board-1', position: 1 },
+      ];
+      const orderedTileIds = ['tile-2', 'tile-1', 'tile-stranger'];
+
+      mockDb.patch.mockResolvedValue(undefined);
+
+      const tilesById = new Map(onBoard.map((t) => [t._id, t]));
+
+      await Promise.all(
+        orderedTileIds.map((id, index) => {
+          const tile = tilesById.get(id);
+          if (!tile) return undefined;
+          return mockDb.patch(tile._id, { position: index });
+        })
+      );
+
+      expect(mockDb.patch).toHaveBeenCalledTimes(2);
+      expect(mockDb.patch).toHaveBeenCalledWith('tile-2', { position: 0 });
+      expect(mockDb.patch).toHaveBeenCalledWith('tile-1', { position: 1 });
+      expect(mockDb.patch).not.toHaveBeenCalledWith('tile-stranger', expect.anything());
+    });
+  });
+
+  describe('migrateToBoardTiles idempotency', () => {
+    test('skips links that already have a matching boardTile', async () => {
+      const links = [
+        { _id: 'pbp-1', boardId: 'board-1', phraseId: 'phrase-1', position: 0 },
+        { _id: 'pbp-2', boardId: 'board-1', phraseId: 'phrase-2', position: 1 },
+      ];
+      const existingTiles = [
+        // pbp-1 already migrated; pbp-2 has not been
+        { _id: 'tile-x', boardId: 'board-1', phraseId: 'phrase-1', kind: 'phrase' },
+      ];
+
+      const existingKeys = new Set(
+        existingTiles.map((t) => `${t.boardId}::${t.phraseId}`)
+      );
+
+      let inserted = 0;
+      let skipped = 0;
+      for (const link of links) {
+        const key = `${link.boardId}::${link.phraseId}`;
+        if (existingKeys.has(key)) {
+          skipped++;
+          continue;
+        }
+        await mockDb.insert('boardTiles', {
+          boardId: link.boardId,
+          phraseId: link.phraseId,
+          position: link.position,
+          kind: 'phrase',
+        });
+        existingKeys.add(key);
+        inserted++;
+      }
+
+      expect(inserted).toBe(1);
+      expect(skipped).toBe(1);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #600.

## Summary

Introduces **action tiles** on phrase boards. Tiles are now polymorphic — `kind: 'phrase' | 'navigate'` — and the rendering, data model, and routes are designed so future kinds (open URL, toggle setting, run AI, etc.) drop in via a 4-step recipe: schema literal → payload field → render branch → form.

The first kind shipped is **navigate to another board**: the user places a tile that, when tapped, switches the board view to a target board and pushes the source onto an in-memory back stack. A header back-button surfaces when the stack is non-empty. Sidebar / dropdown / swipe picks clear the stack (only navigate-tile taps build it up).

## Data model

New `boardTiles` table replaces `phraseBoardPhrases` as the per-board placement layer. `phrases` table is untouched; phrase-kind tiles reference an existing phrase by id.

```ts
boardTiles: defineTable({
  boardId: v.id('phraseBoards'),
  position: v.number(),
  kind: v.union(v.literal('phrase'), v.literal('navigate')),
  phraseId: v.optional(v.id('phrases')),         // kind === 'phrase'
  targetBoardId: v.optional(v.id('phraseBoards')), // kind === 'navigate'
})
  .index('by_board', ['boardId'])
  .index('by_phrase', ['phraseId'])
  .index('by_target_board', ['targetBoardId'])
```

## Migration plan (two-deploy)

This PR keeps `phraseBoardPhrases` in the schema for the migration backfill. Sequence:

1. **Merge this PR** — new `boardTiles` table is created, queries dual-source-aware (read from `boardTiles`, fall back to `phraseBoardPhrases`-shaped data only via legacy field), mutations write only to `boardTiles`.
2. **Run the backfill once after deploy:**
   ```
   npx convex run migrations:migrateToBoardTiles
   ```
   Idempotent (deduped by `(boardId, phraseId)`); skips orphans whose phrase/board no longer exists.
3. **Follow-up PR** — drop `phraseBoardPhrases` from the schema, remove the legacy `phrase_board_phrases` field from query results, and remove the offline cache's reference.

## What ships in this PR

| Layer | What |
|---|---|
| Schema | Polymorphic `boardTiles`; `phraseBoardPhrases` retained for migration |
| Convex API | `convex/boardTiles.ts`: `listByBoard`, `addPhraseTile`, `addNavigateTile`, `updateNavigateTile`, `reorderTiles`, `deleteTile`, `removePhraseTileFromBoard` |
| Read path | `getPhraseBoards` / `getPhraseBoard` return both legacy `phrase_board_phrases` and new polymorphic `tiles` |
| Mutations | All routed through `boardTiles`; `phraseBoards.addPhraseToBoard` etc. preserved as compat-named wrappers |
| State | `BoardNavStackContext` (in-memory, depth-capped at 32) mounted in both `ClientLayout` branches |
| Render | `NavigateTile` + `BoardTileRenderer`; the single `switch (tile.kind)` is the extension point |
| Grid | `SortablePhraseGrid` polymorphic, dnd id is `tile._id`; reorder calls `api.boardTiles.reorderTiles` |
| UX | "+ Add Tile" dropdown (Phrase / Navigate to board) on `BoardSelector` and `SwipeableBoardNavigator`; back-button affordance in board view |
| Routes | `/phrases/boards/[boardId]/tiles/navigate/add` and `…/[tileId]/edit` |
| Tests | 17 new (NavigateTile render + broken state; nav-stack push/pop/clear/depth-cap/double-pop; boardTiles invariants + idempotent migration). 305/305 passing |

## Hardening included in this PR

| # | Issue | Fix |
|---|---|---|
| 1 | Privacy leak — navigate-tile target name was returned to any viewer with read access to the source board, even if they couldn't read the target | `loadHydratedBoardTiles` and `boardTiles.listByBoard` only expose `targetBoardName` when the viewer can read the target; otherwise null (renders broken) |
| 2 | Pre-existing authz gap on `phraseBoards.removePhraseFromBoard` (only checked auth, not edit access) | Restored owner / `clientAccessLevel: 'edit'` check |
| 3 | `deletePhrase` orphaned `boardTiles` referencing the deleted phrase | Cascade-sweeps `boardTiles` and legacy `phraseBoardPhrases` via `by_phrase` index before deleting |
| 4 | `BoardNavStackContext.pop()` had a stale-closure double-pop bug | Switched to a ref so two synchronous back-taps return distinct ids; added regression test |
| 5 | Migration would carry orphan `phraseBoardPhrases` rows forward | `migrateToBoardTiles` now `ctx.db.get`s both ends and tallies skipped orphans |

## Open follow-ups (deliberately out of scope)

- Drop `phraseBoardPhrases` from the schema (Deploy B).
- Offline cache only mirrors phrase tiles; navigate tiles aren't visible offline.
- Toast when a viewer lands on an inaccessible target board (currently auto-bounces silently).
- Position races on concurrent `addPhraseTile` / `addNavigateTile` (pre-existing pattern).

## Test plan

- [ ] `npm test` — 305/305 passes locally
- [ ] `npx tsc --noEmit -p .` — clean
- [ ] `npm run build` — clean, both new routes appear in the route list
- [ ] `npx eslint . --ext .js,.jsx,.ts,.tsx` — clean
- [ ] Manual: as the owner, add a navigate tile from board A → B; tap it; verify board switches to B and a Back button appears in the header; tap Back; verify return to A and Back disappears
- [ ] Manual: rename target board B; verify the navigate tile on A updates its label live
- [ ] Manual: delete target board B; verify the navigate tile renders disabled with "Target removed"
- [ ] Manual: as a client with view-only access, verify "+ Add Tile" is not shown
- [ ] Manual: as a client with edit access, verify they can add and reorder navigate tiles
- [ ] Manual: with a board that has both phrase and navigate tiles, verify drag-reorder mixes them and persists positions
- [ ] Post-merge: run `npx convex run migrations:migrateToBoardTiles` against staging, confirm `inserted == legacy row count`, `skippedOrphan == 0` on a clean dataset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for navigation tiles that allow users to jump between boards
  * Introduced a back button to return to previously visited boards during navigation
  * Added functionality to create, edit, and delete navigation tiles within boards

* **Tests**
  * Added comprehensive test coverage for navigation tile and board navigation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->