### PR TITLE
Make SW cache key unique per build

### DIFF
--- a/scripts/generate-sw.mjs
+++ b/scripts/generate-sw.mjs
@@ -1,12 +1,64 @@
+import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
 
-const template = readFileSync(new URL('../public/sw.template.js', import.meta.url), 'utf8');
-const output = template.replace('__SW_CACHE_VERSION__', version);
+/**
+ * Resolve a short commit SHA. We prefer Vercel's build-env SHA so previews
+ * and prod deploys stay consistent with the underlying commit; fall back to
+ * a local `git rev-parse` for local builds (and non-Vercel CI); finally
+ * fall back to a base-36 timestamp so the script never throws if it ends up
+ * running outside of a git checkout.
+ */
+function resolveShortSha() {
+  const vercelSha = process.env.VERCEL_GIT_COMMIT_SHA;
+  if (vercelSha) {
+    return vercelSha.slice(0, 7);
+  }
+
+  try {
+    const sha = execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    if (sha) return sha;
+  } catch {
+    // git not available or not a repository — fall through.
+  }
+
+  return Date.now().toString(36);
+}
+
+/**
+ * Detect uncommitted changes against HEAD. When the working tree is dirty
+ * we append a timestamp suffix to the cache key so every dev restart and
+ * every locally-built artifact (even on the same commit) gets a fresh
+ * service-worker cache, avoiding stale-asset surprises.
+ */
+function isWorkingTreeDirty() {
+  try {
+    execSync('git diff-index --quiet HEAD --', { stdio: 'ignore' });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+const shortSha = resolveShortSha();
+const baseKey = `${version}-${shortSha}`;
+const cacheKey = isWorkingTreeDirty()
+  ? `${baseKey}-${Date.now().toString(36)}`
+  : baseKey;
+
+const template = readFileSync(
+  new URL('../public/sw.template.js', import.meta.url),
+  'utf8'
+);
+const output = template.replace('__SW_CACHE_VERSION__', cacheKey);
 
 writeFileSync(new URL('../public/sw.js', import.meta.url), output);
 
-console.log(`SW cache key: sayit-shell-v${version}`);
+console.log(`SW cache key: sayit-shell-v${cacheKey}`);


### PR DESCRIPTION
Closes #606.

## Summary

Single-file change to `scripts/generate-sw.mjs`: the cache name baked into `public/sw.js` is now build-unique instead of just `sayit-shell-v<package.json#version>`.

## Why

Hotfix or content-only deploys between releases produced a byte-identical `sw.js`. The browser saw no new SW, install/activate didn't fire, and `cacheFirst` kept serving cached non-hashed assets (`/manifest.json`, `/icons/*`, `/favicon.ico`) and the cached `APP_SHELL` (`/`, `/offline`) from the previous version. The `activate` handler's old-cache cleanup is gated on the cache name changing — so it never ran.

## What

The script now:

1. Resolves a short commit SHA — `VERCEL_GIT_COMMIT_SHA` → `git rev-parse --short HEAD` → `Date.now().toString(36)` fallback.
2. Detects a dirty working tree via `git diff-index --quiet HEAD --`.
3. Composes the cache key:
   - **Clean tree**: `${version}-${shortSha}` — deterministic per commit, traceable in DevTools.
   - **Dirty tree**: `${version}-${shortSha}-${Date.now().toString(36)}` — always fresh on dev restarts and locally-built artifacts so a stale shell can't linger.

`public/sw.template.js` (single `__SW_CACHE_VERSION__` placeholder) and `app/register-pwa.tsx` (prod-only registration) are unchanged.

## Verification

- `node scripts/generate-sw.mjs` → `SW cache key: sayit-shell-v3.15.0-f04758c-moehe6w6` (dirty tree run during testing)
- `VERCEL_GIT_COMMIT_SHA=deadbeefcafebabe node scripts/generate-sw.mjs` → `SW cache key: sayit-shell-v3.15.0-deadbee-…` (env wins over git)
- `npm run build` runs the script as part of the pipeline (logs the cache key)
- `npx tsc --noEmit -p .` — clean
- `npx eslint scripts/generate-sw.mjs` — clean
- `npm test` — 313/313 pass

## Test plan

- [ ] CI green (`test-and-lint`)
- [ ] Vercel preview build logs show the new cache-key format with the preview's commit SHA
- [ ] After deploy, DevTools → Application → Service Workers shows a `sayit-shell-v<version>-<sha>` cache name; subsequent deploys produce a different cache name (visible in DevTools), confirming activate fired and old caches were cleared

## Out of scope

- Adding tests around the build script — single-file, three-step resolution; CI build already exercises it.
- Switching to a content-hash cache key.