### PR TITLE
Update dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-media-recorder": "^1.7.2",
-        "react-tooltip": "^5.30.1",
+        "react-tooltip": "^6.0.0",
         "svix": "^1.90.0",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.12"
@@ -49,7 +49,7 @@
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
-        "convex-test": "^0.0.49",
+        "convex-test": "^0.0.50",
         "eslint": "^10.2.1",
         "eslint-config-next": "^16.2.4",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -60,7 +60,7 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
-        "vercel": "^51.7.0"
+        "vercel": "^52.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -71,13 +71,13 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.104",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
-      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.105.tgz",
+      "integrity": "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
-      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "version": "3.0.54",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.54.tgz",
+      "integrity": "sha512-j1qrNe/ebUKuE+fETzS+CVnczs11jQBR9y9M6aoKtJZAosg6SZnPC1Bb92e2u6yaSK+88TZoFhiY67uYphPitw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24"
       },
       "engines": {
         "node": ">=18"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.9.tgz",
+      "integrity": "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -116,14 +116,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
-      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.24.tgz",
+      "integrity": "sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "3.0.9",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -699,12 +699,12 @@
       "license": "(Apache-2.0 WITH LLVM-exception)"
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.13.tgz",
-      "integrity": "sha512-E4ir94gs9Cxh+v20SGVLXblb0coVUd2La5o1Lmz7olNOBimMEsZ7T6MpGFNJveEH1sQ+HhSf1a1uLm9pMiK/tg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.2.tgz",
+      "integrity": "sha512-3hPVKogxieYiRCXkWqqbAzXc8Rd74SgZi9wRTEVdbV2hOiQqwiIBbjGaR7VM9mQunEV0vwWv8FxHE3ukEpFEAQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.8.2",
+        "@clerk/shared": "^4.8.6",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -713,14 +713,14 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.2.3.tgz",
-      "integrity": "sha512-/+SBW09/Dz7pvIabzSKssHTdoGZn2n/k9u/VhIra700gfsymCAR57NLn7ztW6zjPdw5VMILOMTLqzyqxaal3og==",
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.2.8.tgz",
+      "integrity": "sha512-Z1G/sbIrH7oUgSnn0+00RyzePK0Okg0Guo7oPYGFNdBQDPEhCtkOpIGOsHJc8LUyN97ssfOjfcbGo+GOEVP0mA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.2.13",
-        "@clerk/react": "^6.4.2",
-        "@clerk/shared": "^4.8.2",
+        "@clerk/backend": "^3.4.2",
+        "@clerk/react": "^6.4.6",
+        "@clerk/shared": "^4.8.6",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -734,12 +734,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.4.2.tgz",
-      "integrity": "sha512-l43pon5wcM0n4e3gnRP7MWdvAXAa3M7BOF6aeNwEuITxgy6MU6ypej9tPeGmXxPicL/Hd6E/VRgiEipEKDqyCQ==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.4.6.tgz",
+      "integrity": "sha512-7I8ZnuNWnaxBfiyQw0hj9ju9Lxw56RAWyxPQQnnXxIJvZa/aWAmiEEpvCUJTz1nwC2ONrpHsxdct6Iu+z3INlA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.8.2",
+        "@clerk/shared": "^4.8.6",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -751,13 +751,13 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
-      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.6.tgz",
+      "integrity": "sha512-IItiQftnKaY928Q/DNOWA+32WCoKk/YwpFPOrU46P7gz+FU6O3KR8YGyTO6K+/YLG8LNB7zqBJY7t24GSwoNHA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.16",
+        "@tanstack/query-core": "^5.90.16",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@elevenlabs/elevenlabs-js": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.43.0.tgz",
-      "integrity": "sha512-+1eqTvVjEdgzr8L+u/3ebavWXx/sd06zuTTAKb1wwcar3NNQBYjqmMxuVOH6iUjSUvQUWvwK7sFWZEEcE8wp6A==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.45.0.tgz",
+      "integrity": "sha512-TqD1tBFs7cLJ4qG8xF0BSYagchEx/ME29mba5x6hOv58NqEFpRHkHquTO78vAS2lD+0yxdCKV7qAyTrZQPnnaQ==",
       "license": "MIT",
       "dependencies": {
         "command-exists": "^1.2.9",
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1768,25 +1768,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2283,6 +2297,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
+      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
+      "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -3572,16 +3613,13 @@
       }
     },
     "node_modules/@react-aria/focus": {
-      "version": "3.21.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.5.tgz",
-      "integrity": "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.0.tgz",
+      "integrity": "sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.27.1",
-        "@react-aria/utils": "^3.33.1",
-        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
+        "react-aria": "3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -3589,80 +3627,24 @@
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.27.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.1.tgz",
-      "integrity": "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.0.tgz",
+      "integrity": "sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-aria/utils": "^3.33.1",
-        "@react-stately/flags": "^3.1.2",
-        "@react-types/shared": "^3.33.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/utils": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
-      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.11.0",
-        "@react-types/shared": "^3.33.1",
+        "@react-types/shared": "^3.34.0",
         "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
+        "react-aria": "3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-stately/flags": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
-      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@react-stately/utils": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
-      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.1.tgz",
-      "integrity": "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
@@ -4239,70 +4221,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -4352,9 +4270,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
-      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4362,12 +4280,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
-      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.23"
+        "@tanstack/virtual-core": "3.14.0"
       },
       "funding": {
         "type": "github",
@@ -4379,9 +4297,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
-      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4745,17 +4663,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/type-utils": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4768,7 +4686,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.0",
+        "@typescript-eslint/parser": "^8.59.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4784,16 +4702,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4809,14 +4727,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.0",
-        "@typescript-eslint/types": "^8.59.0",
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4831,14 +4749,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0"
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4849,9 +4767,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4866,15 +4784,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4891,9 +4809,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4905,16 +4823,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.0",
-        "@typescript-eslint/tsconfig-utils": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4972,16 +4890,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0"
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4996,13 +4914,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/types": "8.59.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5303,13 +5221,13 @@
       ]
     },
     "node_modules/@vercel/backends": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.1.2.tgz",
