### PR TITLE
release: v3.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sayit-web",
-  "version": "3.16.4",
+  "version": "3.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sayit-web",
-      "version": "3.16.4",
+      "version": "3.17.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.53",
         "@clerk/nextjs": "^7.2.3",
@@ -4220,6 +4220,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit-web",
-  "version": "3.16.4",
+  "version": "3.17.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release v3.17.0.

## Highlights since v3.16.4

- **Recorded audio tiles** (#621, PR #622) — record / add / edit / delete 60 s labeled audio tiles with playback, broken-state handling, and edit affordances. Includes the AudioRecorderControl hero redesign (progress ring + state-driven palette) and review-fix work (server-side upload guards, MIME allow-list, byte cap, orphan-upload cleanup).
- **Reduce action-tile duplication via useTileGesture hook** (#623, PR #624) — gesture state machine extracted into a single hook; PhraseTile relocated into the `tiles/` directory alongside its peers.
- **Update dependencies to latest** (#625, PR #626) — 9 in-range bumps plus `convex-test` 0.0.50, `react-tooltip` v6, `vercel` v52.

## Test plan

- [ ] CI green (test-and-lint, CodeRabbit, Vercel)
- [ ] Production build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 3.17.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->