### PR TITLE
Drop vercel build --prebuilt from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,44 +31,16 @@ jobs:
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
 
-      - name: Pull web Vercel project settings
-        working-directory: apps/web
-        run: pnpm exec vercel pull --yes --environment=production --token ${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
-
-      - name: Build web
-        working-directory: apps/web
-        run: pnpm exec vercel build --prod --token ${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
-
       - name: Deploy web to Vercel
         working-directory: apps/web
-        run: pnpm exec vercel deploy --prebuilt --prod --token ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm exec vercel deploy --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
-
-      - name: Pull landing Vercel project settings
-        working-directory: apps/landing
-        run: pnpm exec vercel pull --yes --environment=production --token ${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_LANDING_PROJECT_ID }}
-
-      - name: Build landing
-        working-directory: apps/landing
-        run: pnpm exec vercel build --prod --token ${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_LANDING_PROJECT_ID }}
 
       - name: Deploy landing to Vercel
         working-directory: apps/landing
-        run: pnpm exec vercel deploy --prebuilt --prod --token ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm exec vercel deploy --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_LANDING_PROJECT_ID }}


### PR DESCRIPTION
## Summary

The v4.0.0 release run ([25172062654](https://github.com/enaboapps/sayit-web/actions/runs/25172062654)) failed at Build web with `Error: spawn sh ENOENT` from `vercel build --prebuilt`. Reran the failed job, same result.

This PR removes the prebuild path entirely and relies on Vercel building remotely.

- Drops `Pull web Vercel project settings` + `Build web` + the `--prebuilt` flag on `Deploy web`
- Drops `Pull landing Vercel project settings` + `Build landing` + the `--prebuilt` flag on `Deploy landing`
- Adds `--yes` to skip the interactive scope-confirmation prompt

Net diff: -30 +2.

## Why this works

Vercel's hosted build path is what the Git integration used before #641 disabled auto-deploys; it's well-trodden and doesn't depend on local-shell behavior. Trade-off is ~1-3 min per deploy because Vercel cold-starts a build container instead of pulling a prebuilt artifact.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: delete + repush the v4.0.0 tag to retrigger the workflow
- [ ] Workflow completes; web at app.sayitaac.com and landing at sayitaac.com both serve v4.0.0
- [ ] GitHub Release for v4.0.0 created with auto-generated notes

Closes #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow by removing prebuilt artifact dependencies and simplifying deployment commands for web and landing applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->