### PR TITLE
Add copy/paste bottom sheet to typing page

### DIFF
--- a/app/components/composer/Composer.tsx
+++ b/app/components/composer/Composer.tsx
@@ -16,6 +16,7 @@ import ActionPromptBanner from '../typing/ActionPromptBanner';
 import TabBar from '../typing-tabs/TabBar';
 import TabManagementSheet from '../typing-tabs/TabManagementSheet';
 import LiveTypingBottomSheet from '../live-typing/LiveTypingBottomSheet';
+import CopyPasteBottomSheet from './CopyPasteBottomSheet';
 import type { ComposerProps } from './types';
 
 export default function Composer({
@@ -38,6 +39,7 @@ export default function Composer({
   const [showTabList, setShowTabList] = useState(false);
   const [showLiveTypingSheet, setShowLiveTypingSheet] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [isCopyPasteOpen, setCopyPasteOpen] = useState(false);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { settings } = useSettings();
@@ -104,6 +106,28 @@ export default function Composer({
     }
     setShowLiveTypingSheet(true);
   }, [actions]);
+
+  // Insert clipboard text at the textarea caret (or append if no selection).
+  // Routes through `handleTextChange` so scroll capture, undo reset, and the
+  // tab-store write all run as they would for any other edit.
+  const handleClipboardPaste = useCallback((pasted: string) => {
+    const el = inputRef.current;
+    if (!el) {
+      handleTextChange(currentText + pasted);
+      return;
+    }
+    const start = el.selectionStart ?? currentText.length;
+    const end = el.selectionEnd ?? currentText.length;
+    const next = currentText.slice(0, start) + pasted + currentText.slice(end);
+    handleTextChange(next);
+    // After React rerenders with the new value, restore the caret to the end
+    // of the inserted region so the user can continue typing where they left off.
+    requestAnimationFrame(() => {
+      el.focus();
+      const caret = start + pasted.length;
+      el.setSelectionRange(caret, caret);
+    });
+  }, [currentText, handleTextChange]);
 
   // Banner content — portaled on mobile, inline on desktop
   const bannerContent = (
@@ -178,6 +202,7 @@ export default function Composer({
               suggestionsCount={suggestionsCount}
               onSuggestionsOpen={() => setShowSuggestions(true)}
               suggestionsEnabled={!!replySuggestions && !!actions.user && actions.isOnline}
+              onCopyPasteOpen={() => setCopyPasteOpen(true)}
             />
             {replySuggestions && (
               <SuggestionsPopover
@@ -225,6 +250,14 @@ export default function Composer({
           onEndSession={async () => { await actions.endLiveTypingSession(); }}
         />
       )}
+
+      {/* Copy / Paste sheet */}
+      <CopyPasteBottomSheet
+        isOpen={isCopyPasteOpen}
+        onClose={() => setCopyPasteOpen(false)}
+        currentText={currentText}
+        onPaste={handleClipboardPaste}
+      />
     </>
   );
 }

--- a/app/components/composer/ComposerSidebar.tsx
+++ b/app/components/composer/ComposerSidebar.tsx
@@ -7,6 +7,7 @@ import {
   ArrowPathIcon,
   ShareIcon,
   BookmarkIcon,
+  ClipboardIcon,
   LightBulbIcon,
   SpeakerWaveIcon,
   StopIcon,
@@ -37,6 +38,8 @@ interface ComposerSidebarProps {
   suggestionsCount: number;
   onSuggestionsOpen: () => void;
   suggestionsEnabled: boolean;
+  // Copy / Paste
+  onCopyPasteOpen: () => void;
 }
 
 // Shared base classes — every icon tile fills its grid cell as a square.
@@ -64,6 +67,7 @@ export default function ComposerSidebar({
   suggestionsCount,
   onSuggestionsOpen,
   suggestionsEnabled,
+  onCopyPasteOpen,
 }: ComposerSidebarProps) {
   const [showToneSheet, setShowToneSheet] = useState(false);
   const speakDisabled = !isAvailable || !currentText.trim();
@@ -169,6 +173,18 @@ export default function ComposerSidebar({
       </button>
     );
   }
+
+  // Copy / Paste — pink tile (a fifth accent so it's distinct from the others)
+  iconButtons.push(
+    <button
+      key="copy-paste"
+      onClick={onCopyPasteOpen}
+      className={`${TILE_BASE} bg-pink-950/40 text-pink-400 hover:bg-pink-600 hover:text-white`}
+      aria-label="Copy and paste"
+    >
+      <ClipboardIcon className="w-5 h-5" />
+    </button>
+  );
 
   // Balance the 2-column grid when an odd number of buttons rendered.
   if (iconButtons.length % 2 === 1) {

--- a/app/components/composer/CopyPasteBottomSheet.tsx
+++ b/app/components/composer/CopyPasteBottomSheet.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  ClipboardIcon,
+  ClipboardDocumentIcon,
+  CheckIcon,
+} from '@heroicons/react/24/outline';
+import BottomSheet from '@/app/components/ui/BottomSheet';
+
+const COPY_CONFIRM_MS = 2000;
+
+interface CopyPasteBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentText: string;
+  onPaste: (clipboardText: string) => void;
+}
+
+export default function CopyPasteBottomSheet({
+  isOpen,
+  onClose,
+  currentText,
+  onPaste,
+}: CopyPasteBottomSheetProps) {
+  const [copied, setCopied] = useState(false);
+  const [pasteError, setPasteError] = useState<string | null>(null);
+
+  const copyDisabled = !currentText.trim();
+
+  const handleCopy = async () => {
+    if (copyDisabled) return;
+
+    try {
+      await navigator.clipboard.writeText(currentText);
+      setCopied(true);
+      // Show the ✓ for a beat, then close the sheet so the action feels resolved.
+      setTimeout(() => {
+        setCopied(false);
+        onClose();
+      }, COPY_CONFIRM_MS);
+    } catch (err) {
+      console.error('Failed to copy text:', err);
+    }
+  };
+
+  const handlePaste = async () => {
+    setPasteError(null);
+
+    if (!navigator.clipboard?.readText) {
+      setPasteError('This browser doesn\'t support pasting from clipboard.');
+      return;
+    }
+
+    try {
+      const clipboardText = await navigator.clipboard.readText();
+      if (!clipboardText) {
+        setPasteError('Clipboard is empty.');
+        return;
+      }
+      onPaste(clipboardText);
+      onClose();
+    } catch (err) {
+      console.error('Failed to read clipboard:', err);
+      setPasteError('Couldn\'t read clipboard — check browser permissions.');
+    }
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Copy & paste"
+      snapPoints={[40]}
+      initialSnap={0}
+    >
+      <div className="p-4 space-y-3">
+        {/* Copy all text */}
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={copyDisabled}
+          className={`w-full min-h-[64px] px-6 py-4 rounded-xl font-semibold transition-all duration-200 flex items-center justify-center gap-3 ${
+            copied
+              ? 'bg-green-500 text-white'
+              : 'bg-primary-500 hover:bg-primary-600 text-white'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+          aria-label="Copy all text"
+        >
+          {copied ? (
+            <>
+              <CheckIcon className="w-6 h-6" data-testid="copy-success" />
+              <span>Copied!</span>
+            </>
+          ) : (
+            <>
+              <ClipboardIcon className="w-6 h-6" />
+              <span>Copy all text</span>
+            </>
+          )}
+        </button>
+
+        {/* Paste from clipboard */}
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={handlePaste}
+            className="w-full min-h-[64px] px-6 py-4 rounded-xl font-semibold transition-all duration-200 flex items-center justify-center gap-3 bg-pink-700 hover:bg-pink-600 text-white"
+            aria-label="Paste from clipboard"
+          >
+            <ClipboardDocumentIcon className="w-6 h-6" />
+            <span>Paste from clipboard</span>
+          </button>
+          {pasteError && (
+            <p className="text-sm text-red-400 px-1" role="alert">
+              {pasteError}
+            </p>
+          )}
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/tests/components/Composer.test.tsx
+++ b/tests/components/Composer.test.tsx
@@ -101,6 +101,20 @@ jest.mock('@/app/components/ui/BottomSheet', () => ({
   default: () => null,
 }));
 
+// Stub the copy/paste sheet so we can observe when it opens and trigger paste
+// without dealing with the real clipboard or framer-motion lifecycle.
+jest.mock('@/app/components/composer/CopyPasteBottomSheet', () => ({
+  __esModule: true,
+  default: ({ isOpen, onPaste }: { isOpen: boolean; onPaste: (s: string) => void }) =>
+    isOpen ? (
+      <div data-testid="copy-paste-sheet">
+        <button type="button" onClick={() => onPaste('PASTED')}>
+          Trigger Paste
+        </button>
+      </div>
+    ) : null,
+}));
+
 jest.mock('framer-motion', () => ({
   motion: {
     div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
@@ -391,5 +405,40 @@ describe('Composer', () => {
     expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
     // The toolbar is in the portal (MobileDockPortal renders children), not a second set inline
     expect(screen.getAllByRole('button', { name: 'Clear' })).toHaveLength(1);
+  });
+
+  it('opens the copy/paste sheet when the sidebar tile is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Composer
+        text="Some text"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('copy-paste-sheet')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Copy and paste' }));
+
+    expect(screen.getByTestId('copy-paste-sheet')).toBeInTheDocument();
+  });
+
+  it('inserts pasted clipboard text at the textarea caret position', async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledComposer initialValue="Hello world" />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.focus();
+    // Place caret between "Hello" and " world".
+    textarea.setSelectionRange(5, 5);
+    fireEvent.select(textarea);
+
+    await user.click(screen.getByRole('button', { name: 'Copy and paste' }));
+    await user.click(screen.getByRole('button', { name: 'Trigger Paste' }));
+
+    expect(textarea).toHaveValue('HelloPASTED world');
   });
 });

--- a/tests/components/CopyPasteBottomSheet.test.tsx
+++ b/tests/components/CopyPasteBottomSheet.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CopyPasteBottomSheet from '@/app/components/composer/CopyPasteBottomSheet';
+
+// Render BottomSheet's children directly so we can assert on the inner buttons
+// without dealing with framer-motion's animation lifecycle.
+jest.mock('@/app/components/ui/BottomSheet', () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    children,
+    title,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    title?: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+interface ClipboardStub {
+  writeText: jest.Mock;
+  readText: jest.Mock;
+}
+
+/**
+ * Install a mock clipboard. MUST be called AFTER `userEvent.setup()` because
+ * userEvent v14 installs its own clipboard polyfill at setup time, which would
+ * otherwise overwrite our stub.
+ */
+function installClipboard(
+  overrides: Partial<{ writeText: jest.Mock; readText: jest.Mock | undefined }> = {}
+): ClipboardStub {
+  const stub = {
+    writeText: overrides.writeText ?? jest.fn().mockResolvedValue(undefined),
+    readText: overrides.readText ?? jest.fn().mockResolvedValue(''),
+  };
+  Object.defineProperty(navigator, 'clipboard', {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
+  return stub as ClipboardStub;
+}
+
+describe('CopyPasteBottomSheet', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders nothing when closed', () => {
+    render(
+      <CopyPasteBottomSheet
+        isOpen={false}
+        onClose={jest.fn()}
+        currentText="hello"
+        onPaste={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /copy all text/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /paste from clipboard/i })).not.toBeInTheDocument();
+  });
+
+  it('renders both action buttons when open', () => {
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={jest.fn()}
+        currentText="hello"
+        onPaste={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /copy all text/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /paste from clipboard/i })).toBeInTheDocument();
+  });
+
+  it('disables Copy when current text is empty or whitespace', () => {
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={jest.fn()}
+        currentText="   "
+        onPaste={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /copy all text/i })).toBeDisabled();
+  });
+
+  it('writes the current text to the clipboard and shows a checkmark on copy', async () => {
+    const user = userEvent.setup();
+    const clipboard = installClipboard();
+
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={jest.fn()}
+        currentText="payload"
+        onPaste={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /copy all text/i }));
+
+    await waitFor(() => {
+      expect(clipboard.writeText).toHaveBeenCalledWith('payload');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('copy-success')).toBeInTheDocument();
+    });
+  });
+
+  it('closes the sheet shortly after a successful copy', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    installClipboard();
+    const onClose = jest.fn();
+
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={onClose}
+        currentText="payload"
+        onPaste={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /copy all text/i }));
+
+    // Allow the writeText promise to resolve before advancing timers.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('reads from the clipboard, calls onPaste, and closes the sheet on paste', async () => {
+    const user = userEvent.setup();
+    installClipboard({ readText: jest.fn().mockResolvedValue('pasted!') });
+    const onPaste = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={onClose}
+        currentText=""
+        onPaste={onPaste}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /paste from clipboard/i }));
+
+    await waitFor(() => {
+      expect(onPaste).toHaveBeenCalledWith('pasted!');
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows a permission error and keeps the sheet open when readText rejects', async () => {
+    // The component intentionally console.errors when clipboard read fails.
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+    installClipboard({ readText: jest.fn().mockRejectedValue(new Error('denied')) });
+    const onPaste = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={onClose}
+        currentText=""
+        onPaste={onPaste}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /paste from clipboard/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/check browser permissions/i)).toBeInTheDocument();
+    });
+    expect(onPaste).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('shows an empty-clipboard error when readText returns an empty string', async () => {
+    const user = userEvent.setup();
+    installClipboard({ readText: jest.fn().mockResolvedValue('') });
+    const onPaste = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={onClose}
+        currentText=""
+        onPaste={onPaste}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /paste from clipboard/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/clipboard is empty/i)).toBeInTheDocument();
+    });
+    expect(onPaste).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows an unsupported-browser error when clipboard.readText is missing', async () => {
+    const user = userEvent.setup();
+    // Install a clipboard with writeText only (no readText) — simulates a
+    // browser without paste support.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn() },
+      configurable: true,
+      writable: true,
+    });
+    const onPaste = jest.fn();
+
+    render(
+      <CopyPasteBottomSheet
+        isOpen={true}
+        onClose={jest.fn()}
+        currentText=""
+        onPaste={onPaste}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /paste from clipboard/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/doesn't support pasting/i)).toBeInTheDocument();
+    });
+    expect(onPaste).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #615.

## Summary
- New `CopyPasteBottomSheet` on the composer page with two large action buttons: **Copy all text** (disabled when empty, 2-second checkmark, auto-closes) and **Paste from clipboard** (inserts at the textarea caret).
- New clipboard tile in `ComposerSidebar`'s top icon grid opens the sheet (pink accent so it's distinct from the existing 4 tile colors).
- Pasted text routes through the existing `handleTextChange` wrapper, so scroll capture, undo reset, and tab-store updates all run as for any other edit.
- No new dependencies. Reuses `BottomSheet`, the `TILE_BASE` styling, and the existing `inputRef`. Mirrors the copy-with-confirmation pattern from `LiveTypingBottomSheet`.

## Test Plan
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 324 tests pass (9 new + 2 new in Composer + 313 existing)
- [ ] `npm run dev` — sidebar shows the new clipboard tile; tapping it opens the sheet
- [ ] Empty composer → Copy is disabled
- [ ] Type text, tap Copy → ✓ shows for 2s, sheet closes, text is on the system clipboard
- [ ] Place caret mid-word, tap Paste → text inserts at caret, sheet closes, caret lands at end of inserted region
- [ ] Deny clipboard permission → red error appears under Paste, sheet stays open
- [ ] Mobile viewport (Chrome DevTools) — sheet snaps correctly, generous tap targets, no overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy/paste functionality to the composer UI
  * Copy your current message text to clipboard with a single click
  * Paste content from your clipboard directly into the composer at your cursor position
  * New "Copy and paste" button added to the composer sidebar for easy access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->