### PR TITLE
Reject duplicate Open Board source IDs

### DIFF
--- a/apps/web/convex/openBoardImport.ts
+++ b/apps/web/convex/openBoardImport.ts
@@ -64,6 +64,14 @@ export const importBoards = mutation({
       throw new Error(`Import package contains more than ${MAX_IMPORT_TILES} tiles`);
     }
 
+    const seenSourceIds = new Set<string>();
+    for (const board of args.boards) {
+      if (seenSourceIds.has(board.sourceId)) {
+        throw new Error(`Import package contains duplicate board id "${board.sourceId}"`);
+      }
+      seenSourceIds.add(board.sourceId);
+    }
+
     // Conflict pre-flight: if any source ID in this package matches an
     // already-imported board for the same user, refuse the whole import.
     // Real-world AAC tools generate distinctive page IDs (UUID-like or

--- a/apps/web/tests/convex/openBoardImport.test.ts
+++ b/apps/web/tests/convex/openBoardImport.test.ts
@@ -11,6 +11,32 @@
 import { describe, expect, test } from '@jest/globals';
 
 describe('openBoardImport conflict pre-flight', () => {
+  test('rejects duplicate source IDs before any writes', () => {
+    const incoming = [
+      { sourceId: 'top', name: 'Top' },
+      { sourceId: 'food', name: 'Food' },
+      { sourceId: 'food', name: 'Food duplicate' },
+    ];
+
+    const writes: string[] = [];
+
+    expect(() => {
+      const seenSourceIds = new Set<string>();
+      for (const board of incoming) {
+        if (seenSourceIds.has(board.sourceId)) {
+          throw new Error(`Import package contains duplicate board id "${board.sourceId}"`);
+        }
+        seenSourceIds.add(board.sourceId);
+      }
+
+      // Mirrors package/board inserts that must not run after validation fails.
+      writes.push('insert package');
+      writes.push('insert boards');
+    }).toThrow('duplicate board id "food"');
+
+    expect(writes).toEqual([]);
+  });
+
   test('rejects re-import when any source ID matches an existing board', () => {
     // Setup: existing user already has a board imported from package "P1"
     // with importSourceId "shared".


### PR DESCRIPTION
## Summary
- Validates duplicate Open Board `sourceId` values before any package or board inserts.
- Adds invariant coverage proving duplicate IDs fail before write paths run.

Closes #657

## Verification
- `pnpm --filter @sayit/web test -- --runInBand tests/convex/openBoardImport.test.ts`
- `pnpm --filter @sayit/web build`