### PR TITLE
Add recorded audio tiles

### DIFF
--- a/app/components/home/PhrasesInterface.tsx
+++ b/app/components/home/PhrasesInterface.tsx
@@ -152,9 +152,11 @@ export default function PhrasesInterface() {
                 boardData.handleNavigateToBoard(tile.targetBoardId)
               }
               onNavigateEdit={boardData.handleEditNavigateTile}
+              onAudioEdit={boardData.handleEditAudioTile}
               onNavigateBack={boardData.handleNavigateBack}
               onAddPhrase={isOnline && boardData.canEditCurrentBoard ? boardData.handleAddPhrase : undefined}
               onAddNavigateTile={isOnline && boardData.canEditCurrentBoard ? boardData.handleAddNavigateTile : undefined}
+              onAddAudioTile={isOnline && boardData.canEditCurrentBoard ? boardData.handleAddAudioTile : undefined}
               onAddBoard={boardData.handleAddBoard}
               onReorderTiles={boardData.handleReorderTiles}
               onBoardIndexChange={boardData.handleBoardIndexChange}

--- a/app/components/home/PhrasesTabContent.tsx
+++ b/app/components/home/PhrasesTabContent.tsx
@@ -28,9 +28,11 @@ interface PhrasesTabContentProps {
   onEditPhrase: (phrase: PhraseSummary) => void;
   onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
   onNavigateEdit: (tileId: string) => void;
+  onAudioEdit: (tileId: string) => void;
   onNavigateBack: () => void;
   onAddPhrase: (() => void) | undefined;
   onAddNavigateTile: (() => void) | undefined;
+  onAddAudioTile: (() => void) | undefined;
   onAddBoard: () => void;
   onReorderTiles: (orderedTileIds: string[]) => void;
   onBoardIndexChange: (index: number) => void;
@@ -62,9 +64,11 @@ export default function PhrasesTabContent({
   onEditPhrase,
   onNavigateTap,
   onNavigateEdit,
+  onAudioEdit,
   onNavigateBack,
   onAddPhrase,
   onAddNavigateTile,
+  onAddAudioTile,
   onAddBoard,
   onReorderTiles,
   onBoardIndexChange,
@@ -76,6 +80,10 @@ export default function PhrasesTabContent({
 }: PhrasesTabContentProps) {
   const handleNavigateEditTile = (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => {
     onNavigateEdit(tile.id);
+  };
+
+  const handleAudioEditTile = (tile: Extract<BoardTileSummary, { kind: 'audio' }>) => {
+    onAudioEdit(tile.id);
   };
 
   // Defensive: parents should always pass an array, but a transient HMR / data
@@ -93,6 +101,7 @@ export default function PhrasesTabContent({
       onPhraseEdit={onEditPhrase}
       onNavigateTap={onNavigateTap}
       onNavigateEdit={handleNavigateEditTile}
+      onAudioEdit={handleAudioEditTile}
       onReorder={onReorderTiles}
       textSizePx={textSizePx}
     />
@@ -113,6 +122,7 @@ export default function PhrasesTabContent({
             isPhraseSpeaking={isPhraseSpeaking}
             onNavigateTap={onNavigateTap}
             onNavigateEdit={canEditCurrentBoard ? handleNavigateEditTile : undefined}
+            onAudioEdit={canEditCurrentBoard ? handleAudioEditTile : undefined}
             isEditMode={false}
           />
         );
@@ -190,6 +200,7 @@ export default function PhrasesTabContent({
           onOpenBoardPicker={onOpenBoardPicker}
           onAddPhrase={isOnline && canEditCurrentBoard ? onAddPhrase : undefined}
           onAddNavigateTile={isOnline && canEditCurrentBoard ? onAddNavigateTile : undefined}
+          onAddAudioTile={isOnline && canEditCurrentBoard ? onAddAudioTile : undefined}
           onAddBoard={isOnline ? onAddBoard : undefined}
           onEdit={onToggleEditMode}
           onEditBoard={isOnline && selectedBoard && canEditCurrentBoard ? () => onEditBoard(selectedBoard.id) : undefined}
@@ -219,6 +230,7 @@ export default function PhrasesTabContent({
           onEditBoard={onEditBoard}
           onAddPhrase={isOnline && canEditCurrentBoard ? onAddPhrase : undefined}
           onAddNavigateTile={isOnline && canEditCurrentBoard ? onAddNavigateTile : undefined}
+          onAddAudioTile={isOnline && canEditCurrentBoard ? onAddAudioTile : undefined}
           onAddBoard={isOnline ? onAddBoard : undefined}
           onEdit={onToggleEditMode}
           embedded={true}

--- a/app/components/phrases/BoardActionButtons.tsx
+++ b/app/components/phrases/BoardActionButtons.tsx
@@ -9,12 +9,14 @@ import {
   CheckIcon,
   ChatBubbleLeftIcon,
   ArrowRightCircleIcon,
+  SpeakerWaveIcon,
 } from '@heroicons/react/24/outline';
 import BottomSheet from '@/app/components/ui/BottomSheet';
 
 interface BoardActionButtonsProps {
   onAddPhrase?: () => void;
   onAddNavigateTile?: () => void;
+  onAddAudioTile?: () => void;
   onAddBoard?: () => void;
   onEdit?: () => void;
   onEditBoard?: () => void;
@@ -25,6 +27,7 @@ interface BoardActionButtonsProps {
 export default function BoardActionButtons({
   onAddPhrase,
   onAddNavigateTile,
+  onAddAudioTile,
   onAddBoard,
   onEdit,
   onEditBoard,
@@ -36,13 +39,15 @@ export default function BoardActionButtons({
 
   const showAddPhrase = canEditBoard && !!onAddPhrase;
   const showAddNavigate = canEditBoard && !!onAddNavigateTile;
-  // If both add-options are present, render them as a single "Add Tile" menu;
+  const showAddAudio = canEditBoard && !!onAddAudioTile;
+  // If multiple add-options are present, render them as a single "Add Tile" menu;
   // if only one is present, fall back to the legacy single button.
-  const showAddTileMenu = showAddPhrase && showAddNavigate;
+  const addTileOptionCount = [showAddPhrase, showAddNavigate, showAddAudio].filter(Boolean).length;
+  const showAddTileMenu = addTileOptionCount > 1;
   const showAddBoard = !!onAddBoard;
   const showMenu = !!onEdit || !!onEditBoard;
 
-  if (!showAddPhrase && !showAddNavigate && !showAddBoard && !showMenu) return null;
+  if (!showAddPhrase && !showAddNavigate && !showAddAudio && !showAddBoard && !showMenu) return null;
 
   return (
     <div className="flex items-center justify-center gap-2 py-2 bg-surface">
@@ -74,6 +79,15 @@ export default function BoardActionButtons({
         >
           <PlusIcon className="w-4 h-4" />
           <span>Add Navigate Tile</span>
+        </button>
+      ) : showAddAudio ? (
+        <button
+          onClick={onAddAudioTile}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-primary-500 hover:bg-primary-600 text-white transition-colors font-medium"
+          aria-label="Add audio tile"
+        >
+          <PlusIcon className="w-4 h-4" />
+          <span>Add Audio Tile</span>
         </button>
       ) : null}
 
@@ -126,6 +140,15 @@ export default function BoardActionButtons({
             >
               <ArrowRightCircleIcon className="w-5 h-5 text-text-secondary" />
               <span className="text-foreground">Navigate to board</span>
+            </button>
+          )}
+          {showAddAudio && (
+            <button
+              onClick={() => { onAddAudioTile?.(); setAddMenuOpen(false); }}
+              className="w-full flex items-center gap-3 px-4 py-4 text-base rounded-2xl hover:bg-surface-hover transition-colors"
+            >
+              <SpeakerWaveIcon className="w-5 h-5 text-text-secondary" />
+              <span className="text-foreground">Recorded audio</span>
             </button>
           )}
         </div>

--- a/app/components/phrases/BoardSelector.tsx
+++ b/app/components/phrases/BoardSelector.tsx
@@ -13,6 +13,7 @@ interface BoardSelectorProps {
   onEditBoard?: (boardId: string) => void;
   onAddPhrase?: () => void;
   onAddNavigateTile?: () => void;
+  onAddAudioTile?: () => void;
   onAddBoard?: () => void;
   onEdit?: () => void;
   embedded?: boolean;
@@ -26,6 +27,7 @@ export default function BoardSelector({
   onEditBoard,
   onAddPhrase,
   onAddNavigateTile,
+  onAddAudioTile,
   onAddBoard,
   onEdit,
   embedded = false,
@@ -90,6 +92,7 @@ export default function BoardSelector({
         <BoardActionButtons
           onAddPhrase={onAddPhrase}
           onAddNavigateTile={onAddNavigateTile}
+          onAddAudioTile={onAddAudioTile}
           onAddBoard={onAddBoard}
           onEdit={onEdit}
           onEditBoard={editSelectedBoard}
@@ -127,6 +130,7 @@ export default function BoardSelector({
         <BoardActionButtons
           onAddPhrase={onAddPhrase}
           onAddNavigateTile={onAddNavigateTile}
+          onAddAudioTile={onAddAudioTile}
           onAddBoard={onAddBoard}
           onEdit={onEdit}
           onEditBoard={editSelectedBoard}

--- a/app/components/phrases/SortablePhraseGrid.tsx
+++ b/app/components/phrases/SortablePhraseGrid.tsx
@@ -28,6 +28,7 @@ interface SortableTileItemProps {
   isPhraseSpeaking: boolean;
   onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
   onNavigateEdit: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  onAudioEdit: (tile: Extract<BoardTileSummary, { kind: 'audio' }>) => void;
 }
 
 function SortableTileItem(props: SortableTileItemProps) {
@@ -53,6 +54,7 @@ function SortableTileItem(props: SortableTileItemProps) {
         isPhraseSpeaking={props.isPhraseSpeaking}
         onNavigateTap={props.onNavigateTap}
         onNavigateEdit={props.onNavigateEdit}
+        onAudioEdit={props.onAudioEdit}
         isEditMode
       />
     </div>
@@ -69,6 +71,7 @@ interface SortablePhraseGridProps {
   onPhraseEdit: (phrase: PhraseSummary) => void;
   onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
   onNavigateEdit: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  onAudioEdit: (tile: Extract<BoardTileSummary, { kind: 'audio' }>) => void;
   /** Receives ordered boardTile ids; caller should call api.boardTiles.reorderTiles. */
   onReorder: (orderedTileIds: string[]) => void;
   extraTile?: React.ReactNode;
@@ -84,6 +87,7 @@ export default function SortablePhraseGrid({
   onPhraseEdit,
   onNavigateTap,
   onNavigateEdit,
+  onAudioEdit,
   onReorder,
   extraTile,
   textSizePx,
@@ -131,6 +135,7 @@ export default function SortablePhraseGrid({
                 isPhraseSpeaking={isPhraseSpeaking}
                 onNavigateTap={onNavigateTap}
                 onNavigateEdit={onNavigateEdit}
+                onAudioEdit={onAudioEdit}
               />
             );
           })}

--- a/app/components/phrases/SwipeableBoardNavigator.tsx
+++ b/app/components/phrases/SwipeableBoardNavigator.tsx
@@ -15,6 +15,7 @@ interface SwipeableBoardNavigatorProps {
   // Action button props
   onAddPhrase?: () => void;
   onAddNavigateTile?: () => void;
+  onAddAudioTile?: () => void;
   onAddBoard?: () => void;
   onEdit?: () => void;
   onEditBoard?: () => void;
@@ -30,6 +31,7 @@ export default function SwipeableBoardNavigator({
   children,
   onAddPhrase,
   onAddNavigateTile,
+  onAddAudioTile,
   onAddBoard,
   onEdit,
   onEditBoard,
@@ -139,6 +141,7 @@ export default function SwipeableBoardNavigator({
       <BoardActionButtons
         onAddPhrase={onAddPhrase}
         onAddNavigateTile={onAddNavigateTile}
+        onAddAudioTile={onAddAudioTile}
         onAddBoard={onAddBoard}
         onEdit={onEdit}
         onEditBoard={onEditBoard}

--- a/app/components/phrases/tiles/AudioRecorderControl.tsx
+++ b/app/components/phrases/tiles/AudioRecorderControl.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ReactMediaRecorder } from 'react-media-recorder';
+import { MicrophoneIcon, PlayIcon, StopIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { Button } from '@/app/components/ui/Button';
+
+export interface RecordedAudio {
+  blob: Blob;
+  url: string;
+  durationMs: number;
+}
+
+interface AudioRecorderControlProps {
+  value: RecordedAudio | null;
+  onChange: (recording: RecordedAudio | null) => void;
+  maxDurationMs?: number;
+}
+
+const DEFAULT_MAX_DURATION_MS = 60_000;
+
+function formatDuration(durationMs: number) {
+  const totalSeconds = Math.ceil(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function mapRecordingError(error: string | undefined) {
+  if (!error) return null;
+  if (error.toLowerCase().includes('permission') || error.toLowerCase().includes('denied')) {
+    return 'Microphone access was denied. Allow access and try again.';
+  }
+  return 'Audio recording is not available in this browser.';
+}
+
+export default function AudioRecorderControl({
+  value,
+  onChange,
+  maxDurationMs = DEFAULT_MAX_DURATION_MS,
+}: AudioRecorderControlProps) {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startedAtRef = useRef<number | null>(null);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      if (previewAudioRef.current) {
+        previewAudioRef.current.pause();
+      }
+      if (value?.url) {
+        URL.revokeObjectURL(value.url);
+      }
+    };
+  }, [value?.url]);
+
+  const stopTimer = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const playPreview = () => {
+    if (!value) return;
+    previewAudioRef.current?.pause();
+    const audio = new Audio(value.url);
+    previewAudioRef.current = audio;
+    void audio.play();
+  };
+
+  return (
+    <ReactMediaRecorder
+      audio
+      onStop={(_blobUrl, blob) => {
+        stopTimer();
+        const durationMs = Math.min(elapsedMs || maxDurationMs, maxDurationMs);
+        const url = URL.createObjectURL(blob);
+        onChange({ blob, url, durationMs });
+      }}
+      render={({ status, startRecording, stopRecording, error }) => {
+        const isRecording = status === 'recording';
+        const displayError = localError ?? mapRecordingError(error);
+
+        const start = () => {
+          setLocalError(null);
+          if (!navigator.mediaDevices?.getUserMedia) {
+            setLocalError('Audio recording is not available in this browser.');
+            return;
+          }
+          if (value?.url) URL.revokeObjectURL(value.url);
+          onChange(null);
+          setElapsedMs(0);
+          startedAtRef.current = Date.now();
+          startRecording();
+          timerRef.current = setInterval(() => {
+            if (startedAtRef.current === null) return;
+            const nextElapsed = Date.now() - startedAtRef.current;
+            setElapsedMs(Math.min(nextElapsed, maxDurationMs));
+            if (nextElapsed >= maxDurationMs) {
+              stopRecording();
+              stopTimer();
+            }
+          }, 250);
+        };
+
+        const stop = () => {
+          stopRecording();
+          stopTimer();
+        };
+
+        return (
+          <div className="rounded-3xl border border-border bg-surface-hover p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-foreground">Recording</p>
+                <p className="text-sm text-text-secondary">
+                  {isRecording ? formatDuration(elapsedMs) : value ? formatDuration(value.durationMs) : '0:00'}
+                  <span className="text-text-tertiary"> / 1:00</span>
+                </p>
+              </div>
+              <div className="flex flex-wrap justify-end gap-2">
+                {isRecording ? (
+                  <Button type="button" onClick={stop} variant="secondary">
+                    <StopIcon className="w-4 h-4" />
+                    <span>Stop</span>
+                  </Button>
+                ) : (
+                  <Button type="button" onClick={start} variant={value ? 'secondary' : 'default'}>
+                    {value ? <ArrowPathIcon className="w-4 h-4" /> : <MicrophoneIcon className="w-4 h-4" />}
+                    <span>{value ? 'Re-record' : 'Record'}</span>
+                  </Button>
+                )}
+                {value && !isRecording && (
+                  <Button type="button" onClick={playPreview} variant="ghost">
+                    <PlayIcon className="w-4 h-4" />
+                    <span>Preview</span>
+                  </Button>
+                )}
+              </div>
+            </div>
+            {displayError && (
+              <div className="mt-3 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">
+                {displayError}
+              </div>
+            )}
+          </div>
+        );
+      }}
+    />
+  );
+}

--- a/app/components/phrases/tiles/AudioRecorderControl.tsx
+++ b/app/components/phrases/tiles/AudioRecorderControl.tsx
@@ -1,9 +1,20 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ReactMediaRecorder } from 'react-media-recorder';
-import { MicrophoneIcon, PlayIcon, StopIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { motion } from 'framer-motion';
+import {
+  ArrowPathIcon as ArrowPathOutline,
+  PlayIcon,
+} from '@heroicons/react/24/outline';
+import { MicrophoneIcon, StopIcon } from '@heroicons/react/24/solid';
 import { Button } from '@/app/components/ui/Button';
+import {
+  COUNTDOWN_WARNING_MS,
+  MAX_AUDIO_BYTES,
+  MAX_AUDIO_DURATION_MS,
+  isAllowedAudioMimeType,
+} from '@/lib/audio/constants';
 
 export interface RecordedAudio {
   blob: Blob;
@@ -15,9 +26,13 @@ interface AudioRecorderControlProps {
   value: RecordedAudio | null;
   onChange: (recording: RecordedAudio | null) => void;
   maxDurationMs?: number;
+  maxBytes?: number;
 }
 
-const DEFAULT_MAX_DURATION_MS = 60_000;
+// Hero ring sizing. The viewBox stays 0-100 so stroke-dashoffset math works in
+// pure circumference units (2π·r ≈ 282.74 for r=45).
+const RING_RADIUS = 45;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
 function formatDuration(durationMs: number) {
   const totalSeconds = Math.ceil(durationMs / 1000);
@@ -28,7 +43,8 @@ function formatDuration(durationMs: number) {
 
 function mapRecordingError(error: string | undefined) {
   if (!error) return null;
-  if (error.toLowerCase().includes('permission') || error.toLowerCase().includes('denied')) {
+  const lower = error.toLowerCase();
+  if (lower.includes('permission') || lower.includes('denied')) {
     return 'Microphone access was denied. Allow access and try again.';
   }
   return 'Audio recording is not available in this browser.';
@@ -37,25 +53,28 @@ function mapRecordingError(error: string | undefined) {
 export default function AudioRecorderControl({
   value,
   onChange,
-  maxDurationMs = DEFAULT_MAX_DURATION_MS,
+  maxDurationMs = MAX_AUDIO_DURATION_MS,
+  maxBytes = MAX_AUDIO_BYTES,
 }: AudioRecorderControlProps) {
   const [elapsedMs, setElapsedMs] = useState(0);
   const [localError, setLocalError] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Wall-clock timestamps for the current recording. We keep these in refs
+  // (not state) so that `onStop` — which fires asynchronously after the
+  // encoder finalises — can compute the actual duration without depending on
+  // a possibly-stale React closure over `elapsedMs`.
   const startedAtRef = useRef<number | null>(null);
+  const stoppedAtRef = useRef<number | null>(null);
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
-      if (previewAudioRef.current) {
-        previewAudioRef.current.pause();
-      }
-      if (value?.url) {
-        URL.revokeObjectURL(value.url);
-      }
-    };
-  }, [value?.url]);
+  // Tracks the *currently-active* object URL we minted so cleanup is unambiguous
+  // even when `value` changes between renders.
+  const activeUrlRef = useRef<string | null>(null);
+  // The progress arc is updated imperatively so we don't re-render the whole
+  // component four times a second just to advance a stroke offset. Because we
+  // mutate `style.strokeDashoffset` directly, we deliberately do NOT pass a
+  // `strokeDashoffset` JSX attribute on the <circle> — otherwise React's
+  // reconciliation would overwrite our imperative value every re-render.
+  const progressCircleRef = useRef<SVGCircleElement | null>(null);
 
   const stopTimer = () => {
     if (timerRef.current) {
@@ -63,6 +82,40 @@ export default function AudioRecorderControl({
       timerRef.current = null;
     }
   };
+
+  const releaseActiveUrl = () => {
+    if (activeUrlRef.current) {
+      URL.revokeObjectURL(activeUrlRef.current);
+      activeUrlRef.current = null;
+    }
+  };
+
+  // Imperatively set the progress arc to a 0..1 fraction of the ring.
+  // Safe to call when the ref isn't attached yet (initial render path).
+  const setProgressFraction = (fraction: number) => {
+    const node = progressCircleRef.current;
+    if (!node) return;
+    const clamped = Math.max(0, Math.min(1, fraction));
+    node.style.strokeDashoffset = String(RING_CIRCUMFERENCE * (1 - clamped));
+  };
+
+  // One-shot unmount cleanup. Per-recording URL cleanup is handled by
+  // releaseActiveUrl() when start()/onStop() rotates the value.
+  useEffect(() => {
+    return () => {
+      stopTimer();
+      previewAudioRef.current?.pause();
+      releaseActiveUrl();
+    };
+  }, []);
+
+  // Sync the progress arc to the current `value`-derived state whenever we're
+  // not in the middle of a live recording. During recording, the interval is
+  // the sole driver of the dashoffset.
+  useLayoutEffect(() => {
+    if (timerRef.current !== null) return;
+    setProgressFraction(value ? 1 : 0);
+  }, [value]);
 
   const playPreview = () => {
     if (!value) return;
@@ -72,18 +125,77 @@ export default function AudioRecorderControl({
     void audio.play();
   };
 
+  const remainingMs = Math.max(0, maxDurationMs - elapsedMs);
+  const showCountdown = remainingMs > 0 && remainingMs <= COUNTDOWN_WARNING_MS;
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
   return (
     <ReactMediaRecorder
       audio
       onStop={(_blobUrl, blob) => {
         stopTimer();
-        const durationMs = Math.min(elapsedMs || maxDurationMs, maxDurationMs);
+        const startedAt = startedAtRef.current;
+        const stoppedAt = stoppedAtRef.current ?? Date.now();
+        const measuredMs = startedAt !== null ? Math.max(0, stoppedAt - startedAt) : 0;
+        startedAtRef.current = null;
+        stoppedAtRef.current = null;
+
+        if (blob.size > maxBytes) {
+          const mb = (maxBytes / (1024 * 1024)).toFixed(0);
+          setLocalError(`Recording exceeds ${mb} MB limit. Try a shorter clip.`);
+          onChange(null);
+          setProgressFraction(0);
+          return;
+        }
+        if (blob.type && !isAllowedAudioMimeType(blob.type)) {
+          setLocalError('Your browser produced an audio format we don\'t support.');
+          onChange(null);
+          setProgressFraction(0);
+          return;
+        }
+        const durationMs = Math.min(measuredMs, maxDurationMs);
+        releaseActiveUrl();
         const url = URL.createObjectURL(blob);
+        activeUrlRef.current = url;
+        // Has-recording state: pin ring to full.
+        setProgressFraction(1);
         onChange({ blob, url, durationMs });
       }}
       render={({ status, startRecording, stopRecording, error }) => {
         const isRecording = status === 'recording';
+        const hasRecording = !isRecording && !!value;
         const displayError = localError ?? mapRecordingError(error);
+        const inCountdown = isRecording && showCountdown;
+
+        // Time-text color follows the same state palette as the ring.
+        const timeColorClass = isRecording
+          ? inCountdown
+            ? 'text-warning'
+            : 'text-error'
+          : 'text-foreground';
+
+        // Track (unfilled portion) goes amber in the last-10s countdown so the
+        // remaining-time signal is visible at a glance.
+        const trackColor = inCountdown
+          ? 'var(--color-warning)'
+          : 'var(--color-border)';
+
+        // Filled arc + button color story.
+        const arcColor = isRecording
+          ? 'var(--color-error)'
+          : hasRecording
+            ? 'var(--color-primary-500)'
+            : 'transparent';
+
+        // Big-button styling per state.
+        const buttonStateClasses = isRecording
+          ? 'bg-error text-white shadow-lg'
+          : hasRecording
+            ? 'bg-surface text-primary-500 border-2 border-primary-500'
+            : 'bg-primary-500 text-white shadow-lg';
 
         const start = () => {
           setLocalError(null);
@@ -91,16 +203,20 @@ export default function AudioRecorderControl({
             setLocalError('Audio recording is not available in this browser.');
             return;
           }
-          if (value?.url) URL.revokeObjectURL(value.url);
+          releaseActiveUrl();
           onChange(null);
           setElapsedMs(0);
+          setProgressFraction(0);
           startedAtRef.current = Date.now();
+          stoppedAtRef.current = null;
           startRecording();
           timerRef.current = setInterval(() => {
             if (startedAtRef.current === null) return;
             const nextElapsed = Date.now() - startedAtRef.current;
             setElapsedMs(Math.min(nextElapsed, maxDurationMs));
+            setProgressFraction(nextElapsed / maxDurationMs);
             if (nextElapsed >= maxDurationMs) {
+              stoppedAtRef.current = startedAtRef.current + maxDurationMs;
               stopRecording();
               stopTimer();
             }
@@ -108,42 +224,147 @@ export default function AudioRecorderControl({
         };
 
         const stop = () => {
+          if (startedAtRef.current !== null && stoppedAtRef.current === null) {
+            stoppedAtRef.current = Date.now();
+          }
           stopRecording();
           stopTimer();
         };
 
+        const onPrimaryClick = () => {
+          if (isRecording) {
+            stop();
+          } else {
+            // Idle and has-recording both kick off a fresh recording. The
+            // distinction lives in the icon/label and the existing recording
+            // is released by start() → releaseActiveUrl() → onChange(null).
+            start();
+          }
+        };
+
+        const primaryLabel = isRecording
+          ? 'Stop recording'
+          : hasRecording
+            ? 'Re-record (replaces current clip)'
+            : 'Start recording';
+
         return (
-          <div className="rounded-3xl border border-border bg-surface-hover p-4">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-sm font-semibold text-foreground">Recording</p>
-                <p className="text-sm text-text-secondary">
-                  {isRecording ? formatDuration(elapsedMs) : value ? formatDuration(value.durationMs) : '0:00'}
-                  <span className="text-text-tertiary"> / 1:00</span>
+          <div className="rounded-3xl border border-border bg-surface shadow-md hover:shadow-xl transition-shadow duration-300 p-8">
+            <div className="flex flex-col items-center gap-5">
+              {/* Ring + big button cluster */}
+              <div className="relative w-24 h-24 flex items-center justify-center">
+                <svg
+                  viewBox="0 0 100 100"
+                  className="absolute inset-0 -rotate-90"
+                  width="96"
+                  height="96"
+                  aria-hidden="true"
+                >
+                  {/* Track */}
+                  <circle
+                    cx="50"
+                    cy="50"
+                    r={RING_RADIUS}
+                    fill="none"
+                    stroke={trackColor}
+                    strokeWidth="3"
+                    style={{ transition: 'stroke 200ms ease' }}
+                  />
+                  {/* Foreground arc — strokeDashoffset is owned by the
+                      imperative path (interval / has-recording sync effect).
+                      Do NOT add a JSX strokeDashoffset attr here. */}
+                  <circle
+                    ref={progressCircleRef}
+                    cx="50"
+                    cy="50"
+                    r={RING_RADIUS}
+                    fill="none"
+                    stroke={arcColor}
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeDasharray={RING_CIRCUMFERENCE}
+                    style={{
+                      transition: prefersReducedMotion
+                        ? 'none'
+                        : 'stroke-dashoffset 250ms linear, stroke 200ms ease',
+                    }}
+                  />
+                </svg>
+                <motion.button
+                  type="button"
+                  onClick={onPrimaryClick}
+                  aria-label={primaryLabel}
+                  className={`relative z-10 w-[72px] h-[72px] min-h-[44px] min-w-[44px] rounded-full
+                    flex items-center justify-center
+                    focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface
+                    transition-colors duration-200 ${buttonStateClasses}`}
+                  animate={
+                    isRecording && !prefersReducedMotion
+                      ? { scale: [1, 1.05, 1] }
+                      : { scale: 1 }
+                  }
+                  transition={
+                    isRecording && !prefersReducedMotion
+                      ? { duration: 1.2, repeat: Infinity, ease: 'easeInOut' }
+                      : { duration: 0.2 }
+                  }
+                  whileHover={prefersReducedMotion ? undefined : { scale: 1.05 }}
+                  whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
+                >
+                  {isRecording ? (
+                    <StopIcon className="w-7 h-7" aria-hidden="true" />
+                  ) : hasRecording ? (
+                    <ArrowPathOutline className="w-7 h-7" aria-hidden="true" />
+                  ) : (
+                    <MicrophoneIcon className="w-7 h-7" aria-hidden="true" />
+                  )}
+                </motion.button>
+              </div>
+
+              {/* Time */}
+              <div className="text-center">
+                <p
+                  className={`text-2xl font-mono tabular-nums font-semibold ${timeColorClass} transition-colors duration-200`}
+                  aria-live="off"
+                >
+                  {isRecording
+                    ? formatDuration(elapsedMs)
+                    : hasRecording
+                      ? formatDuration(value!.durationMs)
+                      : '0:00'}
+                  <span className="text-text-tertiary"> / {formatDuration(maxDurationMs)}</span>
                 </p>
               </div>
-              <div className="flex flex-wrap justify-end gap-2">
-                {isRecording ? (
-                  <Button type="button" onClick={stop} variant="secondary">
-                    <StopIcon className="w-4 h-4" />
-                    <span>Stop</span>
+
+              {/* Footer actions — only when there's a clip to act on */}
+              {hasRecording && (
+                <div className="flex flex-wrap justify-center gap-2">
+                  <Button type="button" onClick={start} variant="secondary" size="sm">
+                    <ArrowPathOutline className="w-4 h-4" />
+                    <span>Re-record</span>
                   </Button>
-                ) : (
-                  <Button type="button" onClick={start} variant={value ? 'secondary' : 'default'}>
-                    {value ? <ArrowPathIcon className="w-4 h-4" /> : <MicrophoneIcon className="w-4 h-4" />}
-                    <span>{value ? 'Re-record' : 'Record'}</span>
-                  </Button>
-                )}
-                {value && !isRecording && (
-                  <Button type="button" onClick={playPreview} variant="ghost">
+                  <Button type="button" onClick={playPreview} variant="ghost" size="sm">
                     <PlayIcon className="w-4 h-4" />
                     <span>Preview</span>
                   </Button>
-                )}
-              </div>
+                </div>
+              )}
             </div>
+
+            {inCountdown && (
+              <div
+                className="mt-5 text-amber-600 text-sm bg-status-warning px-4 py-2 rounded-3xl text-center"
+                role="status"
+                aria-live="polite"
+              >
+                {Math.ceil(remainingMs / 1000)}s left — recording will stop automatically.
+              </div>
+            )}
             {displayError && (
-              <div className="mt-3 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">
+              <div
+                className="mt-5 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl text-center"
+                role="alert"
+              >
                 {displayError}
               </div>
             )}

--- a/app/components/phrases/tiles/AudioTile.tsx
+++ b/app/components/phrases/tiles/AudioTile.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { ExclamationTriangleIcon, SpeakerWaveIcon, StopIcon } from '@heroicons/react/24/solid';
+
+interface AudioTileProps {
+  tile: {
+    id: string;
+    audioLabel: string;
+    audioUrl: string | null;
+  };
+  onEdit?: () => void;
+  onLongPress?: () => void;
+  className?: string;
+  textSizePx: number;
+}
+
+export default function AudioTile({
+  tile,
+  onEdit,
+  onLongPress,
+  className = '',
+  textSizePx,
+}: AudioTileProps) {
+  const [isPressed, setIsPressed] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isLongPress = useRef(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const isBroken = tile.audioUrl === null;
+
+  const stopAudio = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.currentTime = 0;
+    setIsPlaying(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+      }
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.src = '';
+        audioRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    stopAudio();
+    audioRef.current = null;
+  }, [stopAudio, tile.audioUrl]);
+
+  const handleTouchStart = useCallback(() => {
+    if (isBroken && !onEdit) return;
+    isLongPress.current = false;
+    setIsPressed(true);
+
+    if (onLongPress && !onEdit) {
+      longPressTimer.current = setTimeout(() => {
+        isLongPress.current = true;
+        setIsPressed(false);
+        if (typeof navigator !== 'undefined' && navigator.vibrate) {
+          navigator.vibrate(50);
+        }
+        onLongPress();
+      }, 500);
+    }
+  }, [isBroken, onEdit, onLongPress]);
+
+  const handleTouchEnd = useCallback(() => {
+    setIsPressed(false);
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const playAudio = () => {
+    if (!tile.audioUrl) return;
+
+    const audio = new Audio(tile.audioUrl);
+    audioRef.current = audio;
+    audio.onended = () => setIsPlaying(false);
+    audio.onerror = () => setIsPlaying(false);
+    setIsPlaying(true);
+    void audio.play().catch(() => {
+      setIsPlaying(false);
+    });
+  };
+
+  const handleClick = () => {
+    if (isLongPress.current) {
+      isLongPress.current = false;
+      return;
+    }
+    if (onEdit) {
+      onEdit();
+      return;
+    }
+    if (isBroken) return;
+    if (isPlaying) {
+      stopAudio();
+      return;
+    }
+    playAudio();
+  };
+
+  const prefersReducedMotion = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const ariaLabel = onEdit
+    ? `Edit audio tile: ${tile.audioLabel}`
+    : isBroken
+      ? `${tile.audioLabel} (audio is unavailable)`
+      : isPlaying
+        ? `Stop audio tile: ${tile.audioLabel}`
+        : `Play audio tile: ${tile.audioLabel}`;
+
+  return (
+    <motion.div
+      data-testid="audio-tile"
+      data-tile-kind="audio"
+      data-broken={isBroken ? 'true' : undefined}
+      className={`relative rounded-xl shadow-md cursor-pointer
+        flex flex-col items-center justify-center min-h-[52px] aspect-square overflow-hidden
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+        ${onEdit
+      ? 'bg-surface border-l-4 border-blue-400'
+      : isBroken
+        ? 'bg-surface border-2 border-dashed border-border opacity-60 cursor-not-allowed'
+        : isPlaying
+          ? 'bg-surface border-2 border-warning'
+          : 'bg-surface border-2 border-primary-400'}
+        ${className}`}
+      onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+      onMouseDown={handleTouchStart}
+      onMouseUp={handleTouchEnd}
+      onMouseLeave={handleTouchEnd}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      whileTap={prefersReducedMotion || isBroken ? undefined : { scale: 0.95 }}
+      animate={prefersReducedMotion ? undefined : {
+        scale: isPressed ? 0.95 : 1,
+      }}
+      transition={{ duration: 0.15 }}
+      role="button"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      aria-disabled={isBroken && !onEdit}
+      aria-pressed={isPlaying}
+    >
+      <div className="absolute top-1 right-1">
+        {isBroken ? (
+          <ExclamationTriangleIcon className="w-4 h-4 text-warning" aria-hidden="true" />
+        ) : isPlaying ? (
+          <StopIcon className="w-4 h-4 text-warning" aria-hidden="true" />
+        ) : (
+          <SpeakerWaveIcon className="w-4 h-4 text-primary-500" aria-hidden="true" />
+        )}
+      </div>
+      <div className="flex flex-col items-center justify-center w-full h-full min-h-0 p-2 gap-1">
+        <SpeakerWaveIcon
+          className={`w-7 h-7 ${isBroken ? 'text-text-tertiary' : 'text-primary-500'}`}
+          aria-hidden="true"
+        />
+        <p
+          className={`font-semibold line-clamp-2 leading-tight text-center w-full ${
+            isBroken ? 'text-text-secondary italic' : 'text-foreground'
+          }`}
+          style={{ fontSize: `${textSizePx}px` }}
+        >
+          {tile.audioLabel}
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/app/components/phrases/tiles/BoardTileRenderer.tsx
+++ b/app/components/phrases/tiles/BoardTileRenderer.tsx
@@ -2,6 +2,7 @@
 
 import PhraseTile from '../PhraseTile';
 import NavigateTile from './NavigateTile';
+import AudioTile from './AudioTile';
 import type { BoardTileSummary, PhraseSummary } from '../types';
 
 interface BoardTileRendererProps {
@@ -15,6 +16,8 @@ interface BoardTileRendererProps {
   // Navigate-tile handlers
   onNavigateTap: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
   onNavigateEdit?: (tile: Extract<BoardTileSummary, { kind: 'navigate' }>) => void;
+  // Audio-tile handlers
+  onAudioEdit?: (tile: Extract<BoardTileSummary, { kind: 'audio' }>) => void;
   // True when the parent grid is in edit mode (long-press → edit on phrase tiles
   // is replaced by tap-to-edit). Both kinds use the same affordance.
   isEditMode?: boolean;
@@ -35,6 +38,7 @@ export default function BoardTileRenderer({
   isPhraseSpeaking = false,
   onNavigateTap,
   onNavigateEdit,
+  onAudioEdit,
   isEditMode = false,
   className,
 }: BoardTileRendererProps) {
@@ -51,6 +55,17 @@ export default function BoardTileRenderer({
         // opens edit (when `onPhraseEdit` is supplied).
         onEdit={isEditMode && onPhraseEdit ? () => onPhraseEdit(phrase) : undefined}
         onLongPress={!isEditMode && onPhraseEdit ? () => onPhraseEdit(phrase) : undefined}
+        textSizePx={textSizePx}
+        className={className}
+      />
+    );
+  }
+  case 'audio': {
+    return (
+      <AudioTile
+        tile={tile}
+        onEdit={isEditMode && onAudioEdit ? () => onAudioEdit(tile) : undefined}
+        onLongPress={!isEditMode && onAudioEdit ? () => onAudioEdit(tile) : undefined}
         textSizePx={textSizePx}
         className={className}
       />

--- a/app/components/phrases/types.ts
+++ b/app/components/phrases/types.ts
@@ -29,6 +29,16 @@ export type BoardTileSummary =
       targetBoardId: string;
       /** Live name of the target board; null when target is missing/deleted. */
       targetBoardName: string | null;
+    }
+  | {
+      id: string;
+      kind: 'audio';
+      position: number;
+      audioLabel: string;
+      audioUrl: string | null;
+      audioMimeType: string;
+      audioDurationMs: number;
+      audioByteSize: number;
     };
 
 export interface BoardSummary {

--- a/app/phrases/boards/[boardId]/tiles/audio/[tileId]/edit/page.tsx
+++ b/app/phrases/boards/[boardId]/tiles/audio/[tileId]/edit/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useMutation, useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import Input from '@/app/components/ui/Input';
@@ -10,20 +11,12 @@ import { Button } from '@/app/components/ui/Button';
 import PageHeader from '@/app/components/ui/PageHeader';
 import AudioRecorderControl, { RecordedAudio } from '@/app/components/phrases/tiles/AudioRecorderControl';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import { MAX_AUDIO_LABEL_LENGTH } from '@/lib/audio/constants';
+import { uploadRecording } from '@/lib/audio/upload';
 
-const MAX_LABEL_LENGTH = 80;
-
-async function uploadRecording(uploadUrl: string, recording: RecordedAudio) {
-  const response = await fetch(uploadUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': recording.blob.type || 'audio/webm' },
-    body: recording.blob,
-  });
-
-  if (!response.ok) throw new Error('Failed to upload audio. Please try again.');
-  const { storageId } = await response.json();
-  return storageId as Id<'_storage'>;
-}
+type BoardData = NonNullable<FunctionReturnType<typeof api.phraseBoards.getPhraseBoard>>;
+type BoardTile = BoardData['tiles'][number];
+type AudioBoardTile = Extract<BoardTile, { kind: 'audio' }>;
 
 function EditAudioTileForm() {
   const router = useRouter();
@@ -37,51 +30,63 @@ function EditAudioTileForm() {
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Prefill the label exactly once when the tile loads. Using a ref (not the
+  // current label value) avoids the footgun where clearing the input would
+  // restore the original on the next re-render.
+  const labelInitialisedRef = useRef(false);
 
   const boardData = useQuery(
     api.phraseBoards.getPhraseBoard,
     boardId ? { id: boardId as Id<'phraseBoards'> } : 'skip'
   );
   const generateUploadUrl = useMutation(api.audio.generateUploadUrl);
+  const deleteOrphanUpload = useMutation(api.audio.deleteOrphanUpload);
   const updateAudioTile = useMutation(api.boardTiles.updateAudioTile);
   const deleteTile = useMutation(api.boardTiles.deleteTile);
 
-  const existingTile = useMemo(() => {
+  const existingTile = useMemo<AudioBoardTile | null>(() => {
     if (!boardData || !tileId) return null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const tiles = (boardData.tiles ?? []) as any[];
-    return tiles.find((tile) => String(tile._id) === tileId && tile.kind === 'audio') ?? null;
+    const tiles = (boardData.tiles ?? []) as BoardTile[];
+    const match = tiles.find(
+      (tile): tile is AudioBoardTile =>
+        String(tile._id) === tileId && tile.kind === 'audio'
+    );
+    return match ?? null;
   }, [boardData, tileId]);
 
   useEffect(() => {
-    if (existingTile && !label) {
+    if (existingTile && !labelInitialisedRef.current) {
       setLabel(existingTile.audioLabel ?? '');
+      labelInitialisedRef.current = true;
     }
-  }, [existingTile, label]);
+  }, [existingTile]);
 
   const trimmedLabel = label.trim();
-  const labelError = trimmedLabel.length > MAX_LABEL_LENGTH
-    ? `Label must be ${MAX_LABEL_LENGTH} characters or fewer`
+  const labelError = trimmedLabel.length > MAX_AUDIO_LABEL_LENGTH
+    ? `Label must be ${MAX_AUDIO_LABEL_LENGTH} characters or fewer`
     : undefined;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!tileId || !existingTile || !trimmedLabel || labelError) return;
+    if (!boardId || !tileId || !existingTile || !trimmedLabel || labelError) return;
 
     setLoading(true);
     setError(null);
+    const typedBoardId = boardId as Id<'phraseBoards'>;
+    let uploadedStorageId: Id<'_storage'> | null = null;
     try {
       if (replacementRecording) {
-        const uploadUrl = await generateUploadUrl();
-        const storageId = await uploadRecording(uploadUrl, replacementRecording);
+        const uploadUrl = await generateUploadUrl({ boardId: typedBoardId });
+        uploadedStorageId = await uploadRecording(uploadUrl, replacementRecording);
         await updateAudioTile({
           tileId: tileId as Id<'boardTiles'>,
           audioLabel: trimmedLabel,
-          audioStorageId: storageId,
+          audioStorageId: uploadedStorageId,
           audioMimeType: replacementRecording.blob.type || 'audio/webm',
           audioDurationMs: replacementRecording.durationMs,
           audioByteSize: replacementRecording.blob.size,
         });
+        uploadedStorageId = null;
       } else {
         await updateAudioTile({
           tileId: tileId as Id<'boardTiles'>,
@@ -92,6 +97,13 @@ function EditAudioTileForm() {
     } catch (err) {
       console.error('Error updating audio tile:', err);
       setError(err instanceof Error ? err.message : 'Failed to update audio tile.');
+      if (uploadedStorageId) {
+        try {
+          await deleteOrphanUpload({ boardId: typedBoardId, storageId: uploadedStorageId });
+        } catch (cleanupErr) {
+          console.error('Failed to clean up orphaned upload:', cleanupErr);
+        }
+      }
     } finally {
       setLoading(false);
     }
@@ -142,7 +154,7 @@ function EditAudioTileForm() {
                 value={label}
                 onChange={(event) => setLabel(event.target.value)}
                 placeholder="Tile label"
-                maxLength={MAX_LABEL_LENGTH}
+                maxLength={MAX_AUDIO_LABEL_LENGTH}
                 required
                 error={labelError}
               />

--- a/app/phrases/boards/[boardId]/tiles/audio/[tileId]/edit/page.tsx
+++ b/app/phrases/boards/[boardId]/tiles/audio/[tileId]/edit/page.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import Input from '@/app/components/ui/Input';
+import { Button } from '@/app/components/ui/Button';
+import PageHeader from '@/app/components/ui/PageHeader';
+import AudioRecorderControl, { RecordedAudio } from '@/app/components/phrases/tiles/AudioRecorderControl';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+
+const MAX_LABEL_LENGTH = 80;
+
+async function uploadRecording(uploadUrl: string, recording: RecordedAudio) {
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': recording.blob.type || 'audio/webm' },
+    body: recording.blob,
+  });
+
+  if (!response.ok) throw new Error('Failed to upload audio. Please try again.');
+  const { storageId } = await response.json();
+  return storageId as Id<'_storage'>;
+}
+
+function EditAudioTileForm() {
+  const router = useRouter();
+  const params = useParams<{ boardId: string; tileId: string }>();
+  const boardId = params?.boardId ?? null;
+  const tileId = params?.tileId ?? null;
+  const { isOnline } = useOnlineStatus();
+
+  const [label, setLabel] = useState('');
+  const [replacementRecording, setReplacementRecording] = useState<RecordedAudio | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const boardData = useQuery(
+    api.phraseBoards.getPhraseBoard,
+    boardId ? { id: boardId as Id<'phraseBoards'> } : 'skip'
+  );
+  const generateUploadUrl = useMutation(api.audio.generateUploadUrl);
+  const updateAudioTile = useMutation(api.boardTiles.updateAudioTile);
+  const deleteTile = useMutation(api.boardTiles.deleteTile);
+
+  const existingTile = useMemo(() => {
+    if (!boardData || !tileId) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tiles = (boardData.tiles ?? []) as any[];
+    return tiles.find((tile) => String(tile._id) === tileId && tile.kind === 'audio') ?? null;
+  }, [boardData, tileId]);
+
+  useEffect(() => {
+    if (existingTile && !label) {
+      setLabel(existingTile.audioLabel ?? '');
+    }
+  }, [existingTile, label]);
+
+  const trimmedLabel = label.trim();
+  const labelError = trimmedLabel.length > MAX_LABEL_LENGTH
+    ? `Label must be ${MAX_LABEL_LENGTH} characters or fewer`
+    : undefined;
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!tileId || !existingTile || !trimmedLabel || labelError) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      if (replacementRecording) {
+        const uploadUrl = await generateUploadUrl();
+        const storageId = await uploadRecording(uploadUrl, replacementRecording);
+        await updateAudioTile({
+          tileId: tileId as Id<'boardTiles'>,
+          audioLabel: trimmedLabel,
+          audioStorageId: storageId,
+          audioMimeType: replacementRecording.blob.type || 'audio/webm',
+          audioDurationMs: replacementRecording.durationMs,
+          audioByteSize: replacementRecording.blob.size,
+        });
+      } else {
+        await updateAudioTile({
+          tileId: tileId as Id<'boardTiles'>,
+          audioLabel: trimmedLabel,
+        });
+      }
+      router.back();
+    } catch (err) {
+      console.error('Error updating audio tile:', err);
+      setError(err instanceof Error ? err.message : 'Failed to update audio tile.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!tileId) return;
+    if (!confirm('Delete this audio tile?')) return;
+
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteTile({ tileId: tileId as Id<'boardTiles'> });
+      router.back();
+    } catch (err) {
+      console.error('Error deleting audio tile:', err);
+      setError(err instanceof Error ? err.message : 'Failed to delete audio tile.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <PageHeader title="Edit Audio Tile" backHref="/" />
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24">
+        <form
+          onSubmit={handleSubmit}
+          className="bg-surface shadow-2xl hover:shadow-3xl transition-all duration-300 rounded-3xl p-8"
+        >
+          {!isOnline && (
+            <div className="mb-4 text-amber-600 text-sm bg-status-warning px-4 py-3 rounded-3xl">
+              Audio tiles need an internet connection.
+            </div>
+          )}
+
+          {boardData === undefined ? (
+            <div className="text-text-tertiary">Loading...</div>
+          ) : !existingTile ? (
+            <div className="mb-4 text-amber-600 bg-status-warning px-4 py-3 rounded-2xl">
+              Tile not found. It may have been deleted.
+            </div>
+          ) : (
+            <>
+              <Input
+                id="audioLabel"
+                label="Tile Label"
+                value={label}
+                onChange={(event) => setLabel(event.target.value)}
+                placeholder="Tile label"
+                maxLength={MAX_LABEL_LENGTH}
+                required
+                error={labelError}
+              />
+
+              {existingTile.audioUrl && (
+                <div className="mb-4">
+                  <label className="block text-foreground text-sm font-semibold mb-2">
+                    Current Audio
+                  </label>
+                  <audio controls src={existingTile.audioUrl} className="w-full" />
+                </div>
+              )}
+
+              <div className="mb-4">
+                <label className="block text-foreground text-sm font-semibold mb-2">
+                  Replacement Audio
+                </label>
+                <AudioRecorderControl value={replacementRecording} onChange={setReplacementRecording} />
+              </div>
+            </>
+          )}
+
+          {error && (
+            <div className="mb-4 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-between items-center">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleDelete}
+              disabled={deleting || !isOnline || !existingTile}
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading || !isOnline || !existingTile || !trimmedLabel || !!labelError}
+            >
+              {loading ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function EditAudioTilePage() {
+  return (
+    <Suspense fallback={<div className="text-foreground">Loading...</div>}>
+      <EditAudioTileForm />
+    </Suspense>
+  );
+}

--- a/app/phrases/boards/[boardId]/tiles/audio/add/page.tsx
+++ b/app/phrases/boards/[boardId]/tiles/audio/add/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import Input from '@/app/components/ui/Input';
+import { Button } from '@/app/components/ui/Button';
+import PageHeader from '@/app/components/ui/PageHeader';
+import AudioRecorderControl, { RecordedAudio } from '@/app/components/phrases/tiles/AudioRecorderControl';
+import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+
+const MAX_LABEL_LENGTH = 80;
+
+async function uploadRecording(uploadUrl: string, recording: RecordedAudio) {
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': recording.blob.type || 'audio/webm' },
+    body: recording.blob,
+  });
+
+  if (!response.ok) throw new Error('Failed to upload audio. Please try again.');
+  const { storageId } = await response.json();
+  return storageId as Id<'_storage'>;
+}
+
+function AddAudioTileForm() {
+  const router = useRouter();
+  const params = useParams<{ boardId: string }>();
+  const boardId = params?.boardId ?? null;
+  const { isOnline } = useOnlineStatus();
+
+  const [label, setLabel] = useState('');
+  const [recording, setRecording] = useState<RecordedAudio | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generateUploadUrl = useMutation(api.audio.generateUploadUrl);
+  const addAudioTile = useMutation(api.boardTiles.addAudioTile);
+
+  const trimmedLabel = label.trim();
+  const labelError = trimmedLabel.length > MAX_LABEL_LENGTH
+    ? `Label must be ${MAX_LABEL_LENGTH} characters or fewer`
+    : undefined;
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!boardId || !recording || !trimmedLabel || labelError) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const uploadUrl = await generateUploadUrl();
+      const storageId = await uploadRecording(uploadUrl, recording);
+      await addAudioTile({
+        boardId: boardId as Id<'phraseBoards'>,
+        audioLabel: trimmedLabel,
+        audioStorageId: storageId,
+        audioMimeType: recording.blob.type || 'audio/webm',
+        audioDurationMs: recording.durationMs,
+        audioByteSize: recording.blob.size,
+      });
+      router.back();
+    } catch (err) {
+      console.error('Error adding audio tile:', err);
+      setError(err instanceof Error ? err.message : 'Failed to add audio tile.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <PageHeader title="Add Audio Tile" backHref="/" />
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pb-24">
+        <form
+          onSubmit={handleSubmit}
+          className="bg-surface shadow-2xl hover:shadow-3xl transition-all duration-300 rounded-3xl p-8"
+        >
+          {!isOnline && (
+            <div className="mb-4 text-amber-600 text-sm bg-status-warning px-4 py-3 rounded-3xl">
+              Audio tiles need an internet connection.
+            </div>
+          )}
+
+          <Input
+            id="audioLabel"
+            label="Tile Label"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder="Tile label"
+            maxLength={MAX_LABEL_LENGTH}
+            required
+            error={labelError}
+          />
+
+          <div className="mb-4">
+            <label className="block text-foreground text-sm font-semibold mb-2">
+              Audio
+            </label>
+            <AudioRecorderControl value={recording} onChange={setRecording} />
+          </div>
+
+          {error && (
+            <div className="mb-4 text-red-500 text-sm bg-status-error px-4 py-3 rounded-3xl">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={loading || !isOnline || !trimmedLabel || !!labelError || !recording}
+            >
+              {loading ? 'Adding...' : 'Add Audio Tile'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function AddAudioTilePage() {
+  return (
+    <Suspense fallback={<div className="text-foreground">Loading...</div>}>
+      <AddAudioTileForm />
+    </Suspense>
+  );
+}

--- a/app/phrases/boards/[boardId]/tiles/audio/add/page.tsx
+++ b/app/phrases/boards/[boardId]/tiles/audio/add/page.tsx
@@ -10,20 +10,8 @@ import { Button } from '@/app/components/ui/Button';
 import PageHeader from '@/app/components/ui/PageHeader';
 import AudioRecorderControl, { RecordedAudio } from '@/app/components/phrases/tiles/AudioRecorderControl';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
-
-const MAX_LABEL_LENGTH = 80;
-
-async function uploadRecording(uploadUrl: string, recording: RecordedAudio) {
-  const response = await fetch(uploadUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': recording.blob.type || 'audio/webm' },
-    body: recording.blob,
-  });
-
-  if (!response.ok) throw new Error('Failed to upload audio. Please try again.');
-  const { storageId } = await response.json();
-  return storageId as Id<'_storage'>;
-}
+import { MAX_AUDIO_LABEL_LENGTH } from '@/lib/audio/constants';
+import { uploadRecording } from '@/lib/audio/upload';
 
 function AddAudioTileForm() {
   const router = useRouter();
@@ -37,11 +25,12 @@ function AddAudioTileForm() {
   const [error, setError] = useState<string | null>(null);
 
   const generateUploadUrl = useMutation(api.audio.generateUploadUrl);
+  const deleteOrphanUpload = useMutation(api.audio.deleteOrphanUpload);
   const addAudioTile = useMutation(api.boardTiles.addAudioTile);
 
   const trimmedLabel = label.trim();
-  const labelError = trimmedLabel.length > MAX_LABEL_LENGTH
-    ? `Label must be ${MAX_LABEL_LENGTH} characters or fewer`
+  const labelError = trimmedLabel.length > MAX_AUDIO_LABEL_LENGTH
+    ? `Label must be ${MAX_AUDIO_LABEL_LENGTH} characters or fewer`
     : undefined;
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -50,21 +39,33 @@ function AddAudioTileForm() {
 
     setLoading(true);
     setError(null);
+    const typedBoardId = boardId as Id<'phraseBoards'>;
+    let uploadedStorageId: Id<'_storage'> | null = null;
     try {
-      const uploadUrl = await generateUploadUrl();
-      const storageId = await uploadRecording(uploadUrl, recording);
+      const uploadUrl = await generateUploadUrl({ boardId: typedBoardId });
+      uploadedStorageId = await uploadRecording(uploadUrl, recording);
       await addAudioTile({
-        boardId: boardId as Id<'phraseBoards'>,
+        boardId: typedBoardId,
         audioLabel: trimmedLabel,
-        audioStorageId: storageId,
+        audioStorageId: uploadedStorageId,
         audioMimeType: recording.blob.type || 'audio/webm',
         audioDurationMs: recording.durationMs,
         audioByteSize: recording.blob.size,
       });
+      // Tile owns the storageId now; clear so the catch below doesn't reap it.
+      uploadedStorageId = null;
       router.back();
     } catch (err) {
       console.error('Error adding audio tile:', err);
       setError(err instanceof Error ? err.message : 'Failed to add audio tile.');
+      // If we uploaded but the tile insert failed, reap the orphaned blob.
+      if (uploadedStorageId) {
+        try {
+          await deleteOrphanUpload({ boardId: typedBoardId, storageId: uploadedStorageId });
+        } catch (cleanupErr) {
+          console.error('Failed to clean up orphaned upload:', cleanupErr);
+        }
+      }
     } finally {
       setLoading(false);
     }
@@ -90,7 +91,7 @@ function AddAudioTileForm() {
             value={label}
             onChange={(event) => setLabel(event.target.value)}
             placeholder="Tile label"
-            maxLength={MAX_LABEL_LENGTH}
+            maxLength={MAX_AUDIO_LABEL_LENGTH}
             required
             error={labelError}
           />

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as audio from "../audio.js";
 import type * as boardTiles from "../boardTiles.js";
 import type * as caregiverClients from "../caregiverClients.js";
 import type * as connectionRequests from "../connectionRequests.js";
@@ -28,6 +29,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  audio: typeof audio;
   boardTiles: typeof boardTiles;
   caregiverClients: typeof caregiverClients;
   connectionRequests: typeof connectionRequests;

--- a/convex/audio.ts
+++ b/convex/audio.ts
@@ -1,13 +1,58 @@
+import { v } from 'convex/values';
 import { mutation } from './_generated/server';
 import { getUserIdentity } from './users';
+import { getBoardAccess } from './boardAccess';
 
+/**
+ * Mint a one-shot upload URL for a recording destined for `boardId`.
+ *
+ * The boardId is required (and edit-access verified) so that an authenticated
+ * user can only consume storage tied to a board they can already mutate. This
+ * caps abuse to the user's own boards rather than letting any logged-in user
+ * upload arbitrary blobs to global storage.
+ */
 export const generateUploadUrl = mutation({
-  handler: async (ctx) => {
+  args: { boardId: v.id('phraseBoards') },
+  handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
-    if (!identity) {
-      throw new Error('Unauthenticated');
-    }
+    if (!identity) throw new Error('Unauthenticated');
+
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access) throw new Error('Board not found');
+    if (!access.canEdit) throw new Error('Unauthorized - board');
 
     return await ctx.storage.generateUploadUrl();
+  },
+});
+
+/**
+ * Delete a freshly-uploaded storage object that ended up unreferenced.
+ *
+ * Used by the client when the upload succeeded but the subsequent
+ * `addAudioTile` / `updateAudioTile` mutation failed — without this hook, the
+ * blob would leak in storage. Refuses to delete if any tile already
+ * references the storageId, so a misuse can't unhook a live tile.
+ */
+export const deleteOrphanUpload = mutation({
+  args: {
+    boardId: v.id('phraseBoards'),
+    storageId: v.id('_storage'),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access || !access.canEdit) throw new Error('Unauthorized');
+
+    const referencing = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_audio_storage', (q) => q.eq('audioStorageId', args.storageId))
+      .first();
+    if (referencing) {
+      // Safety: never delete a storage object that's referenced by a tile.
+      return;
+    }
+    await ctx.storage.delete(args.storageId);
   },
 });

--- a/convex/audio.ts
+++ b/convex/audio.ts
@@ -1,0 +1,13 @@
+import { mutation } from './_generated/server';
+import { getUserIdentity } from './users';
+
+export const generateUploadUrl = mutation({
+  handler: async (ctx) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    return await ctx.storage.generateUploadUrl();
+  },
+});

--- a/convex/audioLimits.ts
+++ b/convex/audioLimits.ts
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------
+// Audio tile limits and validators.
+//
+// IMPORTANT: This module deliberately contains only constants and pure
+// functions — no Convex imports. That lets the frontend re-export from here
+// (see lib/audio/constants.ts) so client-side checks stay in lock-step with
+// server-side enforcement.
+// ---------------------------------------------------------------------------
+
+export const MAX_AUDIO_LABEL_LENGTH = 80;
+export const MAX_AUDIO_DURATION_MS = 60_000;
+/** ~5 MB. A 60s opus/aac clip is well under this; WAV will exceed it (intentional). */
+export const MAX_AUDIO_BYTES = 5 * 1024 * 1024;
+/** Show a "X seconds left" warning when the remaining time falls under this. */
+export const COUNTDOWN_WARNING_MS = 10_000;
+
+/**
+ * MIME types we accept on the server. Codec parameters (e.g. `;codecs=opus`)
+ * are stripped before comparison.
+ */
+export const ALLOWED_AUDIO_MIME_TYPES = [
+  'audio/webm',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/ogg',
+  'audio/wav',
+  'audio/x-wav',
+  'audio/aac',
+] as const;
+
+export type AllowedAudioMimeType = typeof ALLOWED_AUDIO_MIME_TYPES[number];
+
+export function normaliseAudioMimeType(mime: string): string {
+  return (mime.split(';')[0] ?? '').trim().toLowerCase();
+}
+
+export function isAllowedAudioMimeType(mime: string): boolean {
+  const base = normaliseAudioMimeType(mime);
+  return (ALLOWED_AUDIO_MIME_TYPES as readonly string[]).includes(base);
+}
+
+export function validateAudioLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) throw new Error('Audio tile label is required');
+  if (trimmed.length > MAX_AUDIO_LABEL_LENGTH) {
+    throw new Error(`Audio tile label must be ${MAX_AUDIO_LABEL_LENGTH} characters or fewer`);
+  }
+  return trimmed;
+}
+
+export function validateAudioMetadata(args: {
+  audioMimeType: string;
+  audioDurationMs: number;
+  audioByteSize: number;
+}) {
+  if (!args.audioMimeType || !isAllowedAudioMimeType(args.audioMimeType)) {
+    throw new Error(
+      `Audio MIME type must be one of: ${ALLOWED_AUDIO_MIME_TYPES.join(', ')}`
+    );
+  }
+  if (args.audioDurationMs <= 0 || args.audioDurationMs > MAX_AUDIO_DURATION_MS) {
+    throw new Error(`Audio recording must be ${MAX_AUDIO_DURATION_MS / 1000} seconds or less`);
+  }
+  if (args.audioByteSize <= 0) {
+    throw new Error('Audio recording is empty');
+  }
+  if (args.audioByteSize > MAX_AUDIO_BYTES) {
+    const mb = (MAX_AUDIO_BYTES / (1024 * 1024)).toFixed(0);
+    throw new Error(`Audio recording exceeds ${mb} MB limit`);
+  }
+}

--- a/convex/boardAccess.ts
+++ b/convex/boardAccess.ts
@@ -1,0 +1,34 @@
+import type { QueryCtx } from './_generated/server';
+import type { Doc, Id } from './_generated/dataModel';
+
+// ---------------------------------------------------------------------------
+// Shared board access helper
+//
+// Used by mutations/queries that need to gate on whether the caller can read
+// or edit a given phraseBoard. Centralised here so that audio uploads and
+// tile mutations apply identical rules.
+// ---------------------------------------------------------------------------
+
+export type BoardAccess = {
+  board: Doc<'phraseBoards'>;
+  isOwner: boolean;
+  canEdit: boolean;
+  canRead: boolean;
+};
+
+export async function getBoardAccess(
+  ctx: QueryCtx,
+  boardId: Id<'phraseBoards'>,
+  userId: string
+): Promise<BoardAccess | null> {
+  const board = await ctx.db.get(boardId);
+  if (!board) return null;
+
+  const isOwner = board.userId === userId;
+  const isAssignedClient = board.forClientId === userId;
+  const canEdit =
+    isOwner || (isAssignedClient && board.clientAccessLevel === 'edit');
+  const canRead = isOwner || isAssignedClient;
+
+  return { board, isOwner, canEdit, canRead };
+}

--- a/convex/boardTiles.ts
+++ b/convex/boardTiles.ts
@@ -1,63 +1,13 @@
 import { v } from 'convex/values';
-import { mutation, query, type QueryCtx } from './_generated/server';
+import { mutation, query } from './_generated/server';
 import type { Doc, Id } from './_generated/dataModel';
 import { getUserIdentity } from './users';
-
-// ---------------------------------------------------------------------------
-// Access helpers
-// ---------------------------------------------------------------------------
-
-type BoardAccess = {
-  board: Doc<'phraseBoards'>;
-  isOwner: boolean;
-  canEdit: boolean;
-  canRead: boolean;
-};
-
-const MAX_AUDIO_LABEL_LENGTH = 80;
-const MAX_AUDIO_DURATION_MS = 60_000;
-
-function validateAudioLabel(label: string): string {
-  const trimmed = label.trim();
-  if (!trimmed) throw new Error('Audio tile label is required');
-  if (trimmed.length > MAX_AUDIO_LABEL_LENGTH) {
-    throw new Error(`Audio tile label must be ${MAX_AUDIO_LABEL_LENGTH} characters or fewer`);
-  }
-  return trimmed;
-}
-
-function validateAudioMetadata(args: {
-  audioMimeType: string;
-  audioDurationMs: number;
-  audioByteSize: number;
-}) {
-  if (!args.audioMimeType.startsWith('audio/')) {
-    throw new Error('Audio file must use an audio MIME type');
-  }
-  if (args.audioDurationMs <= 0 || args.audioDurationMs > MAX_AUDIO_DURATION_MS) {
-    throw new Error('Audio recording must be 60 seconds or less');
-  }
-  if (args.audioByteSize <= 0) {
-    throw new Error('Audio recording is empty');
-  }
-}
-
-async function getBoardAccess(
-  ctx: QueryCtx,
-  boardId: Id<'phraseBoards'>,
-  userId: string
-): Promise<BoardAccess | null> {
-  const board = await ctx.db.get(boardId);
-  if (!board) return null;
-
-  const isOwner = board.userId === userId;
-  const isAssignedClient = board.forClientId === userId;
-  const canEdit =
-    isOwner || (isAssignedClient && board.clientAccessLevel === 'edit');
-  const canRead = isOwner || isAssignedClient;
-
-  return { board, isOwner, canEdit, canRead };
-}
+import { getBoardAccess } from './boardAccess';
+import {
+  normaliseAudioMimeType,
+  validateAudioLabel,
+  validateAudioMetadata,
+} from './audioLimits';
 
 // ---------------------------------------------------------------------------
 // Query: list tiles on a board (polymorphic, hydrated)
@@ -85,7 +35,8 @@ export type ListedBoardTile =
       position: number;
       kind: 'audio';
       audioLabel: string;
-      audioStorageId: Id<'_storage'>;
+      /** null when the underlying storage object is missing/unrecoverable. */
+      audioStorageId: Id<'_storage'> | null;
       audioUrl: string | null;
       audioMimeType: string;
       audioDurationMs: number;
@@ -121,6 +72,10 @@ export const listByBoard = query({
           };
         }
         if (row.kind === 'audio') {
+          // Defensive: a row could be missing one or more audio fields if it
+          // was written by an older client or partially hydrated. Surface a
+          // broken-state tile (audioUrl=null, audioStorageId=null) — the
+          // renderer keys on audioUrl===null and shows the disabled affordance.
           if (
             !row.audioLabel ||
             !row.audioStorageId ||
@@ -134,9 +89,9 @@ export const listByBoard = query({
               position: row.position,
               kind: 'audio',
               audioLabel: row.audioLabel ?? 'Audio tile',
-              audioStorageId: row.audioStorageId ?? (row._id as unknown as Id<'_storage'>),
+              audioStorageId: null,
               audioUrl: null,
-              audioMimeType: row.audioMimeType ?? 'audio/webm',
+              audioMimeType: row.audioMimeType ?? '',
               audioDurationMs: row.audioDurationMs ?? 0,
               audioByteSize: row.audioByteSize ?? 0,
             };
@@ -215,6 +170,10 @@ export const addAudioTile = mutation({
 
     const audioLabel = validateAudioLabel(args.audioLabel);
     validateAudioMetadata(args);
+    // Strip codec parameters before persisting (keeps stored values uniform
+    // across browsers — Chromium emits "audio/webm;codecs=opus", Safari emits
+    // "audio/mp4;codecs=mp4a.40.2", etc.).
+    const audioMimeType = normaliseAudioMimeType(args.audioMimeType);
 
     const existingTiles = await ctx.db
       .query('boardTiles')
@@ -227,7 +186,7 @@ export const addAudioTile = mutation({
       kind: 'audio',
       audioLabel,
       audioStorageId: args.audioStorageId,
-      audioMimeType: args.audioMimeType,
+      audioMimeType,
       audioDurationMs: args.audioDurationMs,
       audioByteSize: args.audioByteSize,
     });
@@ -279,7 +238,7 @@ export const updateAudioTile = mutation({
         audioByteSize: args.audioByteSize,
       });
       patch.audioStorageId = args.audioStorageId;
-      patch.audioMimeType = args.audioMimeType;
+      patch.audioMimeType = normaliseAudioMimeType(args.audioMimeType);
       patch.audioDurationMs = args.audioDurationMs;
       patch.audioByteSize = args.audioByteSize;
     }

--- a/convex/boardTiles.ts
+++ b/convex/boardTiles.ts
@@ -14,6 +14,34 @@ type BoardAccess = {
   canRead: boolean;
 };
 
+const MAX_AUDIO_LABEL_LENGTH = 80;
+const MAX_AUDIO_DURATION_MS = 60_000;
+
+function validateAudioLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) throw new Error('Audio tile label is required');
+  if (trimmed.length > MAX_AUDIO_LABEL_LENGTH) {
+    throw new Error(`Audio tile label must be ${MAX_AUDIO_LABEL_LENGTH} characters or fewer`);
+  }
+  return trimmed;
+}
+
+function validateAudioMetadata(args: {
+  audioMimeType: string;
+  audioDurationMs: number;
+  audioByteSize: number;
+}) {
+  if (!args.audioMimeType.startsWith('audio/')) {
+    throw new Error('Audio file must use an audio MIME type');
+  }
+  if (args.audioDurationMs <= 0 || args.audioDurationMs > MAX_AUDIO_DURATION_MS) {
+    throw new Error('Audio recording must be 60 seconds or less');
+  }
+  if (args.audioByteSize <= 0) {
+    throw new Error('Audio recording is empty');
+  }
+}
+
 async function getBoardAccess(
   ctx: QueryCtx,
   boardId: Id<'phraseBoards'>,
@@ -50,6 +78,18 @@ export type ListedBoardTile =
       kind: 'navigate';
       targetBoardId: Id<'phraseBoards'>;
       targetBoardName: string | null;
+    }
+  | {
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'audio';
+      audioLabel: string;
+      audioStorageId: Id<'_storage'>;
+      audioUrl: string | null;
+      audioMimeType: string;
+      audioDurationMs: number;
+      audioByteSize: number;
     };
 
 export const listByBoard = query({
@@ -80,6 +120,43 @@ export const listByBoard = query({
             phrase: phrase ?? null,
           };
         }
+        if (row.kind === 'audio') {
+          if (
+            !row.audioLabel ||
+            !row.audioStorageId ||
+            !row.audioMimeType ||
+            typeof row.audioDurationMs !== 'number' ||
+            typeof row.audioByteSize !== 'number'
+          ) {
+            return {
+              _id: row._id,
+              boardId: row.boardId,
+              position: row.position,
+              kind: 'audio',
+              audioLabel: row.audioLabel ?? 'Audio tile',
+              audioStorageId: row.audioStorageId ?? (row._id as unknown as Id<'_storage'>),
+              audioUrl: null,
+              audioMimeType: row.audioMimeType ?? 'audio/webm',
+              audioDurationMs: row.audioDurationMs ?? 0,
+              audioByteSize: row.audioByteSize ?? 0,
+            };
+          }
+
+          const audioUrl = await ctx.storage.getUrl(row.audioStorageId);
+          return {
+            _id: row._id,
+            boardId: row.boardId,
+            position: row.position,
+            kind: 'audio',
+            audioLabel: row.audioLabel,
+            audioStorageId: row.audioStorageId,
+            audioUrl,
+            audioMimeType: row.audioMimeType,
+            audioDurationMs: row.audioDurationMs,
+            audioByteSize: row.audioByteSize,
+          };
+        }
+
         // kind === 'navigate'
         const targetBoardId = row.targetBoardId;
         if (!targetBoardId) {
@@ -112,6 +189,106 @@ export const listByBoard = query({
     );
 
     return hydrated;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: add an audio-kind tile
+// ---------------------------------------------------------------------------
+
+export const addAudioTile = mutation({
+  args: {
+    boardId: v.id('phraseBoards'),
+    audioLabel: v.string(),
+    audioStorageId: v.id('_storage'),
+    audioMimeType: v.string(),
+    audioDurationMs: v.number(),
+    audioByteSize: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const access = await getBoardAccess(ctx, args.boardId, identity.subject);
+    if (!access) throw new Error('Board not found');
+    if (!access.canEdit) throw new Error('Unauthorized - board');
+
+    const audioLabel = validateAudioLabel(args.audioLabel);
+    validateAudioMetadata(args);
+
+    const existingTiles = await ctx.db
+      .query('boardTiles')
+      .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
+      .collect();
+
+    return await ctx.db.insert('boardTiles', {
+      boardId: args.boardId,
+      position: existingTiles.length,
+      kind: 'audio',
+      audioLabel,
+      audioStorageId: args.audioStorageId,
+      audioMimeType: args.audioMimeType,
+      audioDurationMs: args.audioDurationMs,
+      audioByteSize: args.audioByteSize,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mutation: update an audio-kind tile
+// ---------------------------------------------------------------------------
+
+export const updateAudioTile = mutation({
+  args: {
+    tileId: v.id('boardTiles'),
+    audioLabel: v.optional(v.string()),
+    audioStorageId: v.optional(v.id('_storage')),
+    audioMimeType: v.optional(v.string()),
+    audioDurationMs: v.optional(v.number()),
+    audioByteSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) throw new Error('Unauthenticated');
+
+    const tile = await ctx.db.get(args.tileId);
+    if (!tile) throw new Error('Tile not found');
+    if (tile.kind !== 'audio') throw new Error('Tile is not an audio tile');
+
+    const access = await getBoardAccess(ctx, tile.boardId, identity.subject);
+    if (!access || !access.canEdit) throw new Error('Unauthorized');
+
+    const patch: Partial<Doc<'boardTiles'>> = {};
+
+    if (args.audioLabel !== undefined) {
+      patch.audioLabel = validateAudioLabel(args.audioLabel);
+    }
+
+    const isReplacingAudio = args.audioStorageId !== undefined;
+    if (isReplacingAudio) {
+      if (
+        args.audioMimeType === undefined ||
+        args.audioDurationMs === undefined ||
+        args.audioByteSize === undefined
+      ) {
+        throw new Error('Replacement audio metadata is required');
+      }
+      validateAudioMetadata({
+        audioMimeType: args.audioMimeType,
+        audioDurationMs: args.audioDurationMs,
+        audioByteSize: args.audioByteSize,
+      });
+      patch.audioStorageId = args.audioStorageId;
+      patch.audioMimeType = args.audioMimeType;
+      patch.audioDurationMs = args.audioDurationMs;
+      patch.audioByteSize = args.audioByteSize;
+    }
+
+    await ctx.db.patch(args.tileId, patch);
+
+    if (isReplacingAudio && tile.audioStorageId) {
+      await ctx.storage.delete(tile.audioStorageId);
+    }
   },
 });
 
@@ -291,6 +468,10 @@ export const deleteTile = mutation({
 
     const access = await getBoardAccess(ctx, tile.boardId, identity.subject);
     if (!access || !access.canEdit) throw new Error('Unauthorized');
+
+    if (tile.kind === 'audio' && tile.audioStorageId) {
+      await ctx.storage.delete(tile.audioStorageId);
+    }
 
     await ctx.db.delete(args.tileId);
   },

--- a/convex/phraseBoards.ts
+++ b/convex/phraseBoards.ts
@@ -42,7 +42,8 @@ type PolymorphicBoardTile =
       position: number;
       kind: 'audio';
       audioLabel: string;
-      audioStorageId: Id<'_storage'>;
+      /** null when the underlying storage object is missing/unrecoverable. */
+      audioStorageId: Id<'_storage'> | null;
       audioUrl: string | null;
       audioMimeType: string;
       audioDurationMs: number;
@@ -97,6 +98,8 @@ async function loadHydratedBoardTiles(
     }
 
     if (row.kind === 'audio') {
+      // Defensive: surface a broken-state tile if the row is missing one or
+      // more required audio fields. Renderer keys on audioUrl===null.
       if (
         !row.audioLabel ||
         !row.audioStorageId ||
@@ -110,9 +113,9 @@ async function loadHydratedBoardTiles(
           position: row.position,
           kind: 'audio',
           audioLabel: row.audioLabel ?? 'Audio tile',
-          audioStorageId: row.audioStorageId ?? (row._id as unknown as Id<'_storage'>),
+          audioStorageId: null,
           audioUrl: null,
-          audioMimeType: row.audioMimeType ?? 'audio/webm',
+          audioMimeType: row.audioMimeType ?? '',
           audioDurationMs: row.audioDurationMs ?? 0,
           audioByteSize: row.audioByteSize ?? 0,
         });

--- a/convex/phraseBoards.ts
+++ b/convex/phraseBoards.ts
@@ -35,6 +35,18 @@ type PolymorphicBoardTile =
       kind: 'navigate';
       targetBoardId: Id<'phraseBoards'>;
       targetBoardName: string | null;
+    }
+  | {
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'audio';
+      audioLabel: string;
+      audioStorageId: Id<'_storage'>;
+      audioUrl: string | null;
+      audioMimeType: string;
+      audioDurationMs: number;
+      audioByteSize: number;
     };
 
 function viewerCanReadBoard(
@@ -81,6 +93,44 @@ async function loadHydratedBoardTiles(
           phrase,
         });
       }
+      continue;
+    }
+
+    if (row.kind === 'audio') {
+      if (
+        !row.audioLabel ||
+        !row.audioStorageId ||
+        !row.audioMimeType ||
+        typeof row.audioDurationMs !== 'number' ||
+        typeof row.audioByteSize !== 'number'
+      ) {
+        tiles.push({
+          _id: row._id,
+          boardId: row.boardId,
+          position: row.position,
+          kind: 'audio',
+          audioLabel: row.audioLabel ?? 'Audio tile',
+          audioStorageId: row.audioStorageId ?? (row._id as unknown as Id<'_storage'>),
+          audioUrl: null,
+          audioMimeType: row.audioMimeType ?? 'audio/webm',
+          audioDurationMs: row.audioDurationMs ?? 0,
+          audioByteSize: row.audioByteSize ?? 0,
+        });
+        continue;
+      }
+
+      tiles.push({
+        _id: row._id,
+        boardId: row.boardId,
+        position: row.position,
+        kind: 'audio',
+        audioLabel: row.audioLabel,
+        audioStorageId: row.audioStorageId,
+        audioUrl: await ctx.storage.getUrl(row.audioStorageId),
+        audioMimeType: row.audioMimeType,
+        audioDurationMs: row.audioDurationMs,
+        audioByteSize: row.audioByteSize,
+      });
       continue;
     }
 
@@ -398,6 +448,9 @@ export const deletePhraseBoard = mutation({
       .collect();
 
     for (const tile of tilesOnBoard) {
+      if (tile.kind === 'audio' && tile.audioStorageId) {
+        await ctx.storage.delete(tile.audioStorageId);
+      }
       await ctx.db.delete(tile._id);
       if (tile.kind === 'phrase' && tile.phraseId) {
         await ctx.db.delete(tile.phraseId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -65,15 +65,22 @@ export default defineSchema({
   boardTiles: defineTable({
     boardId: v.id('phraseBoards'),
     position: v.number(),
-    kind: v.union(v.literal('phrase'), v.literal('navigate')),
+    kind: v.union(v.literal('phrase'), v.literal('navigate'), v.literal('audio')),
     // kind === 'phrase'
     phraseId: v.optional(v.id('phrases')),
     // kind === 'navigate'
     targetBoardId: v.optional(v.id('phraseBoards')),
+    // kind === 'audio'
+    audioLabel: v.optional(v.string()),
+    audioStorageId: v.optional(v.id('_storage')),
+    audioMimeType: v.optional(v.string()),
+    audioDurationMs: v.optional(v.number()),
+    audioByteSize: v.optional(v.number()),
   })
     .index('by_board', ['boardId'])
     .index('by_phrase', ['phraseId'])
-    .index('by_target_board', ['targetBoardId']),
+    .index('by_target_board', ['targetBoardId'])
+    .index('by_audio_storage', ['audioStorageId']),
 
   typingSessions: defineTable({
     userId: v.string(), // Clerk user ID

--- a/lib/audio/constants.ts
+++ b/lib/audio/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Re-export of audio limits from the Convex side so that client-side checks
+ * (form validation, recorder UI) stay locked to whatever the server enforces.
+ *
+ * Importing from `@/convex/audioLimits` is safe because that file deliberately
+ * has no Convex runtime imports — only constants and pure functions.
+ */
+export {
+  MAX_AUDIO_LABEL_LENGTH,
+  MAX_AUDIO_DURATION_MS,
+  MAX_AUDIO_BYTES,
+  COUNTDOWN_WARNING_MS,
+  ALLOWED_AUDIO_MIME_TYPES,
+  isAllowedAudioMimeType,
+  normaliseAudioMimeType,
+} from '@/convex/audioLimits';

--- a/lib/audio/upload.ts
+++ b/lib/audio/upload.ts
@@ -1,0 +1,33 @@
+import type { Id } from '@/convex/_generated/dataModel';
+import type { RecordedAudio } from '@/app/components/phrases/tiles/AudioRecorderControl';
+import { isAllowedAudioMimeType } from './constants';
+
+/**
+ * POST a recording to a Convex storage upload URL and return the resulting
+ * storageId.
+ *
+ * Throws if the recording's MIME type is not in the allow-list (mirrors
+ * server-side `validateAudioMetadata` so the user gets a clear error before
+ * the upload is attempted) or if the upload itself fails.
+ */
+export async function uploadRecording(
+  uploadUrl: string,
+  recording: RecordedAudio,
+): Promise<Id<'_storage'>> {
+  const contentType = recording.blob.type || '';
+  if (!isAllowedAudioMimeType(contentType)) {
+    throw new Error(
+      'Your browser produced an audio format we don\'t support. Try a different browser.',
+    );
+  }
+
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body: recording.blob,
+  });
+
+  if (!response.ok) throw new Error('Failed to upload audio. Please try again.');
+  const { storageId } = await response.json();
+  return storageId as Id<'_storage'>;
+}

--- a/lib/hooks/usePhraseBoardData.ts
+++ b/lib/hooks/usePhraseBoardData.ts
@@ -95,6 +95,19 @@ export function usePhraseBoardData() {
           },
         };
       }
+      if (tile.kind === 'audio') {
+        return {
+          id: String(tile._id),
+          kind: 'audio',
+          position: tile.position,
+          audioLabel: tile.audioLabel,
+          audioUrl: tile.audioUrl ?? null,
+          audioMimeType: tile.audioMimeType,
+          audioDurationMs: tile.audioDurationMs,
+          audioByteSize: tile.audioByteSize,
+        };
+      }
+
       // kind === 'navigate'
       return {
         id: String(tile._id),
@@ -191,6 +204,11 @@ export function usePhraseBoardData() {
     router.push(`/phrases/boards/${selectedBoardId}/tiles/navigate/add`);
   };
 
+  const handleAddAudioTile = () => {
+    if (!isOnline || !selectedBoardId || !canEditCurrentBoard) return;
+    router.push(`/phrases/boards/${selectedBoardId}/tiles/audio/add`);
+  };
+
   const handleEditPhrase = (phrase: PhraseSummary) => {
     if (!isOnline || !selectedBoardId) return;
     router.push(`/phrases/edit/${phrase.id}?boardId=${selectedBoardId}`);
@@ -199,6 +217,11 @@ export function usePhraseBoardData() {
   const handleEditNavigateTile = (tileId: string) => {
     if (!isOnline || !selectedBoardId) return;
     router.push(`/phrases/boards/${selectedBoardId}/tiles/navigate/${tileId}/edit`);
+  };
+
+  const handleEditAudioTile = (tileId: string) => {
+    if (!isOnline || !selectedBoardId) return;
+    router.push(`/phrases/boards/${selectedBoardId}/tiles/audio/${tileId}/edit`);
   };
 
   const handleAddBoard = () => {
@@ -240,8 +263,10 @@ export function usePhraseBoardData() {
     handleReorderTiles,
     handleAddPhrase,
     handleAddNavigateTile,
+    handleAddAudioTile,
     handleEditPhrase,
     handleEditNavigateTile,
+    handleEditAudioTile,
     handleAddBoard,
     handleEditBoard,
     handleAddAsPhrase,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-media-recorder": "^1.7.2",
         "react-tooltip": "^5.30.1",
         "svix": "^1.90.0",
         "tailwind-merge": "^3.5.0",
@@ -630,7 +631,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6759,6 +6759,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/automation-events": {
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.19.tgz",
+      "integrity": "sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -7005,6 +7018,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.14.tgz",
+      "integrity": "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
       }
     },
     "node_modules/browserslist": {
@@ -7442,6 +7467,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/compilerr": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/compilerr/-/compilerr-10.0.2.tgz",
+      "integrity": "sha512-CFwUXxJ9OuWsSvnLSbefxi+GLsZ0YnuJh40ry5QdmZ1FWK59OG+QB8XSj6t7Kq+/c5DSS7en+cML6GlzHKH58A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "dashify": "^2.0.0",
+        "indefinite-article": "0.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.4"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7590,6 +7630,15 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dashify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
+      "integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -8899,6 +8948,56 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/extendable-media-recorder": {
+      "version": "6.6.10",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder/-/extendable-media-recorder-6.6.10.tgz",
+      "integrity": "sha512-gnSmLqDFq40ZdbGfuarnMLNqYPLCPpPr0p21V+g67wG4Pv2oCc/ga8sfsZrEM5GywEi7FcpyRm3z99JWZ/0aPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "media-encoder-host": "^8.0.76",
+        "multi-buffer-data-view": "^3.0.20",
+        "recorder-audio-worklet": "^5.1.26",
+        "standardized-audio-context": "^25.3.29",
+        "subscribable-things": "^2.1.6",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/extendable-media-recorder-wav-encoder": {
+      "version": "7.0.137",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder/-/extendable-media-recorder-wav-encoder-7.0.137.tgz",
+      "integrity": "sha512-2g1x46TOLlkleoh4H2AwlFrGb/FDb52mKlTuUjvU7ta948QsnxWSuKURshREEmhcP05YZVzE6xTTBTLTaplYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "extendable-media-recorder-wav-encoder-broker": "^7.0.126",
+        "extendable-media-recorder-wav-encoder-worker": "^8.0.122",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/extendable-media-recorder-wav-encoder-broker": {
+      "version": "7.0.126",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-broker/-/extendable-media-recorder-wav-encoder-broker-7.0.126.tgz",
+      "integrity": "sha512-uGh/5BWQXt2NBZfGxTnlbhJVyfthKM5QVFen+cgEgYOfTUYW8S7gn7DQiy2Gkxb6TN9xLBdqHki/9gyl64zxWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "broker-factory": "^3.1.14",
+        "extendable-media-recorder-wav-encoder-worker": "^8.0.122",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/extendable-media-recorder-wav-encoder-worker": {
+      "version": "8.0.122",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-worker/-/extendable-media-recorder-wav-encoder-worker-8.0.122.tgz",
+      "integrity": "sha512-9yQoNyTzj/9m0rPh+rqoUo2WU+br2CuyiToQgNuh01cmqEDkcI5piXJv30U99Q65oSB7dnM0Wj89oxQwiOsSTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8962,6 +9061,19 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -9783,6 +9895,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/indefinite-article": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indefinite-article/-/indefinite-article-0.0.2.tgz",
+      "integrity": "sha512-Au/2XzRkvxq2J6w5uvSSbBKPZ5kzINx5F2wb0SF8xpRL8BP9Lav81TnRbfPp6p+SYjYxwaaLn4EUwI3/MmYKSw==",
+      "license": "MIT"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -12090,6 +12208,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-encoder-host": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/media-encoder-host/-/media-encoder-host-8.1.0.tgz",
+      "integrity": "sha512-VwX3ex48ltl+K1ObGEq3IcZp/XqpNTWemd9brC9ovo89rYmCRKTZAp1FCyfAY86RdvSMrUs26lbo45DIDVyERg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4",
+        "media-encoder-host-broker": "^7.1.0",
+        "media-encoder-host-worker": "^9.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/media-encoder-host-broker": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/media-encoder-host-broker/-/media-encoder-host-broker-7.1.0.tgz",
+      "integrity": "sha512-Emu3f45Wbf6AoRJxfvZ8e5nh8fRVviBfkABgYNvVUsVBgJ7+l137gn324g/JmNVQhhVQ89fjmGT1kHIJ9JG5Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4",
+        "broker-factory": "^3.0.97",
+        "fast-unique-numbers": "^9.0.4",
+        "media-encoder-host-worker": "^9.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/media-encoder-host-worker": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/media-encoder-host-worker/-/media-encoder-host-worker-9.2.0.tgz",
+      "integrity": "sha512-LrJJgNBDZH2y1PYBLaiYQw9uFU5i3yPvDkDxdko+L3Z4qzhKq9+4eYxKDqlwO4EdOlaiggvMpkgZl3roOniz2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4",
+        "extendable-media-recorder-wav-encoder-broker": "^7.0.100",
+        "tslib": "^2.6.2",
+        "worker-factory": "^7.0.24"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12294,6 +12449,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multi-buffer-data-view": {
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/multi-buffer-data-view/-/multi-buffer-data-view-3.0.24.tgz",
+      "integrity": "sha512-jm7Ycplx37ExXyQmqhwl7zfQmAj81y5LLzVx0XyWea4omP9W/xJhLEHs/5b+WojGyYSRt8BHiXZVcYzu68Ma0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12.20.1"
+      }
     },
     "node_modules/myna-parser": {
       "version": "2.5.1",
@@ -13466,6 +13634,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-media-recorder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/react-media-recorder/-/react-media-recorder-1.7.2.tgz",
+      "integrity": "sha512-qNn9VUe/bScN3IXWGbSgULbCnYvfamj8RDzjWa5jAtA8M8l9tKg3GujcCgwx2rLCq4rLw+k048LK8i3oPDx4hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extendable-media-recorder": "^6.6.5",
+        "extendable-media-recorder-wav-encoder": "^7.0.68"
+      }
+    },
     "node_modules/react-tooltip": {
       "version": "5.30.1",
       "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.1.tgz",
@@ -13492,6 +13670,57 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recorder-audio-worklet": {
+      "version": "5.1.39",
+      "resolved": "https://registry.npmjs.org/recorder-audio-worklet/-/recorder-audio-worklet-5.1.39.tgz",
+      "integrity": "sha512-w/RazoBwZnkFnEPRsJYNThOHznLQC98/IzWRrutpJQVvCcL0nbLsVSLDaRrnrqVpRUI11VgiXRh30HaHiSdVhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "broker-factory": "^3.0.75",
+        "fast-unique-numbers": "^7.0.2",
+        "recorder-audio-worklet-processor": "^4.2.21",
+        "standardized-audio-context": "^25.3.41",
+        "subscribable-things": "^2.1.14",
+        "tslib": "^2.5.0",
+        "worker-factory": "^6.0.76"
+      }
+    },
+    "node_modules/recorder-audio-worklet-processor": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/recorder-audio-worklet-processor/-/recorder-audio-worklet-processor-4.2.21.tgz",
+      "integrity": "sha512-oiiS2sp6eMxkvjt13yetSYUJvnAxBZk60mIxz0Vf/2lDWa/4svCyMLHIDzYKbHahkISd0UYyqLS9dI7xDlUOCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/recorder-audio-worklet/node_modules/fast-unique-numbers": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-7.0.2.tgz",
+      "integrity": "sha512-xnqpsnu889bHbq5cbDMwCJ2BPf6kjFPMu+RHfqKvisRxeEbTOVxY5aW/ZNsZ/r8OlwatxmjdFEVQog2xAhLkvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.4"
+      }
+    },
+    "node_modules/recorder-audio-worklet/node_modules/worker-factory": {
+      "version": "6.0.76",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-6.0.76.tgz",
+      "integrity": "sha512-W1iBNPmE9p0asU4aFmYJYCnMxhkvk4qlKc660GlHxWgmflY64NxxTbmKqipu4K5p9LiKKPjqXfcQme6153BZEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "compilerr": "^10.0.2",
+        "fast-unique-numbers": "^7.0.2",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/redent": {
@@ -13732,6 +13961,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rxjs-interop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rxjs-interop/-/rxjs-interop-2.0.0.tgz",
+      "integrity": "sha512-ASEq9atUw7lualXB+knvgtvwkCEvGWV2gDD/8qnASzBkzEARZck9JAyxmY8OS6Nc1pCPEgDTKNcx+YqqYfzArw==",
+      "license": "MIT"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -14333,6 +14568,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -14718,6 +14964,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/subscribable-things": {
+      "version": "2.1.59",
+      "resolved": "https://registry.npmjs.org/subscribable-things/-/subscribable-things-2.1.59.tgz",
+      "integrity": "sha512-V0GCOgYw7ZzJCDsKtEPJCZ2+BWlRIUulDdCiSetexX4qXsCs8gFRImf+y/ySGYSF9bXawsXlUE1ioKMwET7FUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "rxjs-interop": "^2.0.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/supports-color": {
@@ -15720,6 +15977,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.49",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.49.tgz",
+      "integrity": "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-media-recorder": "^1.7.2",
     "react-tooltip": "^5.30.1",
     "svix": "^1.90.0",
     "tailwind-merge": "^3.5.0",

--- a/tests/components/phrases/BoardActionButtons.test.tsx
+++ b/tests/components/phrases/BoardActionButtons.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BoardActionButtons from '@/app/components/phrases/BoardActionButtons';
+
+describe('BoardActionButtons', () => {
+  it('shows recorded audio in the add tile menu and calls its handler', async () => {
+    const onAddPhrase = jest.fn();
+    const onAddNavigateTile = jest.fn();
+    const onAddAudioTile = jest.fn();
+
+    render(
+      <BoardActionButtons
+        onAddPhrase={onAddPhrase}
+        onAddNavigateTile={onAddNavigateTile}
+        onAddAudioTile={onAddAudioTile}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add tile' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Recorded audio' }));
+
+    expect(onAddAudioTile).toHaveBeenCalledTimes(1);
+    expect(onAddPhrase).not.toHaveBeenCalled();
+    expect(onAddNavigateTile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/phrases/tiles/AudioRecorderControl.test.tsx
+++ b/tests/components/phrases/tiles/AudioRecorderControl.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * AudioRecorderControl tests
+ *
+ * react-media-recorder is mocked so we can deterministically drive the
+ * start/stop lifecycle and call the onStop callback at a chosen wall-clock
+ * moment. The non-trivial bit under test is that the saved durationMs
+ * reflects the actual recorded interval (Date.now-based) rather than the
+ * possibly-stale React state at the time onStop fires.
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import AudioRecorderControl, {
+  type RecordedAudio,
+} from '@/app/components/phrases/tiles/AudioRecorderControl';
+
+// Capture the onStop prop and a way to trigger start/stop from the test.
+type RecorderHandle = {
+  triggerStop: (blob: Blob) => void;
+  startRecording: jest.Mock;
+  stopRecording: jest.Mock;
+};
+
+let currentHandle: RecorderHandle | null = null;
+
+jest.mock('react-media-recorder', () => ({
+  ReactMediaRecorder: ({
+    onStop,
+    render: renderProp,
+  }: {
+    onStop: (blobUrl: string, blob: Blob) => void;
+    render: (state: {
+      status: string;
+      startRecording: () => void;
+      stopRecording: () => void;
+      error: string | undefined;
+    }) => React.ReactNode;
+  }) => {
+    const [status, setStatus] = React.useState('idle');
+    const startRecording = jest.fn(() => setStatus('recording'));
+    const stopRecording = jest.fn(() => setStatus('stopped'));
+    currentHandle = {
+      startRecording,
+      stopRecording,
+      triggerStop: (blob: Blob) => onStop('blob:mock', blob),
+    };
+    return <>{renderProp({ status, startRecording, stopRecording, error: undefined })}</>;
+  },
+}));
+
+describe('AudioRecorderControl duration capture', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    currentHandle = null;
+    URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+    URL.revokeObjectURL = jest.fn();
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: jest.fn() },
+    });
+  });
+
+  afterAll(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('saves the actual elapsed wall-clock duration when stopped manually', async () => {
+    const onChange = jest.fn<void, [RecordedAudio | null]>();
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    render(<AudioRecorderControl value={null} onChange={onChange} />);
+
+    // t=1000: user clicks Record
+    nowSpy.mockReturnValue(1_000);
+    await userEvent.click(screen.getByRole('button', { name: /record/i }));
+
+    expect(currentHandle).not.toBeNull();
+
+    // t=4250: user clicks Stop (~3.25 seconds elapsed)
+    nowSpy.mockReturnValue(4_250);
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    // t=4500: react-media-recorder finalises and fires onStop 250ms later.
+    // The saved duration should reflect when the user *clicked* stop, not when
+    // onStop happens to fire.
+    nowSpy.mockReturnValue(4_500);
+    act(() => {
+      currentHandle!.triggerStop(new Blob(['x'], { type: 'audio/webm' }));
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ durationMs: 3_250 }),
+    );
+  });
+
+  it('does not default short clips to maxDurationMs', async () => {
+    const onChange = jest.fn<void, [RecordedAudio | null]>();
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    render(<AudioRecorderControl value={null} onChange={onChange} />);
+
+    // Sub-second recording: starts at t=1000, stops at t=1100, onStop at t=1200.
+    nowSpy.mockReturnValue(1_000);
+    await userEvent.click(screen.getByRole('button', { name: /record/i }));
+    nowSpy.mockReturnValue(1_100);
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+    nowSpy.mockReturnValue(1_200);
+    act(() => {
+      currentHandle!.triggerStop(new Blob(['x'], { type: 'audio/webm' }));
+    });
+
+    // Should be ~100ms, not the 60s default that the previous bug produced.
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall).not.toBeNull();
+    expect(lastCall!.durationMs).toBeGreaterThan(0);
+    expect(lastCall!.durationMs).toBeLessThan(1_000);
+  });
+
+  it('caps the saved duration at maxDurationMs', async () => {
+    const onChange = jest.fn<void, [RecordedAudio | null]>();
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    render(
+      <AudioRecorderControl value={null} onChange={onChange} maxDurationMs={2_000} />,
+    );
+
+    // Simulate the user holding past the cap. We click Stop at t=5_000 (3s
+    // past the 2s cap) and onStop fires another second later. The component
+    // should still cap measuredMs to 2_000.
+    nowSpy.mockReturnValue(0);
+    await userEvent.click(screen.getByRole('button', { name: /record/i }));
+    nowSpy.mockReturnValue(5_000);
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+    nowSpy.mockReturnValue(6_000);
+    act(() => {
+      currentHandle!.triggerStop(new Blob(['x'], { type: 'audio/webm' }));
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ durationMs: 2_000 }),
+    );
+  });
+
+  it('rejects oversized recordings without saving them', async () => {
+    const onChange = jest.fn<void, [RecordedAudio | null]>();
+
+    render(<AudioRecorderControl value={null} onChange={onChange} maxBytes={1_024} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /record/i }));
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    const oversized = new Blob([new Uint8Array(2_048)], { type: 'audio/webm' });
+    act(() => {
+      currentHandle!.triggerStop(oversized);
+    });
+
+    // The last onChange call should be the null reset, not a saved recording.
+    expect(onChange).toHaveBeenLastCalledWith(null);
+    expect(screen.getByText(/exceeds.*MB limit/i)).toBeInTheDocument();
+  });
+});
+
+describe('AudioRecorderControl hero state machine', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    currentHandle = null;
+    URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+    URL.revokeObjectURL = jest.fn();
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: jest.fn() },
+    });
+  });
+
+  afterAll(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('shows the idle state aria-label and microphone icon at mount', () => {
+    render(<AudioRecorderControl value={null} onChange={jest.fn()} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Start recording' }),
+    ).toBeInTheDocument();
+    // No footer actions when there's no recording.
+    expect(screen.queryByRole('button', { name: 'Re-record' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /preview/i })).not.toBeInTheDocument();
+  });
+
+  it('flips the big button aria-label to Stop while recording', async () => {
+    render(<AudioRecorderControl value={null} onChange={jest.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Start recording' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Stop recording' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the has-recording state when an existing value is passed', () => {
+    const existing: RecordedAudio = {
+      blob: new Blob(['x'], { type: 'audio/webm' }),
+      url: 'blob:existing',
+      durationMs: 4_500,
+    };
+    render(<AudioRecorderControl value={existing} onChange={jest.fn()} />);
+
+    // Big button is the Re-record affordance.
+    expect(
+      screen.getByRole('button', { name: 'Re-record (replaces current clip)' }),
+    ).toBeInTheDocument();
+    // Footer actions are visible.
+    expect(screen.getByRole('button', { name: 'Re-record' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /preview/i })).toBeInTheDocument();
+    // Duration rendered (0:05 is what 4500ms ceils to in formatDuration).
+    expect(screen.getByText(/0:05/)).toBeInTheDocument();
+  });
+
+  it('countdown chip appears in the last-10s window of recording', async () => {
+    const onChange = jest.fn<void, [RecordedAudio | null]>();
+    jest.useFakeTimers({ doNotFake: ['Date'] });
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    try {
+      // 30s cap: before 20s elapsed, remaining > 10s (no chip). After 22s,
+      // remaining = 8s ≤ 10s (chip appears).
+      render(
+        <AudioRecorderControl value={null} onChange={onChange} maxDurationMs={30_000} />,
+      );
+
+      nowSpy.mockReturnValue(0);
+      await act(async () => {
+        await userEvent
+          .setup({ advanceTimers: jest.advanceTimersByTime })
+          .click(screen.getByRole('button', { name: 'Start recording' }));
+      });
+
+      // Tick to 5s — outside the last-10s window. No chip.
+      nowSpy.mockReturnValue(5_000);
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+      expect(screen.queryByText(/s left/i)).not.toBeInTheDocument();
+
+      // Tick to 22s — inside last-10s window. Chip appears.
+      nowSpy.mockReturnValue(22_000);
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+      expect(screen.getByText(/s left/i)).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('error chip uses role=alert', async () => {
+    render(<AudioRecorderControl value={null} onChange={jest.fn()} maxBytes={1_024} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Start recording' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Stop recording' }));
+    act(() => {
+      currentHandle!.triggerStop(
+        new Blob([new Uint8Array(2_048)], { type: 'audio/webm' }),
+      );
+    });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/exceeds/i);
+  });
+
+  it('progress ring is decorative (aria-hidden) and does not crash on initial render', () => {
+    const { container } = render(
+      <AudioRecorderControl value={null} onChange={jest.fn()} />,
+    );
+    const svg = container.querySelector('svg[aria-hidden="true"]');
+    expect(svg).not.toBeNull();
+    // The foreground arc circle exists and has a stroke-dasharray attr,
+    // confirming the ring is wired up. We deliberately don't assert on the
+    // imperative strokeDashoffset value because that's set via direct DOM
+    // mutation in a useLayoutEffect.
+    const circles = svg!.querySelectorAll('circle');
+    expect(circles.length).toBe(2);
+  });
+});

--- a/tests/components/phrases/tiles/AudioTile.test.tsx
+++ b/tests/components/phrases/tiles/AudioTile.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AudioTile from '@/app/components/phrases/tiles/AudioTile';
+
+describe('AudioTile', () => {
+  const baseTile = {
+    id: 'tile-1',
+    audioLabel: 'Greeting',
+    audioUrl: 'https://example.com/audio.webm',
+  };
+
+  const originalAudio = global.Audio;
+  const play = jest.fn(() => Promise.resolve());
+  const pause = jest.fn();
+
+  beforeEach(() => {
+    play.mockClear();
+    pause.mockClear();
+    global.Audio = jest.fn().mockImplementation(() => ({
+      play,
+      pause,
+      currentTime: 0,
+      src: '',
+      onended: null,
+      onerror: null,
+    })) as unknown as typeof Audio;
+  });
+
+  afterAll(() => {
+    global.Audio = originalAudio;
+  });
+
+  it('renders the label and play aria label', () => {
+    render(<AudioTile tile={baseTile} textSizePx={20} />);
+
+    expect(screen.getByText('Greeting')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play audio tile: Greeting' })).toBeInTheDocument();
+    expect(screen.getByText('Greeting')).toHaveStyle({ fontSize: '20px' });
+  });
+
+  it('plays audio when clicked', async () => {
+    render(<AudioTile tile={baseTile} textSizePx={20} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Play audio tile: Greeting' }));
+
+    expect(global.Audio).toHaveBeenCalledWith(baseTile.audioUrl);
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops audio on a second click while playing', async () => {
+    render(<AudioTile tile={baseTile} textSizePx={20} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Play audio tile: Greeting' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Stop audio tile: Greeting' }));
+
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders disabled state when the audio URL is unavailable', async () => {
+    render(<AudioTile tile={{ ...baseTile, audioUrl: null }} textSizePx={20} />);
+
+    const button = screen.getByRole('button', { name: 'Greeting (audio is unavailable)' });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.click(button);
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it('uses tap-to-edit when onEdit is supplied', async () => {
+    const onEdit = jest.fn();
+    render(<AudioTile tile={baseTile} onEdit={onEdit} textSizePx={20} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit audio tile: Greeting' }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it('calls onLongPress after the long-press threshold', () => {
+    jest.useFakeTimers();
+    const onLongPress = jest.fn();
+    render(<AudioTile tile={baseTile} onLongPress={onLongPress} textSizePx={20} />);
+
+    const button = screen.getByRole('button', { name: 'Play audio tile: Greeting' });
+    fireEvent.mouseDown(button);
+    jest.advanceTimersByTime(500);
+    fireEvent.mouseUp(button);
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+});

--- a/tests/convex/audio.test.ts
+++ b/tests/convex/audio.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Convex audio function tests
+ *
+ * Mirrors the same "mock the runtime, re-implement the invariants" pattern as
+ * boardTiles.test.ts / phraseBoards.test.ts. The new orphan-cleanup mutation
+ * has additional invariants (must not delete a referenced storage object)
+ * that we exercise explicitly.
+ */
+
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+
+const mockDb = {
+  query: jest.fn(),
+  get: jest.fn(),
+};
+
+const mockCtx = {
+  db: mockDb,
+  storage: {
+    generateUploadUrl: jest.fn(),
+    delete: jest.fn(),
+  },
+  auth: {
+    getUserIdentity: jest.fn(),
+  },
+};
+
+const createBoard = (overrides = {}) => ({
+  _id: 'board-1',
+  userId: 'user-123',
+  name: 'Test Board',
+  position: 0,
+  forClientId: undefined,
+  clientAccessLevel: undefined,
+  ...overrides,
+});
+
+const computeAccess = (
+  board: ReturnType<typeof createBoard> | null,
+  viewerSubject: string,
+) => {
+  if (!board) return null;
+  const isOwner = board.userId === viewerSubject;
+  const isAssignedClient = board.forClientId === viewerSubject;
+  const canEdit =
+    isOwner || (isAssignedClient && board.clientAccessLevel === 'edit');
+  const canRead = isOwner || isAssignedClient;
+  return { board, isOwner, canEdit, canRead };
+};
+
+describe('audio', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateUploadUrl', () => {
+    test('rejects unauthenticated callers', async () => {
+      mockCtx.auth.getUserIdentity.mockResolvedValue(null);
+      const identity = await mockCtx.auth.getUserIdentity();
+      const guard = () => {
+        if (!identity) throw new Error('Unauthenticated');
+      };
+      expect(guard).toThrow(/Unauthenticated/);
+      expect(mockCtx.storage.generateUploadUrl).not.toHaveBeenCalled();
+    });
+
+    test('rejects callers without edit access on the board', () => {
+      const board = createBoard({
+        userId: 'caregiver-1',
+        forClientId: 'client-1',
+        clientAccessLevel: 'view',
+      });
+      const access = computeAccess(board, 'client-1');
+
+      const guard = () => {
+        if (!access || !access.canEdit) throw new Error('Unauthorized - board');
+      };
+      expect(guard).toThrow(/Unauthorized/);
+      expect(mockCtx.storage.generateUploadUrl).not.toHaveBeenCalled();
+    });
+
+    test('rejects when the board does not exist', () => {
+      const access = computeAccess(null, 'user-123');
+      const guard = () => {
+        if (!access) throw new Error('Board not found');
+      };
+      expect(guard).toThrow(/Board not found/);
+    });
+
+    test('issues an upload URL for the board owner', async () => {
+      const board = createBoard();
+      const access = computeAccess(board, 'user-123');
+      mockCtx.storage.generateUploadUrl.mockResolvedValue('https://upload/xyz');
+
+      if (!access || !access.canEdit) throw new Error('Unexpected');
+      const url = await mockCtx.storage.generateUploadUrl();
+      expect(url).toBe('https://upload/xyz');
+    });
+
+    test('issues an upload URL for a client with edit access', async () => {
+      const board = createBoard({
+        userId: 'caregiver-1',
+        forClientId: 'client-1',
+        clientAccessLevel: 'edit',
+      });
+      const access = computeAccess(board, 'client-1');
+      mockCtx.storage.generateUploadUrl.mockResolvedValue('https://upload/xyz');
+
+      if (!access || !access.canEdit) throw new Error('Unexpected');
+      await mockCtx.storage.generateUploadUrl();
+      expect(mockCtx.storage.generateUploadUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteOrphanUpload', () => {
+    test('rejects unauthenticated callers', async () => {
+      mockCtx.auth.getUserIdentity.mockResolvedValue(null);
+      const identity = await mockCtx.auth.getUserIdentity();
+      const guard = () => {
+        if (!identity) throw new Error('Unauthenticated');
+      };
+      expect(guard).toThrow(/Unauthenticated/);
+      expect(mockCtx.storage.delete).not.toHaveBeenCalled();
+    });
+
+    test('rejects callers without edit access on the board', () => {
+      const board = createBoard({
+        userId: 'caregiver-1',
+        forClientId: 'client-1',
+        clientAccessLevel: 'view',
+      });
+      const access = computeAccess(board, 'client-1');
+      const guard = () => {
+        if (!access || !access.canEdit) throw new Error('Unauthorized');
+      };
+      expect(guard).toThrow(/Unauthorized/);
+      expect(mockCtx.storage.delete).not.toHaveBeenCalled();
+    });
+
+    test('refuses to delete a storage object that a tile already references', async () => {
+      const referencingTile = {
+        _id: 'tile-1',
+        kind: 'audio',
+        audioStorageId: 'storage-live',
+      };
+
+      const queryChain = {
+        withIndex: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(referencingTile),
+      };
+      mockDb.query.mockReturnValue(queryChain);
+
+      const found = await mockDb
+        .query('boardTiles')
+        // @ts-expect-error mock chain
+        .withIndex('by_audio_storage', (q) => q)
+        .first();
+
+      // Replicate handler: if found, return early without calling storage.delete.
+      if (found) {
+        // no-op
+      } else {
+        await mockCtx.storage.delete('storage-live');
+      }
+      expect(mockCtx.storage.delete).not.toHaveBeenCalled();
+    });
+
+    test('deletes a storage object that no tile references', async () => {
+      const queryChain = {
+        withIndex: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      };
+      mockDb.query.mockReturnValue(queryChain);
+
+      const found = await mockDb
+        .query('boardTiles')
+        // @ts-expect-error mock chain
+        .withIndex('by_audio_storage', (q) => q)
+        .first();
+
+      if (!found) {
+        await mockCtx.storage.delete('storage-orphan');
+      }
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('storage-orphan');
+    });
+  });
+});

--- a/tests/convex/boardTiles.test.ts
+++ b/tests/convex/boardTiles.test.ts
@@ -19,6 +19,10 @@ const mockDb = {
 
 const mockCtx = {
   db: mockDb,
+  storage: {
+    getUrl: jest.fn(),
+    delete: jest.fn(),
+  },
   auth: {
     getUserIdentity: jest.fn(),
   },
@@ -38,9 +42,14 @@ const createTile = (overrides = {}) => ({
   _id: 'tile-1',
   boardId: 'board-1',
   position: 0,
-  kind: 'phrase' as 'phrase' | 'navigate',
+  kind: 'phrase' as 'phrase' | 'navigate' | 'audio',
   phraseId: 'phrase-1',
   targetBoardId: undefined,
+  audioLabel: undefined,
+  audioStorageId: undefined,
+  audioMimeType: undefined,
+  audioDurationMs: undefined,
+  audioByteSize: undefined,
   ...overrides,
 });
 
@@ -143,6 +152,165 @@ describe('boardTiles', () => {
       };
 
       expect(result.targetBoardName).toBeNull();
+    });
+
+    test('audio-kind tile resolves a storage URL', async () => {
+      const tile = createTile({
+        _id: 'tile-audio',
+        kind: 'audio',
+        phraseId: undefined,
+        audioLabel: 'Greeting',
+        audioStorageId: 'storage-1',
+        audioMimeType: 'audio/webm',
+        audioDurationMs: 1200,
+        audioByteSize: 2048,
+      });
+
+      mockCtx.storage.getUrl.mockResolvedValue('https://files.example/audio.webm');
+
+      const result = {
+        ...tile,
+        audioUrl: await mockCtx.storage.getUrl(tile.audioStorageId),
+      };
+
+      expect(result).toMatchObject({
+        kind: 'audio',
+        audioLabel: 'Greeting',
+        audioUrl: 'https://files.example/audio.webm',
+      });
+      expect(mockCtx.storage.getUrl).toHaveBeenCalledWith('storage-1');
+    });
+  });
+
+  describe('audio tile invariants', () => {
+    const validateLabel = (label: string) => {
+      const trimmed = label.trim();
+      if (!trimmed) throw new Error('Audio tile label is required');
+      if (trimmed.length > 80) throw new Error('Audio tile label must be 80 characters or fewer');
+      return trimmed;
+    };
+
+    const validateMetadata = (mimeType: string, durationMs: number, byteSize: number) => {
+      if (!mimeType.startsWith('audio/')) throw new Error('Audio file must use an audio MIME type');
+      if (durationMs <= 0 || durationMs > 60000) throw new Error('Audio recording must be 60 seconds or less');
+      if (byteSize <= 0) throw new Error('Audio recording is empty');
+    };
+
+    test('addAudioTile rejects unauthenticated users', async () => {
+      mockCtx.auth.getUserIdentity.mockResolvedValue(null);
+      const identity = await mockCtx.auth.getUserIdentity();
+
+      const guard = () => {
+        if (!identity) throw new Error('Unauthenticated');
+      };
+
+      expect(guard).toThrow(/Unauthenticated/);
+    });
+
+    test('addAudioTile rejects users without edit access', () => {
+      const board = createBoard({
+        userId: 'caregiver-1',
+        forClientId: 'client-1',
+        clientAccessLevel: 'view',
+      });
+
+      const canEdit =
+        board.userId === 'client-1' ||
+        (board.forClientId === 'client-1' && board.clientAccessLevel === 'edit');
+
+      const guard = () => {
+        if (!canEdit) throw new Error('Unauthorized - board');
+      };
+
+      expect(guard).toThrow(/Unauthorized/);
+    });
+
+    test('addAudioTile rejects empty labels', () => {
+      expect(() => validateLabel('   ')).toThrow(/label is required/);
+    });
+
+    test('addAudioTile rejects recordings over 60 seconds', () => {
+      expect(() => validateMetadata('audio/webm', 60001, 1200)).toThrow(/60 seconds/);
+    });
+
+    test('addAudioTile inserts an audio tile at the next position', async () => {
+      const existingTiles = [
+        createTile({ _id: 'tile-1', position: 0 }),
+        createTile({ _id: 'tile-2', position: 1, kind: 'navigate' }),
+      ];
+
+      await mockDb.insert('boardTiles', {
+        boardId: 'board-1',
+        position: existingTiles.length,
+        kind: 'audio',
+        audioLabel: validateLabel(' Greeting '),
+        audioStorageId: 'storage-1',
+        audioMimeType: 'audio/webm',
+        audioDurationMs: 1000,
+        audioByteSize: 1200,
+      });
+
+      expect(mockDb.insert).toHaveBeenCalledWith('boardTiles', expect.objectContaining({
+        kind: 'audio',
+        position: 2,
+        audioLabel: 'Greeting',
+      }));
+    });
+
+    test('updateAudioTile rejects non-audio tiles', () => {
+      const tile = createTile({ kind: 'phrase' });
+
+      const guard = () => {
+        if (tile.kind !== 'audio') throw new Error('Tile is not an audio tile');
+      };
+
+      expect(guard).toThrow(/not an audio tile/);
+    });
+
+    test('updateAudioTile requires edit access', () => {
+      const board = createBoard({ userId: 'other-user' });
+      const canEdit = board.userId === 'user-123';
+
+      const guard = () => {
+        if (!canEdit) throw new Error('Unauthorized');
+      };
+
+      expect(guard).toThrow(/Unauthorized/);
+    });
+
+    test('updateAudioTile deletes old storage when replacing audio', async () => {
+      const tile = createTile({
+        kind: 'audio',
+        audioStorageId: 'old-storage',
+      });
+
+      await mockDb.patch(tile._id, {
+        audioStorageId: 'new-storage',
+        audioMimeType: 'audio/webm',
+        audioDurationMs: 1500,
+        audioByteSize: 2000,
+      });
+      await mockCtx.storage.delete(tile.audioStorageId);
+
+      expect(mockDb.patch).toHaveBeenCalledWith('tile-1', expect.objectContaining({
+        audioStorageId: 'new-storage',
+      }));
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('old-storage');
+    });
+
+    test('deleteTile deletes audio storage before deleting the tile', async () => {
+      const tile = createTile({
+        kind: 'audio',
+        audioStorageId: 'storage-1',
+      });
+
+      if (tile.kind === 'audio' && tile.audioStorageId) {
+        await mockCtx.storage.delete(tile.audioStorageId);
+      }
+      await mockDb.delete(tile._id);
+
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('storage-1');
+      expect(mockDb.delete).toHaveBeenCalledWith('tile-1');
     });
   });
 

--- a/tests/convex/boardTiles.test.ts
+++ b/tests/convex/boardTiles.test.ts
@@ -8,6 +8,13 @@
  */
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import {
+  isAllowedAudioMimeType,
+  normaliseAudioMimeType,
+  validateAudioLabel,
+  validateAudioMetadata,
+  MAX_AUDIO_BYTES,
+} from '@/convex/audioLimits';
 
 const mockDb = {
   query: jest.fn(),
@@ -183,18 +190,15 @@ describe('boardTiles', () => {
   });
 
   describe('audio tile invariants', () => {
-    const validateLabel = (label: string) => {
-      const trimmed = label.trim();
-      if (!trimmed) throw new Error('Audio tile label is required');
-      if (trimmed.length > 80) throw new Error('Audio tile label must be 80 characters or fewer');
-      return trimmed;
-    };
-
-    const validateMetadata = (mimeType: string, durationMs: number, byteSize: number) => {
-      if (!mimeType.startsWith('audio/')) throw new Error('Audio file must use an audio MIME type');
-      if (durationMs <= 0 || durationMs > 60000) throw new Error('Audio recording must be 60 seconds or less');
-      if (byteSize <= 0) throw new Error('Audio recording is empty');
-    };
+    // These exercise the real validators from convex/audioLimits.ts so any
+    // change to label/metadata rules surfaces here.
+    const validateLabel = validateAudioLabel;
+    const validateMetadata = (mimeType: string, durationMs: number, byteSize: number) =>
+      validateAudioMetadata({
+        audioMimeType: mimeType,
+        audioDurationMs: durationMs,
+        audioByteSize: byteSize,
+      });
 
     test('addAudioTile rejects unauthenticated users', async () => {
       mockCtx.auth.getUserIdentity.mockResolvedValue(null);
@@ -229,11 +233,47 @@ describe('boardTiles', () => {
       expect(() => validateLabel('   ')).toThrow(/label is required/);
     });
 
+    test('addAudioTile rejects labels over the length cap', () => {
+      expect(() => validateLabel('a'.repeat(200))).toThrow(/80 characters/);
+    });
+
     test('addAudioTile rejects recordings over 60 seconds', () => {
       expect(() => validateMetadata('audio/webm', 60001, 1200)).toThrow(/60 seconds/);
     });
 
-    test('addAudioTile inserts an audio tile at the next position', async () => {
+    test('addAudioTile rejects empty recordings', () => {
+      expect(() => validateMetadata('audio/webm', 1000, 0)).toThrow(/empty/);
+    });
+
+    test('addAudioTile rejects recordings over the byte cap', () => {
+      expect(() => validateMetadata('audio/webm', 1000, MAX_AUDIO_BYTES + 1)).toThrow(/MB limit/);
+    });
+
+    test('addAudioTile rejects unknown MIME types', () => {
+      expect(() => validateMetadata('audio/x-bogus', 1000, 1200)).toThrow(/MIME type/);
+      expect(() => validateMetadata('image/png', 1000, 1200)).toThrow(/MIME type/);
+      expect(() => validateMetadata('', 1000, 1200)).toThrow(/MIME type/);
+    });
+
+    test('addAudioTile accepts every allow-listed MIME (incl. codec params)', () => {
+      expect(() => validateMetadata('audio/webm;codecs=opus', 1000, 1200)).not.toThrow();
+      expect(() => validateMetadata('audio/mp4;codecs=mp4a.40.2', 1000, 1200)).not.toThrow();
+      expect(() => validateMetadata('audio/ogg', 1000, 1200)).not.toThrow();
+      expect(() => validateMetadata('audio/wav', 1000, 1200)).not.toThrow();
+    });
+
+    test('isAllowedAudioMimeType strips codec params before matching', () => {
+      expect(isAllowedAudioMimeType('audio/webm;codecs=opus')).toBe(true);
+      expect(isAllowedAudioMimeType('AUDIO/WEBM')).toBe(true);
+      expect(isAllowedAudioMimeType('audio/x-bogus')).toBe(false);
+    });
+
+    test('normaliseAudioMimeType trims and lowercases', () => {
+      expect(normaliseAudioMimeType('AUDIO/WEBM ;codecs=opus')).toBe('audio/webm');
+      expect(normaliseAudioMimeType('  audio/mp4  ')).toBe('audio/mp4');
+    });
+
+    test('addAudioTile inserts an audio tile at the next position with normalised label/MIME', async () => {
       const existingTiles = [
         createTile({ _id: 'tile-1', position: 0 }),
         createTile({ _id: 'tile-2', position: 1, kind: 'navigate' }),
@@ -245,7 +285,7 @@ describe('boardTiles', () => {
         kind: 'audio',
         audioLabel: validateLabel(' Greeting '),
         audioStorageId: 'storage-1',
-        audioMimeType: 'audio/webm',
+        audioMimeType: normaliseAudioMimeType('audio/webm;codecs=opus'),
         audioDurationMs: 1000,
         audioByteSize: 1200,
       });
@@ -254,6 +294,7 @@ describe('boardTiles', () => {
         kind: 'audio',
         position: 2,
         audioLabel: 'Greeting',
+        audioMimeType: 'audio/webm',
       }));
     });
 

--- a/tests/convex/phraseBoards.test.ts
+++ b/tests/convex/phraseBoards.test.ts
@@ -18,6 +18,9 @@ const mockDb = {
 
 const mockCtx = {
   db: mockDb,
+  storage: {
+    delete: jest.fn(),
+  },
   auth: {
     getUserIdentity: jest.fn(),
   },
@@ -354,6 +357,27 @@ describe('phraseBoards', () => {
       expect(mockDb.delete).toHaveBeenCalledWith('phrase-1');
       expect(mockDb.delete).toHaveBeenCalledWith('pbp-1');
       expect(mockDb.delete).toHaveBeenCalledWith('board-1');
+    });
+
+    test('deletes audio storage for contained audio tiles', async () => {
+      const tilesOnBoard = [
+        {
+          _id: 'tile-audio',
+          boardId: 'board-1',
+          kind: 'audio',
+          audioStorageId: 'storage-1',
+        },
+      ];
+
+      for (const tile of tilesOnBoard) {
+        if (tile.kind === 'audio' && tile.audioStorageId) {
+          await mockCtx.storage.delete(tile.audioStorageId);
+        }
+        await mockDb.delete(tile._id);
+      }
+
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('storage-1');
+      expect(mockDb.delete).toHaveBeenCalledWith('tile-audio');
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a Convex-backed audio tile kind with storage metadata and upload URL support
- Add record/add/edit/delete UI for 60-second labeled audio tiles using react-media-recorder
- Render audio tiles in board grids with playback, broken-state handling, and edit affordances

Closes #621

## Verification
- npm test -- --runInBand
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Record, add, and play audio tiles on boards; add via the “Add Tile” menu when available
  * Edit audio tile labels and replace recordings (including a dedicated edit page); long-press also opens edit
  * Upload/replace recordings with size/type/duration limits; actions disabled when offline

* **Tests**
  * Added comprehensive unit and server-side tests covering audio recording, playback, validation, upload, and storage behavior

* **Chores**
  * Added a media recording runtime dependency (react-media-recorder)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->