### PR TITLE
release: v3.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.53",
         "@clerk/nextjs": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release **v3.16.0**.

## What's in this release

| # | Title |
|---|---|
| #600 / #601 | Action tiles on boards: navigate-to-board, polymorphic `boardTiles` table, in-memory back stack, add/edit pages, hardening (privacy filter, authz, cascade cleanup, migration orphan skip) |
| #602 / #603 | Convert BoardActionButtons popups to BottomSheet |
| #604 / #605 | Reusable `PageHeader` for add/edit pages (replaces ad-hoc BackButton + h1 boilerplate) |
| #606 / #607 | Make SW cache key unique per build (commit-SHA + dirty-tree timestamp suffix) |

## Required post-deploy step

Once `release.yml` finishes the **Deploy Convex functions** step, run the one-time backfill against prod Convex:

```
npx convex run migrations:migrateToBoardTiles --prod
```

This copies any remaining `phraseBoardPhrases` rows into the new `boardTiles` table (idempotent, dedup'd by `(boardId, phraseId)`, skips orphans). Without it, prod users see empty boards until it runs.

## Per release-checklist

- [x] Tests pass (`npm test` — 313/313)
- [x] Lint clean (`npx eslint . --fix` — no fixes needed)
- [x] Version bumped: 3.15.0 → 3.16.0 (commit `77ae75e`)
- [ ] CI green on this PR
- [ ] Merge → pull main → tag `v3.16.0` from `origin/main` → push tag (triggers release.yml)
- [ ] Run `migrateToBoardTiles --prod` after Convex functions deploy
- [ ] Close milestone v3.16.0