### PR TITLE
Fix NavigateTile white background on light-mode browsers

### DIFF
--- a/app/components/phrases/tiles/NavigateTile.tsx
+++ b/app/components/phrases/tiles/NavigateTile.tsx
@@ -118,7 +118,7 @@ export default function NavigateTile({
       ? 'bg-surface border-l-4 border-blue-400'
       : isBroken
         ? 'bg-surface border-2 border-dashed border-border opacity-60 cursor-not-allowed'
-        : 'bg-primary-50 dark:bg-primary-950/40 border-2 border-primary-400'}
+        : 'bg-surface border-2 border-primary-400'}
         ${className}`}
       onClick={handleClick}
       onTouchStart={handleTouchStart}


### PR DESCRIPTION
Closes #612.

## Summary

`NavigateTile`'s non-edit, non-broken state used `bg-primary-50 dark:bg-primary-950/40`. The app is dark-only via `:root` CSS variables in `app/globals.css` (no `dark` class strategy, no light-theme branch). Tailwind's `dark:` variant defaults to media-query, so users on a light-mode OS got `bg-primary-50` (`#f0fdfa`, near-white) while every other surface around them rendered dark. Visual mismatch.

## Change

`app/components/phrases/tiles/NavigateTile.tsx`:

```diff
- 'bg-primary-50 dark:bg-primary-950/40 border-2 border-primary-400'
+ 'bg-surface border-2 border-primary-400'
```

Visual differentiation now relies on `border-primary-400` and the arrow icon, matching PhraseTile's surface.

## Test plan

- [ ] `npm test` — 313/313 pass
- [ ] `npx tsc --noEmit -p .` — clean
- [ ] `npm run build` — clean
- [ ] `npx eslint . --ext .js,.jsx,.ts,.tsx` — clean
- [ ] Manual: NavigateTile renders with the same dark surface as PhraseTile, with the teal border + arrow icon for differentiation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated NavigateTile component background color to use the surface theme, providing improved visual consistency with the app's design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->