### PR TITLE
Bump GitHub Actions to v6 (Node 20 → 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- Bump \`actions/checkout@v4\` → \`actions/checkout@v6\` and \`actions/setup-node@v4\` → \`actions/setup-node@v6\` across \`ci.yml\`, \`release.yml\`, and \`vercel-deploy.yml\`. Both v6 majors run on the Node 24 runtime, ahead of the 2026-09-16 deadline when Node 20 leaves the runners.
- \`cache: 'npm'\` is set explicitly in every workflow so the v5/v6 auto-cache changes don't affect behavior.

Closes #628.

## Test plan

- [ ] CI on this PR succeeds (validates \`ci.yml\` end-to-end with v6 actions)
- [ ] No new deprecation annotation in the workflow logs
- [ ] Next release run will exercise \`release.yml\` and \`vercel-deploy.yml\` with v6 actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline infrastructure to use the latest stable versions of build tools across multiple workflows, ensuring better compatibility and security while maintaining existing Node.js configurations and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->