### PR TITLE
Deploy workspace root to Vercel; let Root Directory apply once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,14 @@ jobs:
 
       - name: Deploy web to Vercel
         working-directory: apps/web
-        run: pnpm exec vercel deploy --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm exec vercel deploy ../.. --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
 
       - name: Deploy landing to Vercel
-        working-directory: apps/landing
-        run: pnpm exec vercel deploy --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/web
+        run: pnpm exec vercel deploy ../.. --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_LANDING_PROJECT_ID }}


### PR DESCRIPTION
## Summary

Second fix for #646. The previous PR (#647) removed `--prebuilt` but the deploy still failed with:

> Error: The provided path "~/work/sayit-web/sayit-web/apps/web/apps/web" does not exist.

Path doubling: cwd was `apps/web/`, Vercel project's configured Root Directory is also `apps/web`, so Vercel ended up looking at `apps/web/apps/web`.

## Fix

Deploy `../..` (the workspace root) from `apps/web/`. Vercel's configured Root Directory then applies once, landing on `apps/web/` for the web project and `apps/landing/` for the landing project. The landing step keeps `working-directory: apps/web` because Vercel CLI is only installed there; the project gets selected via `VERCEL_PROJECT_ID`.

## Test plan

- [ ] CI passes
- [ ] After merge: delete + repush v4.0.0 tag (third attempt)
- [ ] Workflow completes; web at app.sayitaac.com and landing at sayitaac.com both serve v4.0.0

Refs #646