### PR TITLE
Fix scroll on phrase boards

### DIFF
--- a/app/components/home/AACTabs.tsx
+++ b/app/components/home/AACTabs.tsx
@@ -76,7 +76,7 @@ export default function AACTabs({ phrasesContent, typeContent }: AACTabsProps) {
               key="phrases"
               id="aac-tab-phrases"
               role="tabpanel"
-              className="absolute inset-0"
+              className="absolute inset-0 flex flex-col"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -182,7 +182,7 @@ export default function PhrasesTabContent({
 
   if (isMobile) {
     return (
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col min-h-0">
         <SwipeableBoardNavigator
           boards={boards}
           currentBoardIndex={validBoardIndex}

--- a/app/components/phrases/SwipeableBoardNavigator.tsx
+++ b/app/components/phrases/SwipeableBoardNavigator.tsx
@@ -84,7 +84,7 @@ export default function SwipeableBoardNavigator({
   const hasNext = currentBoardIndex < boards.length - 1;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col flex-1 min-h-0">
       {/* Board Header with Navigation */}
       <div className="flex items-center justify-between px-4 py-3 bg-surface rounded-t-2xl">
         {/* Previous Arrow - only show if multiple boards */}
@@ -184,6 +184,7 @@ export default function SwipeableBoardNavigator({
         <AnimatePresence mode="wait">
           <motion.div
             key={currentBoardIndex}
+            className="h-full flex flex-col"
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -20 }}


### PR DESCRIPTION
Closes #609.

## Summary

The board grid stopped scrolling once content + chrome exceeded the viewport. Four CSS-class fixes restore the constrained-height chain between `<main>` and the grid container's `flex-1 overflow-auto`.

## Changes

| File | Change |
|---|---|
| `app/components/home/AACTabs.tsx` | phrases tabpanel: `absolute inset-0` → `absolute inset-0 flex flex-col` (matches the type tabpanel) |
| `app/components/home/PhrasesTabContent.tsx` | mobile outer: `flex-1 flex flex-col` → `flex-1 flex flex-col min-h-0` |
| `app/components/phrases/SwipeableBoardNavigator.tsx` | outer wrapper: `flex flex-col` → `flex flex-col flex-1 min-h-0` |
| `app/components/phrases/SwipeableBoardNavigator.tsx` | inner board-content motion.div: added `className="h-full flex flex-col"` |

## Test plan

- [ ] `npm test` — 313/313 pass
- [ ] `npx tsc --noEmit -p .` — clean
- [ ] `npm run build` — clean
- [ ] `npx eslint . --ext .js,.jsx,.ts,.tsx` — clean
- [ ] Manual desktop: board with several rows of tiles → grid area scrolls; BoardSelector + PhraseBar stay above
- [ ] Manual mobile: same → grid scrolls inside swipeable area; horizontal swipe still switches boards
- [ ] After tapping a navigate tile (back row appears) → grid still scrolls; back row stays above
- [ ] Tab between Phrases / Type → no layout shift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout styling across tab panels and navigation components with enhanced flex layout utilities.
  * Improved layout behavior for mobile and desktop views through height constraint and flex sizing adjustments.
  * Refined responsive layout handling to ensure proper content stretching and scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->