### PR TITLE
release: v3.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.16.0",
+      "version": "3.16.1",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.53",
         "@clerk/nextjs": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch release **v3.16.1**.

## What's in this release

| # | Title |
|---|---|
| #609 / #610 | Fix scroll on phrase boards — restore the constrained-height chain between `<main>` and the inner grid container's `flex-1 overflow-auto` |

## Per release-checklist

- [x] Tests pass (`npm test` — 313/313)
- [x] Lint clean (`npx eslint . --fix` — no fixes needed)
- [x] Version bumped: 3.16.0 → 3.16.1 (commit `2de7fc0`)
- [ ] CI green on this PR
- [ ] Merge → pull main → tag `v3.16.1` from `origin/main` → push tag (triggers release.yml)
- [ ] Close milestone v3.16.1

## Migration

No data migration required for this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 3.16.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->