-      "integrity": "sha512-hkE5QpbueWYVZqbolsqR6s+3uSxSvrzSZqoJhM/TzF2BSzwrjZvYjckrppopPFezYu14h5rkxUsLXsjnTVWGLQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.2.0.tgz",
+      "integrity": "sha512-7J0nJCd7h29CXG0jeejS8DnI4qAF96Fo6qibAPG7nbbJ5v0ZpWZhzeL8XwvvT3du6S50bRGcQCPJQNcShw6pEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/build-utils": "13.19.1",
+        "@vercel/build-utils": "13.20.0",
         "@vercel/nft": "1.5.0",
         "@yarnpkg/parsers": "^3.0.0",
         "execa": "3.2.0",
@@ -5434,9 +5352,9 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.19.1",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.19.1.tgz",
-      "integrity": "sha512-TRb8x9MuRrBYx7SjwW4hGnEMTnEPDk/jCQRjziS7AkPj0ahayqYlSjoZG3AWKc5NLOwulLekGbhQXUMRAdaA/A==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.20.0.tgz",
+      "integrity": "sha512-Jd29k42KSCRKOs+oSSVthw4xSjZBK3pUDG6AZl95/TsvIDNwRkjI2Nvs1ZcYDJdeLR346PQdWReFJGqkf/tb6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5453,13 +5371,13 @@
       "license": "MIT"
     },
     "node_modules/@vercel/cervel": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.54.tgz",
