### PR TITLE
Handle fixed-grid tile spans in occupancy checks

### DIFF
--- a/apps/web/convex/aacLayout.ts
+++ b/apps/web/convex/aacLayout.ts
@@ -8,6 +8,79 @@ import type { Doc } from './_generated/dataModel';
 // `i-think-we-ll-need-quizzical-moore.md`).
 export const FIXED_GRID_LAYOUT_VERSION = 1;
 
+export type FixedGridRect = {
+  row: number;
+  column: number;
+  rowSpan: number;
+  columnSpan: number;
+};
+
+export type FixedGridBoardShape = {
+  layoutMode?: string;
+  gridRows?: number;
+  gridColumns?: number;
+};
+
+export type FixedGridTileShape = {
+  cellRow?: number;
+  cellColumn?: number;
+  cellRowSpan?: number;
+  cellColumnSpan?: number;
+};
+
+export function normaliseFixedGridSpan(value: number | undefined): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 1;
+}
+
+export function tileFixedGridRect(tile: FixedGridTileShape): FixedGridRect | null {
+  if (
+    typeof tile.cellRow !== 'number' ||
+    typeof tile.cellColumn !== 'number' ||
+    !Number.isInteger(tile.cellRow) ||
+    !Number.isInteger(tile.cellColumn)
+  ) {
+    return null;
+  }
+
+  return {
+    row: tile.cellRow,
+    column: tile.cellColumn,
+    rowSpan: normaliseFixedGridSpan(tile.cellRowSpan),
+    columnSpan: normaliseFixedGridSpan(tile.cellColumnSpan),
+  };
+}
+
+export function fixedGridRectsOverlap(left: FixedGridRect, right: FixedGridRect): boolean {
+  return (
+    left.row < right.row + right.rowSpan &&
+    left.row + left.rowSpan > right.row &&
+    left.column < right.column + right.columnSpan &&
+    left.column + left.columnSpan > right.column
+  );
+}
+
+export function fixedGridRectWithinBoard(
+  board: FixedGridBoardShape,
+  rect: FixedGridRect
+): boolean {
+  if (
+    board.layoutMode !== 'fixedGrid' ||
+    typeof board.gridRows !== 'number' ||
+    typeof board.gridColumns !== 'number' ||
+    !Number.isInteger(board.gridRows) ||
+    !Number.isInteger(board.gridColumns)
+  ) {
+    return false;
+  }
+
+  return (
+    rect.row >= 0 &&
+    rect.column >= 0 &&
+    rect.row + rect.rowSpan <= board.gridRows &&
+    rect.column + rect.columnSpan <= board.gridColumns
+  );
+}
+
 /**
  * Find the next empty cell (row-major scan) on a fixed-grid board, given the
  * tiles already placed there. Returns `null` for free-mode boards (callers
@@ -32,8 +105,13 @@ export function nextFixedGridCell(
 
   const occupied = new Set<string>();
   for (const tile of tiles) {
-    if (typeof tile.cellRow === 'number' && typeof tile.cellColumn === 'number') {
-      occupied.add(`${tile.cellRow}:${tile.cellColumn}`);
+    const rect = tileFixedGridRect(tile);
+    if (!rect) continue;
+
+    for (let row = rect.row; row < rect.row + rect.rowSpan; row++) {
+      for (let column = rect.column; column < rect.column + rect.columnSpan; column++) {
+        occupied.add(`${row}:${column}`);
+      }
     }
   }
 

--- a/apps/web/convex/boardTiles.ts
+++ b/apps/web/convex/boardTiles.ts
@@ -9,7 +9,13 @@ import {
   validateAudioLabel,
   validateAudioMetadata,
 } from './audioLimits';
-import { nextFixedGridCell } from './aacLayout';
+import {
+  fixedGridRectWithinBoard,
+  fixedGridRectsOverlap,
+  nextFixedGridCell,
+  normaliseFixedGridSpan,
+  tileFixedGridRect,
+} from './aacLayout';
 
 const tileRoleValidator = v.union(
   v.literal('core'),
@@ -44,27 +50,35 @@ async function assertFixedGridCellAvailable(
   if (!Number.isInteger(row) || !Number.isInteger(column) || row < 0 || column < 0) {
     throw new Error('Cell coordinates must be non-negative integers');
   }
-  if (
-    typeof board.gridRows !== 'number' ||
-    typeof board.gridColumns !== 'number' ||
-    row >= board.gridRows ||
-    column >= board.gridColumns
-  ) {
+  if (typeof board.gridRows !== 'number' || typeof board.gridColumns !== 'number') {
     throw new Error('Cell coordinates are outside the board grid');
+  }
+  if (row >= board.gridRows || column >= board.gridColumns) {
+    throw new Error('Cell coordinates are outside the board grid');
+  }
+
+  const requestedRect = {
+    row,
+    column,
+    rowSpan: normaliseFixedGridSpan(tile.cellRowSpan),
+    columnSpan: normaliseFixedGridSpan(tile.cellColumnSpan),
+  };
+
+  if (!fixedGridRectWithinBoard(board, requestedRect)) {
+    throw new Error('Cell span exceeds the board grid');
   }
 
   const existing = await ctx.db
     .query('boardTiles')
     .withIndex('by_board', (q) => q.eq('boardId', board._id))
-    .filter((q) =>
-      q.and(
-        q.eq(q.field('cellRow'), row),
-        q.eq(q.field('cellColumn'), column)
-      )
-    )
     .collect();
 
-  const occupant = existing.find((candidate) => candidate._id !== tile._id);
+  const occupant = existing.find((candidate) => {
+    if (candidate._id === tile._id) return false;
+
+    const candidateRect = tileFixedGridRect(candidate);
+    return candidateRect ? fixedGridRectsOverlap(requestedRect, candidateRect) : false;
+  });
   if (occupant) {
     throw new Error('Cell is already occupied');
   }

--- a/apps/web/tests/convex/boardTiles.test.ts
+++ b/apps/web/tests/convex/boardTiles.test.ts
@@ -15,6 +15,13 @@ import {
   validateAudioMetadata,
   MAX_AUDIO_BYTES,
 } from '@/convex/audioLimits';
+import {
+  fixedGridRectWithinBoard,
+  fixedGridRectsOverlap,
+  nextFixedGridCell,
+  normaliseFixedGridSpan,
+  tileFixedGridRect,
+} from '@/convex/aacLayout';
 
 const mockDb = {
   query: jest.fn(),
@@ -59,6 +66,8 @@ const createTile = (overrides = {}) => ({
   audioByteSize: undefined,
   cellRow: undefined,
   cellColumn: undefined,
+  cellRowSpan: undefined,
+  cellColumnSpan: undefined,
   tileRole: undefined,
   isLocked: undefined,
   ...overrides,
@@ -404,6 +413,81 @@ describe('boardTiles', () => {
 
       expect(() => validateMove(1, 1)).toThrow(/already occupied/);
       expect(() => validateMove(2, 2)).not.toThrow();
+    });
+
+    test('cell collision validation rejects span overlaps', () => {
+      const board = createBoard({ layoutMode: 'fixedGrid', gridRows: 3, gridColumns: 3 });
+      const movingTile = createTile({
+        _id: 'tile-moving',
+        cellRow: 0,
+        cellColumn: 0,
+        cellRowSpan: 1,
+        cellColumnSpan: 2,
+      });
+      const occupiedTile = createTile({
+        _id: 'tile-occupied',
+        cellRow: 1,
+        cellColumn: 1,
+        cellRowSpan: 2,
+        cellColumnSpan: 1,
+      });
+      const existingTiles = [movingTile, occupiedTile];
+
+      const validateMove = (row: number, column: number) => {
+        const requestedRect = {
+          row,
+          column,
+          rowSpan: normaliseFixedGridSpan(movingTile.cellRowSpan),
+          columnSpan: normaliseFixedGridSpan(movingTile.cellColumnSpan),
+        };
+        if (!fixedGridRectWithinBoard(board, requestedRect)) {
+          throw new Error('Cell span exceeds the board grid');
+        }
+
+        const occupant = existingTiles.find((tile) => {
+          if (tile._id === movingTile._id) return false;
+
+          const rect = tileFixedGridRect(tile);
+          return rect ? fixedGridRectsOverlap(requestedRect, rect) : false;
+        });
+        if (occupant) throw new Error('Cell is already occupied');
+      };
+
+      expect(() => validateMove(1, 0)).toThrow(/already occupied/);
+      expect(() => validateMove(2, 2)).toThrow(/span exceeds/);
+      expect(() => validateMove(0, 0)).not.toThrow();
+    });
+
+    test('next fixed-grid cell skips every cell covered by tile spans', () => {
+      const board = createBoard({ layoutMode: 'fixedGrid', gridRows: 2, gridColumns: 3 });
+      const spanningTile = createTile({
+        cellRow: 0,
+        cellColumn: 0,
+        cellRowSpan: 1,
+        cellColumnSpan: 2,
+      });
+
+      expect(nextFixedGridCell(board, [spanningTile] as never)).toEqual({
+        cellRow: 0,
+        cellColumn: 2,
+        cellRowSpan: 1,
+        cellColumnSpan: 1,
+      });
+    });
+
+    test('fixed-grid rectangles treat adjacent spans as non-overlapping', () => {
+      expect(
+        fixedGridRectsOverlap(
+          { row: 0, column: 0, rowSpan: 2, columnSpan: 1 },
+          { row: 0, column: 1, rowSpan: 2, columnSpan: 1 }
+        )
+      ).toBe(false);
+      expect(
+        fixedGridRectsOverlap(
+          { row: 0, column: 0, rowSpan: 2, columnSpan: 2 },
+          { row: 1, column: 1, rowSpan: 1, columnSpan: 1 }
+        )
+      ).toBe(true);
     });
 
     test('locked core tiles require explicit delete confirmation', () => {


### PR DESCRIPTION
## Summary
- add shared fixed-grid rectangle helpers for span bounds and overlap checks
- make fixed-grid placement skip every covered cell when tiles span multiple rows or columns
- make move validation reject span overlaps and spans that exceed the board grid

Closes #656

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/convex/boardTiles.test.ts
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build