### PR TITLE
release: v4.0.0

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "3.17.0",
+  "version": "4.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "3.17.0",
+  "version": "4.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "3.17.0",
+  "version": "4.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts v4.0.0. Bumps `version` to `4.0.0` in all three workspace `package.json` files (root, `apps/web`, `apps/landing`).

## What's in v4.0.0

Retrospective grouping of post-v3.17.0 work:

- #628 — Bump GitHub Actions to v6 (Node 20 → 24)
- #630 — Prepare repository for open source release
- #632 — Move web app into pnpm monorepo workspace
- #634 — Add Astro product landing page
- #636 — Add landing-domain redirects for app subdomain split
- #638 — Update release workflow for monorepo deployments
- #641 — Disable Vercel Git auto-deploy for landing project
- #643 — Redesign apps/landing as a typography-led single-page manifesto

Major-version bump is appropriate: monorepo restructure + domain split + open-source readiness change the project shape, even though no user-facing app feature breaks.

## Verification

- `pnpm test` — 384 tests passed across 43 suites
- `pnpm lint` — 0 errors / 0 warnings (eslint + astro check)

## Test plan

- [ ] CI passes
- [ ] After merge, push tag `v4.0.0` from main; release workflow deploys web + landing via Vercel CLI and creates the GitHub Release with auto-generated notes
- [ ] Verify `sayitaac.com` shows `v4.0.0` in the footer post-deploy
- [ ] Close v4.0.0 milestone