-      "integrity": "sha512-VHIfHr+5YaKdQAy/tatHlU0PnBzwEkHpWCje5f65gi0vd2Ti9d39jL/80q6PYeiFFlhExOrC7YfO87uHOLjsHg==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.55.tgz",
+      "integrity": "sha512-uRisWx/d5goDEKx9eVpDjT4LA65FsOmDRw65ZMqkFZJbeX496ss37g1+/yiVBrQ0+35RcTYB9K1i8JAMFqv57w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.1.2"
+        "@vercel/backends": "0.2.0"
       },
       "bin": {
         "cervel": "bin/cervel.mjs"
@@ -5479,13 +5397,13 @@
       }
     },
     "node_modules/@vercel/elysia": {
-      "version": "0.1.70",
-      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.70.tgz",
-      "integrity": "sha512-UJaXenUsn45b1hrMTs/zAl/OiXPuzj5UzoYXaLf/04rPqvRT6HU9qWYsBpQjtkJgYLg4HB+M1xhv1EKOz1EKWg==",
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.71.tgz",
+      "integrity": "sha512-YTEIX6hfpgg71D/45QyYGLj/wXUjnvfbbNWOgbnmWs9B2yWeZzWFysp6umVg99bvvyxgaPfes9I0MQbqNMvIgA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -5497,15 +5415,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/express": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.80.tgz",
-      "integrity": "sha512-noHMleNoodWYlTNZE5hnC1m4Llt2KsK06/8aRM22kWVItmdRg9D63obTBTs14/N6IIrj0qyzt8YMvv4oHNg7XQ==",
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.81.tgz",
+      "integrity": "sha512-Y7J5L7jdiJ/3ojo0SO2OVINCN4+CzST0kW9SXLCB75oNajwZ0wFsUSp/x5PqjDtJ2WU9QDIXO7qBhjrRkaEK4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/cervel": "0.0.54",
+        "@vercel/cervel": "0.0.55",
         "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -5524,13 +5442,13 @@
       }
     },
     "node_modules/@vercel/fastify": {
-      "version": "0.1.73",
-      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.73.tgz",
-      "integrity": "sha512-BGMg/KuTXQX0DHPgSNCMK7Msfcltdlc/H6NyxDOg6yVhw8ITOhv541YnDD4ogBEvqM1qDA1UPQqb47GfQJMvkw==",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.74.tgz",
+      "integrity": "sha512-CjjuHKysQs41MJOWHVGXyiZvhLQBzAe5KRamXgs4Tn0lNztQh/tY0TlB8Qtty8+R2c5I4l0EnNCSxQ3a/Nayxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -5699,14 +5617,14 @@
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.20.tgz",
-      "integrity": "sha512-smLWjyPK/9dx0KzRktrqvTBDmA5198a7pju80xgt5DA9ffCwPqPNWfRCEHiCf+20eGtkqn+nlaeA5KBBl0NOVQ==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.21.tgz",
+      "integrity": "sha512-QHsoUoiLaUBq6px9oNUtTh2M/Ba1lNa3fVvEU70gY3PkzVlEf20tS/g04lEnBhtqMCSMJgziO8/Ql058pcppFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "13.19.1",
+        "@vercel/build-utils": "13.20.0",
         "esbuild": "0.27.0",
         "etag": "1.8.1",
         "fs-extra": "11.1.0"
@@ -5727,25 +5645,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/h3": {
-      "version": "0.1.79",
-      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.79.tgz",
-      "integrity": "sha512-9dHqIr7qNA43GxPW+gWKu1H+jfNVb67w+a28x5bgc/Ienf5t9o618zNWT1w78C86nwHFlK1b/F/kj+LXFhcKuQ==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.80.tgz",
+      "integrity": "sha512-Vu+l1qXjD9P8P5rnLKGRaSbKkbBnxc2in+zHN7tD0vWxLcpecrPKnAgbVozT37LDvpT5I38aXQIFMKokjCQfAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/hono": {
-      "version": "0.2.73",
-      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.73.tgz",
-      "integrity": "sha512-Lf9iPD1fOK2lv2PX2u5MQEID/FMQyK24qDZFyB56jzEaCWt7Qlihc2uCh2g/ONMPk7DlS4Gw/lHA9VkLP+VjKQ==",
+      "version": "0.2.74",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.74.tgz",
+      "integrity": "sha512-NWOEeb3Vg8d9Y5/wnjajdPzXrrImGoSds/PkqQK802mzR9/8svdFhe1qnqSxzM6e3Y2iID0DJxhnZjVjowkOcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -5775,24 +5693,24 @@
       }
     },
     "node_modules/@vercel/koa": {
-      "version": "0.1.53",
-      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.53.tgz",
-      "integrity": "sha512-vVIQ1zV9f73+Ltr7sWO+uFz6X8KWFT6v1ptjY0l9YE0OZWOY+NPRy0+6n/BFrlE9BWUuWq816Nv5EKqS88/TeQ==",
+      "version": "0.1.54",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.54.tgz",
+      "integrity": "sha512-fUNQ6Wwp8gGT2KnoUH5Xv74eatFjza0cWwj60vY7zdymoNbuVNDBRLxFGiMUHl/wItzYuQIhPoaEeGiiYcuMDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/nestjs": {
-      "version": "0.2.74",
-      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.74.tgz",
-      "integrity": "sha512-mE1C+RFWpwtF7erTiwLuL32lnLBg+xlH57JgmSS0JKXKMTZAWKJgbKC/ya06O9ChXB5PYdSowjVvLk/oGqGj0A==",
+      "version": "0.2.75",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.75.tgz",
+      "integrity": "sha512-0wTm/Yp15Z3tvu8OFEvzQjXyC7R/77mGQ3vKn61LNxxxGztL2m0N+F2oIciEiIaHYszct3TbEkA6bUbUFBGDLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -5928,9 +5846,9 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.7.12",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.12.tgz",
-      "integrity": "sha512-ClU5ttdwMUr+IC43nNdRhHQR9XnIaF1SNUSJ0IrTQvqXt9ItLvS1zEDRF83VPLVFs4Rd6WtSB2kcGGsRzHjcEw==",
+      "version": "5.7.13",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.13.tgz",
+      "integrity": "sha512-IbGplZ0lAvk6D4scBENKRLOjVbLa3knA3nDJL/1tmcy32UeWRdumo/YpoNMYo3Eg6y6uLtI1ajwpnQJsfzUtjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5938,7 +5856,7 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.19.1",
+        "@vercel/build-utils": "13.20.0",
         "@vercel/error-utils": "2.0.3",
         "@vercel/nft": "1.5.0",
         "@vercel/static-config": "3.2.0",
@@ -6096,9 +6014,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.35.0.tgz",
-      "integrity": "sha512-BpJ0+jrufofKQqt2lK7zIW4/ll3b4H8hzMnX7cchE1jbTIyywpIUdr4c9hCxLIfjw6j+NWx2Kew6kisRFyzHxQ==",
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.36.0.tgz",
+      "integrity": "sha512-GLCX2JV2zfjGoSaANWi6gfL1z1IO02ulFhDOGYlOwBmVb1qQFLLssTnbN5uDO5heWm5Owi2/eqBG+l2E7TXiVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6264,14 +6182,14 @@
       }
     },
     "node_modules/@vercel/static-build": {
-      "version": "2.9.20",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.20.tgz",
-      "integrity": "sha512-jE0aG9GswRUwXor2CJunUP15Au5XJEpmbwLlnDhOUruMvjVA3nyAmbHGznzBn0n+PjhopXwehiyFazIJUwKWdg==",
+      "version": "2.9.21",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.21.tgz",
+      "integrity": "sha512-LnaroK/z97iAwg0vNHECQHAm2oaFLSWiKqCZIETnv5RpIqDXgj/URBD8v+DNNSXWGXsYOk7ezLRuQnlpq3Jx5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-        "@vercel/gatsby-plugin-vercel-builder": "2.1.20",
+        "@vercel/gatsby-plugin-vercel-builder": "2.1.21",
         "@vercel/static-config": "3.2.0",
         "ts-morph": "12.0.0"
       }
