### PR TITLE
Reduce action-tile duplication via useTileGesture hook

### DIFF
--- a/app/components/offline/OfflineAppShell.tsx
+++ b/app/components/offline/OfflineAppShell.tsx
@@ -5,7 +5,7 @@ import AACTabs from '@/app/components/home/AACTabs';
 import Composer from '@/app/components/composer';
 import BoardSelector from '@/app/components/phrases/BoardSelector';
 import PhraseGrid from '@/app/components/phrases/PhraseGrid';
-import PhraseTile from '@/app/components/phrases/PhraseTile';
+import PhraseTile from '@/app/components/phrases/tiles/PhraseTile';
 import { useSettings } from '@/app/contexts/SettingsContext';
 import type { BoardSummary, PhraseSummary } from '@/app/components/phrases/types';
 import { useLocalMessageHistory } from '@/lib/hooks/useLocalMessageHistory';

--- a/app/components/phrases/tiles/AudioTile.tsx
+++ b/app/components/phrases/tiles/AudioTile.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { ExclamationTriangleIcon, SpeakerWaveIcon, StopIcon } from '@heroicons/react/24/solid';
+import { useTileGesture } from '@/lib/hooks/useTileGesture';
 
 interface AudioTileProps {
   tile: {
@@ -23,13 +24,15 @@ export default function AudioTile({
   className = '',
   textSizePx,
 }: AudioTileProps) {
-  const [isPressed, setIsPressed] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
-  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isLongPress = useRef(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const isBroken = tile.audioUrl === null;
+
+  const gesture = useTileGesture({
+    onLongPress: onEdit ? undefined : onLongPress,
+    disabled: isBroken && !onEdit,
+  });
 
   const stopAudio = useCallback(() => {
     const audio = audioRef.current;
@@ -39,11 +42,9 @@ export default function AudioTile({
     setIsPlaying(false);
   }, []);
 
+  // Tear down any in-flight audio on unmount.
   useEffect(() => {
     return () => {
-      if (longPressTimer.current) {
-        clearTimeout(longPressTimer.current);
-      }
       if (audioRef.current) {
         audioRef.current.pause();
         audioRef.current.src = '';
@@ -52,35 +53,12 @@ export default function AudioTile({
     };
   }, []);
 
+  // If the underlying audioUrl changes (e.g. the user edited the tile), stop
+  // any currently-playing clip and forget the old <audio> element.
   useEffect(() => {
     stopAudio();
     audioRef.current = null;
   }, [stopAudio, tile.audioUrl]);
-
-  const handleTouchStart = useCallback(() => {
-    if (isBroken && !onEdit) return;
-    isLongPress.current = false;
-    setIsPressed(true);
-
-    if (onLongPress && !onEdit) {
-      longPressTimer.current = setTimeout(() => {
-        isLongPress.current = true;
-        setIsPressed(false);
-        if (typeof navigator !== 'undefined' && navigator.vibrate) {
-          navigator.vibrate(50);
-        }
-        onLongPress();
-      }, 500);
-    }
-  }, [isBroken, onEdit, onLongPress]);
-
-  const handleTouchEnd = useCallback(() => {
-    setIsPressed(false);
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  }, []);
 
   const playAudio = () => {
     if (!tile.audioUrl) return;
@@ -95,11 +73,7 @@ export default function AudioTile({
     });
   };
 
-  const handleClick = () => {
-    if (isLongPress.current) {
-      isLongPress.current = false;
-      return;
-    }
+  const handleClick = gesture.wrapClick(() => {
     if (onEdit) {
       onEdit();
       return;
@@ -110,10 +84,7 @@ export default function AudioTile({
       return;
     }
     playAudio();
-  };
-
-  const prefersReducedMotion = typeof window !== 'undefined'
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   const ariaLabel = onEdit
     ? `Edit audio tile: ${tile.audioLabel}`
@@ -140,21 +111,16 @@ export default function AudioTile({
           : 'bg-surface border-2 border-primary-400'}
         ${className}`}
       onClick={handleClick}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
-      onMouseDown={handleTouchStart}
-      onMouseUp={handleTouchEnd}
-      onMouseLeave={handleTouchEnd}
+      {...gesture.bind}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           handleClick();
         }
       }}
-      whileTap={prefersReducedMotion || isBroken ? undefined : { scale: 0.95 }}
-      animate={prefersReducedMotion ? undefined : {
-        scale: isPressed ? 0.95 : 1,
+      whileTap={gesture.prefersReducedMotion || isBroken ? undefined : { scale: 0.95 }}
+      animate={gesture.prefersReducedMotion ? undefined : {
+        scale: gesture.isPressed ? 0.95 : 1,
       }}
       transition={{ duration: 0.15 }}
       role="button"

--- a/app/components/phrases/tiles/BoardTileRenderer.tsx
+++ b/app/components/phrases/tiles/BoardTileRenderer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import PhraseTile from '../PhraseTile';
+import PhraseTile from './PhraseTile';
 import NavigateTile from './NavigateTile';
 import AudioTile from './AudioTile';
 import type { BoardTileSummary, PhraseSummary } from '../types';

--- a/app/components/phrases/tiles/NavigateTile.tsx
+++ b/app/components/phrases/tiles/NavigateTile.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowRightCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/solid';
+import { useTileGesture } from '@/lib/hooks/useTileGesture';
 
 interface NavigateTileProps {
   tile: {
@@ -39,50 +39,16 @@ export default function NavigateTile({
   className = '',
   textSizePx,
 }: NavigateTileProps) {
-  const [isPressed, setIsPressed] = useState(false);
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const isLongPress = useRef(false);
-
   const isBroken = tile.targetBoardName === null;
 
-  const handleTouchStart = useCallback(() => {
-    if (isBroken && !onEdit) return;
-    isLongPress.current = false;
-    setIsPressed(true);
+  const gesture = useTileGesture({
+    // Tap-to-edit replaces long-press in edit mode.
+    onLongPress: onEdit ? undefined : onLongPress,
+    // Broken tiles without an editor swallow gestures entirely.
+    disabled: isBroken && !onEdit,
+  });
 
-    if (onLongPress && !onEdit) {
-      longPressTimer.current = setTimeout(() => {
-        isLongPress.current = true;
-        setIsPressed(false);
-        if (typeof navigator !== 'undefined' && navigator.vibrate) {
-          navigator.vibrate(50);
-        }
-        onLongPress();
-      }, 500);
-    }
-  }, [onLongPress, onEdit, isBroken]);
-
-  const handleTouchEnd = useCallback(() => {
-    setIsPressed(false);
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (longPressTimer.current) {
-        clearTimeout(longPressTimer.current);
-      }
-    };
-  }, []);
-
-  const handleClick = () => {
-    if (isLongPress.current) {
-      isLongPress.current = false;
-      return;
-    }
+  const handleClick = gesture.wrapClick(() => {
     if (onEdit) {
       onEdit();
       return;
@@ -94,10 +60,7 @@ export default function NavigateTile({
       return;
     }
     onTap();
-  };
-
-  const prefersReducedMotion = typeof window !== 'undefined'
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   const labelText = isBroken ? BROKEN_LABEL : (tile.targetBoardName ?? '');
   const ariaLabel = onEdit
@@ -121,21 +84,16 @@ export default function NavigateTile({
         : 'bg-surface border-2 border-primary-400'}
         ${className}`}
       onClick={handleClick}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
-      onMouseDown={handleTouchStart}
-      onMouseUp={handleTouchEnd}
-      onMouseLeave={handleTouchEnd}
+      {...gesture.bind}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           handleClick();
         }
       }}
-      whileTap={prefersReducedMotion || isBroken ? undefined : { scale: 0.95 }}
-      animate={prefersReducedMotion ? undefined : {
-        scale: isPressed ? 0.95 : 1,
+      whileTap={gesture.prefersReducedMotion || isBroken ? undefined : { scale: 0.95 }}
+      animate={gesture.prefersReducedMotion ? undefined : {
+        scale: gesture.isPressed ? 0.95 : 1,
       }}
       transition={{ duration: 0.15 }}
       role="button"

--- a/app/components/phrases/tiles/PhraseTile.tsx
+++ b/app/components/phrases/tiles/PhraseTile.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { StopIcon } from '@heroicons/react/24/solid';
-import { SymbolImage } from '../symbols';
+import { SymbolImage } from '../../symbols';
+import { useTileGesture } from '@/lib/hooks/useTileGesture';
 
 interface PhraseTileProps {
   phrase: {
@@ -30,51 +30,13 @@ export default function PhraseTile({
   className = '',
   textSizePx,
 }: PhraseTileProps) {
-  const [isPressed, setIsPressed] = useState(false);
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-  const isLongPress = useRef(false);
+  // Tap-to-edit takes precedence over long-press: when onEdit is wired in
+  // (the board is in edit mode), suppress long-press detection entirely.
+  const gesture = useTileGesture({
+    onLongPress: onEdit ? undefined : onLongPress,
+  });
 
-  const handleTouchStart = useCallback(() => {
-    isLongPress.current = false;
-    setIsPressed(true);
-
-    if (onLongPress && !onEdit) {
-      longPressTimer.current = setTimeout(() => {
-        isLongPress.current = true;
-        setIsPressed(false);
-        // Haptic feedback if available
-        if (navigator.vibrate) {
-          navigator.vibrate(50);
-        }
-        onLongPress();
-      }, 500);
-    }
-  }, [onLongPress, onEdit]);
-
-  const handleTouchEnd = useCallback(() => {
-    setIsPressed(false);
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  }, []);
-
-  // Cleanup timer on unmount to prevent memory leaks
-  useEffect(() => {
-    return () => {
-      if (longPressTimer.current) {
-        clearTimeout(longPressTimer.current);
-      }
-    };
-  }, []);
-
-  const handleClick = () => {
-    // Ignore click if it was a long press
-    if (isLongPress.current) {
-      isLongPress.current = false;
-      return;
-    }
-
+  const handleClick = gesture.wrapClick(() => {
     if (onEdit) {
       onEdit();
     } else if (isSpeaking && onStop) {
@@ -82,11 +44,7 @@ export default function PhraseTile({
     } else {
       onPress();
     }
-  };
-
-  // Check for reduced motion preference
-  const prefersReducedMotion = typeof window !== 'undefined'
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   return (
     <motion.div
@@ -96,22 +54,17 @@ export default function PhraseTile({
         ${onEdit ? 'border-l-4 border-blue-400' : isSpeaking ? 'border-2 border-warning' : ''}
         ${className}`}
       onClick={handleClick}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
-      onMouseDown={handleTouchStart}
-      onMouseUp={handleTouchEnd}
-      onMouseLeave={handleTouchEnd}
+      {...gesture.bind}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           handleClick();
         }
       }}
-      whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
-      animate={prefersReducedMotion ? undefined : {
-        scale: isPressed ? 0.95 : 1,
-        backgroundColor: isPressed ? 'var(--surface-hover)' : 'var(--surface)',
+      whileTap={gesture.prefersReducedMotion ? undefined : { scale: 0.95 }}
+      animate={gesture.prefersReducedMotion ? undefined : {
+        scale: gesture.isPressed ? 0.95 : 1,
+        backgroundColor: gesture.isPressed ? 'var(--surface-hover)' : 'var(--surface)',
       }}
       transition={{ duration: 0.15 }}
       role="button"

--- a/lib/hooks/useTileGesture.ts
+++ b/lib/hooks/useTileGesture.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const LONG_PRESS_THRESHOLD_MS = 500;
+const HAPTIC_DURATION_MS = 50;
+
+interface UseTileGestureArgs {
+  /**
+   * Triggered after `LONG_PRESS_THRESHOLD_MS` of sustained press. Pass
+   * `undefined` to disable long-press detection (e.g. when the tile is in
+   * edit mode and tap-to-edit takes over).
+   */
+  onLongPress?: () => void;
+  /**
+   * When `true`, every gesture side effect is suppressed: touch/mouse start
+   * events become no-ops, the press visual never flips on, and no long-press
+   * timer is scheduled. Use for "broken" tiles that should silently ignore
+   * input. Click events still bubble — wrap your `onClick` with `wrapClick`
+   * and let your component's own logic decide what to do.
+   */
+  disabled?: boolean;
+}
+
+interface UseTileGestureBindHandlers {
+  onTouchStart: () => void;
+  onTouchEnd: () => void;
+  onTouchCancel: () => void;
+  onMouseDown: () => void;
+  onMouseUp: () => void;
+  onMouseLeave: () => void;
+}
+
+interface UseTileGestureReturn {
+  /** Tracks the press visual: true between mouse/touch-down and -up. */
+  isPressed: boolean;
+  /**
+   * `prefers-reduced-motion` snapshot taken at mount. Not reactive — the OS
+   * setting can't change in practice without remount, and re-reading every
+   * render would just be wasted work.
+   */
+  prefersReducedMotion: boolean;
+  /** Spread these handlers onto the gesture-receiving element. */
+  bind: UseTileGestureBindHandlers;
+  /**
+   * Wraps an `onClick` handler so the click that browsers naturally fire
+   * after a long-press (mousedown → timer fires → mouseup → click) is
+   * swallowed instead of double-invoking the tile's primary action.
+   */
+  wrapClick: (onClick: () => void) => () => void;
+}
+
+/**
+ * Shared gesture state machine for the board tile components (PhraseTile,
+ * NavigateTile, AudioTile). Encapsulates:
+ *
+ * - the `isPressed` press-visual flag,
+ * - the 500 ms long-press timer + cleanup,
+ * - the trailing-click suppression after a long-press fires,
+ * - the haptic vibrate(50) on long-press fire (SSR-safe),
+ * - a one-shot `prefers-reduced-motion` read.
+ *
+ * Each tile keeps its own click routing (broken/edit/play/speak), audio /
+ * speaking state, and visual chrome — only the gesture mechanics live here.
+ */
+export function useTileGesture({
+  onLongPress,
+  disabled = false,
+}: UseTileGestureArgs = {}): UseTileGestureReturn {
+  const [isPressed, setIsPressed] = useState(false);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isLongPressRef = useRef(false);
+
+  const [prefersReducedMotion] = useState(() =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  );
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  // Cleanup on unmount — don't let a fired-after-unmount timer reach into
+  // a torn-down React tree.
+  useEffect(() => {
+    return () => clearLongPressTimer();
+  }, []);
+
+  const handlePressStart = () => {
+    if (disabled) return;
+    isLongPressRef.current = false;
+    setIsPressed(true);
+
+    if (onLongPress) {
+      longPressTimerRef.current = setTimeout(() => {
+        isLongPressRef.current = true;
+        setIsPressed(false);
+        if (typeof navigator !== 'undefined' && navigator.vibrate) {
+          navigator.vibrate(HAPTIC_DURATION_MS);
+        }
+        onLongPress();
+      }, LONG_PRESS_THRESHOLD_MS);
+    }
+  };
+
+  const handlePressEnd = () => {
+    setIsPressed(false);
+    clearLongPressTimer();
+  };
+
+  const wrapClick = (onClick: () => void) => () => {
+    if (isLongPressRef.current) {
+      isLongPressRef.current = false;
+      return;
+    }
+    onClick();
+  };
+
+  return {
+    isPressed,
+    prefersReducedMotion,
+    bind: {
+      onTouchStart: handlePressStart,
+      onTouchEnd: handlePressEnd,
+      onTouchCancel: handlePressEnd,
+      onMouseDown: handlePressStart,
+      onMouseUp: handlePressEnd,
+      onMouseLeave: handlePressEnd,
+    },
+    wrapClick,
+  };
+}

--- a/tests/components/phrases/tiles/PhraseTile.test.tsx
+++ b/tests/components/phrases/tiles/PhraseTile.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import PhraseTile from '@/app/components/phrases/PhraseTile';
+import PhraseTile from '@/app/components/phrases/tiles/PhraseTile';
 
 describe('PhraseTile', () => {
   it('uses the configured text size for phrase text', () => {

--- a/tests/lib/hooks/useTileGesture.test.tsx
+++ b/tests/lib/hooks/useTileGesture.test.tsx
@@ -1,0 +1,231 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useTileGesture } from '@/lib/hooks/useTileGesture';
+
+/**
+ * Test harness that mounts the hook against a real DOM element so we can
+ * exercise the fireEvent.mouseDown/mouseUp/click sequences the way the
+ * tile components consume the hook.
+ */
+function GestureHarness({
+  onLongPress,
+  onClick,
+  disabled,
+}: {
+  onLongPress?: () => void;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  const gesture = useTileGesture({ onLongPress, disabled });
+  return (
+    <button
+      type="button"
+      data-testid="harness"
+      data-pressed={gesture.isPressed ? 'true' : 'false'}
+      data-reduced-motion={gesture.prefersReducedMotion ? 'true' : 'false'}
+      onClick={gesture.wrapClick(onClick)}
+      {...gesture.bind}
+    >
+      tap
+    </button>
+  );
+}
+
+describe('useTileGesture', () => {
+  describe('press visual', () => {
+    it('flips isPressed=true on mouseDown and back to false on mouseUp', () => {
+      render(<GestureHarness onClick={jest.fn()} />);
+      const btn = screen.getByTestId('harness');
+
+      expect(btn).toHaveAttribute('data-pressed', 'false');
+      fireEvent.mouseDown(btn);
+      expect(btn).toHaveAttribute('data-pressed', 'true');
+      fireEvent.mouseUp(btn);
+      expect(btn).toHaveAttribute('data-pressed', 'false');
+    });
+
+    it('flips isPressed back to false on mouseLeave (mouse drift away)', () => {
+      render(<GestureHarness onClick={jest.fn()} />);
+      const btn = screen.getByTestId('harness');
+
+      fireEvent.mouseDown(btn);
+      expect(btn).toHaveAttribute('data-pressed', 'true');
+      fireEvent.mouseLeave(btn);
+      expect(btn).toHaveAttribute('data-pressed', 'false');
+    });
+
+    it('flips isPressed back to false on touchCancel', () => {
+      render(<GestureHarness onClick={jest.fn()} />);
+      const btn = screen.getByTestId('harness');
+
+      fireEvent.touchStart(btn);
+      expect(btn).toHaveAttribute('data-pressed', 'true');
+      fireEvent.touchCancel(btn);
+      expect(btn).toHaveAttribute('data-pressed', 'false');
+    });
+  });
+
+  describe('long-press', () => {
+    it('fires onLongPress at the 500 ms threshold', () => {
+      jest.useFakeTimers();
+      const onLongPress = jest.fn();
+      try {
+        render(<GestureHarness onClick={jest.fn()} onLongPress={onLongPress} />);
+        const btn = screen.getByTestId('harness');
+
+        fireEvent.mouseDown(btn);
+        act(() => { jest.advanceTimersByTime(499); });
+        expect(onLongPress).not.toHaveBeenCalled();
+
+        act(() => { jest.advanceTimersByTime(1); });
+        expect(onLongPress).toHaveBeenCalledTimes(1);
+
+        // Long-press fire releases the press visual even if the user is
+        // still holding — they get visual confirmation it triggered.
+        expect(btn).toHaveAttribute('data-pressed', 'false');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not fire onLongPress when released before the threshold', () => {
+      jest.useFakeTimers();
+      const onLongPress = jest.fn();
+      try {
+        render(<GestureHarness onClick={jest.fn()} onLongPress={onLongPress} />);
+        const btn = screen.getByTestId('harness');
+
+        fireEvent.mouseDown(btn);
+        act(() => { jest.advanceTimersByTime(300); });
+        fireEvent.mouseUp(btn);
+        act(() => { jest.advanceTimersByTime(500); });
+
+        expect(onLongPress).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not start a timer when onLongPress is undefined', () => {
+      jest.useFakeTimers();
+      try {
+        render(<GestureHarness onClick={jest.fn()} />);
+        const btn = screen.getByTestId('harness');
+
+        fireEvent.mouseDown(btn);
+        // Advance well past the threshold — nothing should fire.
+        act(() => { jest.advanceTimersByTime(2_000); });
+        // isPressed stays true while the user is holding.
+        expect(btn).toHaveAttribute('data-pressed', 'true');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('calls navigator.vibrate(50) when long-press fires', () => {
+      jest.useFakeTimers();
+      const vibrate = jest.fn();
+      Object.defineProperty(global.navigator, 'vibrate', {
+        configurable: true,
+        value: vibrate,
+      });
+      try {
+        render(<GestureHarness onClick={jest.fn()} onLongPress={jest.fn()} />);
+        const btn = screen.getByTestId('harness');
+
+        fireEvent.mouseDown(btn);
+        act(() => { jest.advanceTimersByTime(500); });
+
+        expect(vibrate).toHaveBeenCalledWith(50);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('wrapClick', () => {
+    it('suppresses the click that follows a long-press, then resumes', () => {
+      jest.useFakeTimers();
+      const onLongPress = jest.fn();
+      const onClick = jest.fn();
+      try {
+        render(<GestureHarness onClick={onClick} onLongPress={onLongPress} />);
+        const btn = screen.getByTestId('harness');
+
+        // Natural sequence: mousedown → 500 ms timer fires → mouseup → click.
+        fireEvent.mouseDown(btn);
+        act(() => { jest.advanceTimersByTime(500); });
+        fireEvent.mouseUp(btn);
+        fireEvent.click(btn);
+
+        expect(onLongPress).toHaveBeenCalledTimes(1);
+        expect(onClick).not.toHaveBeenCalled();
+
+        // The next genuine tap fires onClick — the long-press suppression
+        // is one-shot and resets after the swallow.
+        fireEvent.click(btn);
+        expect(onClick).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('passes a regular click straight through', () => {
+      const onClick = jest.fn();
+      render(<GestureHarness onClick={onClick} />);
+      const btn = screen.getByTestId('harness');
+
+      fireEvent.click(btn);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('disabled', () => {
+    it('disabled=true makes mouseDown a no-op (no press visual, no long-press timer)', () => {
+      jest.useFakeTimers();
+      const onLongPress = jest.fn();
+      try {
+        render(
+          <GestureHarness onClick={jest.fn()} onLongPress={onLongPress} disabled />,
+        );
+        const btn = screen.getByTestId('harness');
+
+        fireEvent.mouseDown(btn);
+        expect(btn).toHaveAttribute('data-pressed', 'false');
+        act(() => { jest.advanceTimersByTime(1_000); });
+        expect(onLongPress).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('disabled=true still lets clicks through wrapClick (the caller decides what to do)', () => {
+      const onClick = jest.fn();
+      render(<GestureHarness onClick={onClick} disabled />);
+      const btn = screen.getByTestId('harness');
+
+      fireEvent.click(btn);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('clears the long-press timer on unmount (no fire after teardown)', () => {
+      jest.useFakeTimers();
+      const onLongPress = jest.fn();
+      try {
+        const { unmount } = render(
+          <GestureHarness onClick={jest.fn()} onLongPress={onLongPress} />,
+        );
+        const btn = screen.getByTestId('harness');
+
+        fireEvent.mouseDown(btn);
+        unmount();
+        act(() => { jest.advanceTimersByTime(1_000); });
+
+        expect(onLongPress).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract gesture state machine (long-press timer, press-visual, trailing-click suppression, haptic, reduced-motion read) into `lib/hooks/useTileGesture.ts` and migrate `PhraseTile` / `NavigateTile` / `AudioTile` to consume it. -123 LOC net across the three tile files.
- Move `PhraseTile.tsx` (and its test) into `app/components/phrases/tiles/` alongside `NavigateTile` and `AudioTile`, so all three tile kinds live together and `BoardTileRenderer`'s imports are symmetric.
- Bonus: centralises the `typeof navigator` SSR guard around `navigator.vibrate(50)` that `PhraseTile` was missing.

No visual or behaviour change. Closes #623.

## Test plan

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `npm test -- --runInBand` — 384 tests pass (12 new hook tests; existing tile tests unchanged)
- [ ] `npm run build`
- [ ] Manual: open a board, long-press a phrase tile → edit page opens with haptic; tap-to-edit while in edit mode; navigate tile broken state ignores tap; audio tile plays/stops/long-press-edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added haptic feedback (vibration) when performing long-press actions on tiles

* **Bug Fixes**
  * Improved consistency of gesture detection and handling across tiles
  * Enhanced support for reduced-motion accessibility preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->