### PR TITLE
Ignore Next dev server log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+.next-dev-server.log
 
 # env files (can opt-in for committing if needed)
 .env*.local


### PR DESCRIPTION
## Summary
- Adds `.next-dev-server.log` to `.gitignore` so local dev server logs do not show up as untracked files.

Closes #662

## Verification
- `git check-ignore -v .next-dev-server.log`