@@ -6404,14 +6322,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.168",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
-      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "version": "6.0.170",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.170.tgz",
+      "integrity": "sha512-FWTKeGGDRcYJtPWIrdZDSuvOW5LCjI2NZUJmaml8OTOaPEsXnFdFvmawCXbT+wTGxyWKJTgZ9sZtCjbJsmjM2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.104",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
+        "@ai-sdk/gateway": "3.0.105",
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -6422,9 +6340,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6527,6 +6445,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -6789,9 +6719,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -6965,9 +6895,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6977,9 +6907,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7198,9 +7128,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7304,12 +7234,6 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -7527,9 +7451,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
-      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.1.tgz",
+      "integrity": "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
@@ -7546,7 +7470,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
-        "@clerk/react": "^6.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -7565,9 +7489,9 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.49",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.49.tgz",
-      "integrity": "sha512-mBDhwvxUZYtRuEx4a9opk7LI6IghcPOHd99QVPAzMugeYeAukLjkFkkkAU9J53edxxwGWfx1IsoKLzC+DK6ugg==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.50.tgz",
+      "integrity": "sha512-rMNfrgcKJGToYDqNns2n1AO9KUP1NyC/AF9ldYEuWwTfRbgC9RQiHjlZsZQ/sOjLIVPUyKKIjoI/fNJUzy1urw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -7972,9 +7896,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -8009,14 +7933,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -8881,9 +8805,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -9470,9 +9394,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9696,9 +9620,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9947,9 +9871,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11727,9 +11651,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12133,9 +12057,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
-      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
@@ -12719,9 +12643,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -13352,9 +13276,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -13410,9 +13334,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -13615,6 +13539,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
+      "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.46.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
@@ -13644,14 +13589,31 @@
         "extendable-media-recorder-wav-encoder": "^7.0.68"
       }
     },
