### PR TITLE
Disable Vercel Git auto-deploy for landing

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  },
   "redirects": [
     {
       "source": "/dashboard/:path*",


### PR DESCRIPTION
## Summary
- Add `git.deploymentEnabled: false` to `apps/landing/vercel.json` so pushes no longer trigger Git-integration deploys.
- Release workflow's CLI deploys (`vercel --prod`) are unaffected — that path is the single source of truth for landing deploys now.
- Also adds `$schema` for editor autocomplete.

Closes #641

## Test plan
- [ ] After merge, push to `main` does not produce a new landing deployment in the Vercel dashboard
- [ ] Next tag-driven release workflow run still deploys landing via CLI successfully
- [ ] No regression to existing redirects (Astro routes still proxy to `app.sayitaac.com`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to disable automatic git-triggered deployments; deployments now require manual activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->