### PR TITLE
release: v3.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.16.1",
+      "version": "3.16.2",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.53",
         "@clerk/nextjs": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch release **v3.16.2**.

## What's in this release

| # | Title |
|---|---|
| #612 / #613 | Fix NavigateTile white background on light-mode browsers (drop the `dark:` variant; align with `bg-surface`) |

## Per release-checklist

- [x] Tests pass (`npm test` — 313/313)
- [x] Lint clean (`npx eslint . --fix` — no fixes needed)
- [x] Version bumped: 3.16.1 → 3.16.2 (commit `4008552`)
- [ ] CI green on this PR
- [ ] Merge → pull main → tag `v3.16.2` from `origin/main` → push tag (triggers release.yml)
- [ ] Close milestone v3.16.2

## Migration

No data migration required.