+    "node_modules/react-stately": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
+      "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-tooltip": {
-      "version": "5.30.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.1.tgz",
-      "integrity": "sha512-1lSPLQXuVooePxadUpmcwLgOsF1mIty7UZTJ9XnyfX4drOzStYs4JMXnazcDLguQr41W5OUZddOp9kfvArdpEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.0.tgz",
+      "integrity": "sha512-J7m56tmdmhpjHz8YsQXGNaJdsYtrByKQvKj/Vcd0GBru1fcGRP2yv0ehCEuJbKTirlt3iBg9W5gcMWnM1dj67w==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.6.1",
-        "classnames": "^2.3.0"
+        "@floating-ui/dom": "1.7.6",
+        "clsx": "2.1.1"
       },
       "peerDependencies": {
         "react": ">=16.14.0",
@@ -13969,15 +13931,15 @@
       "license": "MIT"
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -14222,9 +14184,9 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.12.38.tgz",
-      "integrity": "sha512-UIU8gyA2t0oYRobkf2MGUeo0KMjuNn+rHP3y1xZPoZinEVdo+56rUXIJBUbIWmVX4W6mkdKSOHU/ouRKt138vQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.0.tgz",
+      "integrity": "sha512-dBAiGDPP83CL0rMmHIG2oD+eal4eUNVLumOu5Hsae1f4YPqJ2iXeGF7bZg8HphqQk86K9TfZ4L4NO496sUtuGw==",
       "cpu": [
         "arm64"
       ],
@@ -14235,9 +14197,9 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.38.tgz",
-      "integrity": "sha512-+Wa/RmmZys7UzP9nUnaBq9+npj5LrQ73amqFO5cFX5CycYV1h36Dv+X2nyTYYp1nmt7oI/eKg7VPIvv8iMcHxQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.0.tgz",
+      "integrity": "sha512-/iV/uAkB6dkbqEmxLW4xVrhdAnFPKfA5RTXgeIDmX5926Y30JLWeaxHAnMK2M8swqDtv0Qrh+Ega77R96mP9Sw==",
       "cpu": [
         "x64"
       ],
@@ -14248,9 +14210,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.12.38.tgz",
-      "integrity": "sha512-sZmH66L6o1QNBh2MYgFFUTsbqEj1q+uwV0ChBIH6nVDHYQBtPyBndbcXv+KmJQSRpTBmRGET10CYZsK5Y+SCpA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.0.tgz",
+      "integrity": "sha512-szaiEu0RN/OyaYc5hwaeYvyWvNwh/hmZRHyZKbhdbx8H9ydMgQzirMtKYO//I20l2Ufz0nUPwrpVh5L59jblLg==",
       "cpu": [
         "arm64"
       ],
@@ -14261,9 +14223,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.12.38.tgz",
-      "integrity": "sha512-2kZmoD8kE077gKu5AWYB5P5giqDOjKVd20PvUjdu3+tu6FhFXGiAywP2biTu7ivloWiKtx8nygnih+cCHigx6A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.0.tgz",
+      "integrity": "sha512-GYiXTe4lWAICZvJiIvqacCGlxe7A/QveLcgSWHkRidlJfuZ5skLTe4gA/7KoMaxcdhE+SXnlwDUSjVdOgzcOmQ==",
       "cpu": [
         "x64"
       ],
@@ -14274,23 +14236,23 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.12.38.tgz",
-      "integrity": "sha512-WrfTnQd9uy6Y6aJisnS1X7lELLzc/Q/w6Gi3zj8VawTNL1HIPIAYeKVLuDaxio/0IHanrz0hgu7VIIiDGJkwCQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.13.0.tgz",
+      "integrity": "sha512-2EHPV+6yxp40LQ6JjN3lw/v50bsXO268PtvqAddLgAqcWYTvWAvStPlthv1UTjp0CADhdxizAARkW/+5nQLeQQ==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.12.38",
-        "sherpa-onnx-darwin-x64": "^1.12.38",
-        "sherpa-onnx-linux-arm64": "^1.12.38",
-        "sherpa-onnx-linux-x64": "^1.12.38",
-        "sherpa-onnx-win-ia32": "^1.12.38",
-        "sherpa-onnx-win-x64": "^1.12.38"
+        "sherpa-onnx-darwin-arm64": "^1.13.0",
+        "sherpa-onnx-darwin-x64": "^1.13.0",
+        "sherpa-onnx-linux-arm64": "^1.13.0",
+        "sherpa-onnx-linux-x64": "^1.13.0",
+        "sherpa-onnx-win-ia32": "^1.13.0",
+        "sherpa-onnx-win-x64": "^1.13.0"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.12.38.tgz",
-      "integrity": "sha512-NBluqnyXM2DemURbTnGPdkpRSQGlhJ+8RbtxFt6hRYSaJ7gTN0154rJ6IebHI7UiZSuXe3r8ZYUs3UZYqhplAQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.0.tgz",
+      "integrity": "sha512-m8h4rFQUnsI4NP7UezR+yCrdPsU84EUDvPjE/puPJaAlFxcIapD9K6ibnoK4+r3g3QwVbKCIxJnC+fCBW6qr+A==",
       "cpu": [
         "ia32"
       ],
@@ -14301,9 +14263,9 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.12.38",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.12.38.tgz",
-      "integrity": "sha512-D7kimY7oosJID+9gTZI3g/Pc43/3ZYQ6EP8rpBhCGTDlND9DaDXpOS7aUCVqUAVRZU3+w6rZyE0s9LVuWoo/9w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.13.0.tgz",
+      "integrity": "sha512-vDNEt1ztlsG8LLDnuX3Km6WmUDZ9qcwcFhlv4ROERV1qxf9BjK8j3BTg56/1EpQjDogEKBJwi8a4cbiHGPL/hw==",
       "cpu": [
         "x64"
       ],
@@ -14437,13 +14399,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -15004,13 +14966,12 @@
       }
     },
     "node_modules/svix": {
-      "version": "1.91.1",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.91.1.tgz",
-      "integrity": "sha512-Vn8nuer+o3NhGLHJNW3CPxls3te8YLr0xC3ImfcksG7taC/A+o8+PcVAK4sj1LJs4kM9HdmkXBnS3WU4E0YHHA==",
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
       "license": "MIT",
       "dependencies": {
-        "standardwebhooks": "1.0.0",
-        "uuid": "^10.0.0"
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -15521,16 +15482,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
-      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.0",
-        "@typescript-eslint/parser": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0"
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15698,19 +15659,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -15727,35 +15675,35 @@
       }
     },
     "node_modules/vercel": {
-      "version": "51.8.0",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-51.8.0.tgz",
-      "integrity": "sha512-0NVtnfF/7y2b/lEh3MFDpsaSkxdTQEbs58ORJT2orixPDyu67tq/6THvds269JguMWpQui4h7BedYunZXy7d3A==",
+      "version": "52.0.0",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-52.0.0.tgz",
+      "integrity": "sha512-yLQn/wrGWVjvoCKQJuqi+aZvy+yYNDY9tSWiq6sH3LlTZ8zdEIHS7hB07TTsYTLQQWb55rW0h5d05QPExMVcSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.1.2",
+        "@vercel/backends": "0.2.0",
         "@vercel/blob": "2.3.0",
-        "@vercel/build-utils": "13.19.1",
+        "@vercel/build-utils": "13.20.0",
         "@vercel/detect-agent": "1.2.3",
-        "@vercel/elysia": "0.1.70",
-        "@vercel/express": "0.1.80",
-        "@vercel/fastify": "0.1.73",
+        "@vercel/elysia": "0.1.71",
+        "@vercel/express": "0.1.81",
+        "@vercel/fastify": "0.1.74",
         "@vercel/fun": "1.3.0",
         "@vercel/go": "3.5.0",
-        "@vercel/h3": "0.1.79",
-        "@vercel/hono": "0.2.73",
+        "@vercel/h3": "0.1.80",
+        "@vercel/hono": "0.2.74",
         "@vercel/hydrogen": "1.3.6",
-        "@vercel/koa": "0.1.53",
-        "@vercel/nestjs": "0.2.74",
+        "@vercel/koa": "0.1.54",
+        "@vercel/nestjs": "0.2.75",
         "@vercel/next": "4.16.8",
-        "@vercel/node": "5.7.12",
+        "@vercel/node": "5.7.13",
         "@vercel/prepare-flags-definitions": "0.2.1",
-        "@vercel/python": "6.35.0",
+        "@vercel/python": "6.36.0",
         "@vercel/redwood": "2.4.12",
         "@vercel/remix-builder": "5.7.2",
         "@vercel/ruby": "2.3.2",
         "@vercel/rust": "1.1.1",
-        "@vercel/static-build": "2.9.20",
+        "@vercel/static-build": "2.9.21",
         "chokidar": "4.0.0",
         "esbuild": "0.27.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-media-recorder": "^1.7.2",
-    "react-tooltip": "^5.30.1",
+    "react-tooltip": "^6.0.0",
     "svix": "^1.90.0",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
@@ -54,7 +54,7 @@
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
-    "convex-test": "^0.0.49",
+    "convex-test": "^0.0.50",
     "eslint": "^10.2.1",
     "eslint-config-next": "^16.2.4",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -65,6 +65,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
-    "vercel": "^51.7.0"
+    "vercel": "^52.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bring all outdated npm dependencies to their latest published versions: 9 in-range bumps via \`npm update\` (patches + two minors), plus 3 manual upgrades behind range constraints (\`convex-test\` 0.0.49 → 0.0.50, \`react-tooltip\` v5 → v6, \`vercel\` v51 → v52).
- The two majors are vetted: \`react-tooltip\` v6 only removes APIs we don't use (\`data-tooltip-html\`, the \`html\` prop, HTML-string content); \`vercel\` v52's only breaking change excludes config files from static deployments at deploy time.

Closes #625.

## Test plan

- [ ] \`npm run lint\` — clean
- [ ] \`npx tsc --noEmit\` — clean
- [ ] \`npm test -- --runInBand\` — 384/384 passed
- [ ] \`npm run build\` — Compiled successfully
- [ ] Manual smoke: hover the sidebar nav icons (collapsed state) and verify tooltips render correctly under react-tooltip v6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to their latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->