### PR TITLE
Introduce app logging helper

### DIFF
--- a/apps/web/app/components/phrases/FixedAACGrid.tsx
+++ b/apps/web/app/components/phrases/FixedAACGrid.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import BoardTileRenderer from './tiles/BoardTileRenderer';
 import type { BoardTileSummary, PhraseSummary } from './types';
+import { appLogger } from '@/lib/logger';
 
 const WORD_CLASS_ACCENTS: Record<string, string> = {
   pronoun: 'ring-1 ring-slate-300/70',
@@ -70,16 +71,11 @@ export default function FixedAACGrid({
     for (const tile of tiles) {
       const { row, column } = tileCell(tile, columns);
       if (row < 0 || column < 0 || row >= rows || column >= columns) {
-        // Surface the silent drop in dev so a user reporting "my tile
-        // disappeared" has a breadcrumb. Skipped in production to avoid
-        // noisy warnings from valid migration / import cases where cell
-        // metadata is being filled in lazily.
-        if (process.env.NODE_ENV !== 'production') {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[FixedAACGrid] Tile ${tile.id} has out-of-bounds cell (${row}, ${column}) for ${rows}x${columns} grid; skipping.`
-          );
-        }
+        appLogger.warn(
+          'FixedAACGrid skipped an out-of-bounds tile',
+          { tileId: tile.id, row, column, rows, columns },
+          { production: false }
+        );
         continue;
       }
       map.set(`${row}:${column}`, tile);

--- a/apps/web/lib/logger.ts
+++ b/apps/web/lib/logger.ts
@@ -1,0 +1,57 @@
+type LogContext = Record<string, unknown>;
+
+type LogOptions = {
+  production?: boolean;
+};
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type NodeEnvReader = () => string | undefined;
+
+function currentNodeEnv(): string | undefined {
+  return process.env['NODE_ENV'];
+}
+
+function shouldLog(level: LogLevel, nodeEnv: string | undefined, options?: LogOptions): boolean {
+
+  if (nodeEnv === 'test') return true;
+  if (level === 'debug') return nodeEnv !== 'production';
+  if (options?.production === false && nodeEnv === 'production') return false;
+
+  return true;
+}
+
+function writeLog(
+  level: LogLevel,
+  message: string,
+  context?: LogContext,
+  options?: LogOptions,
+  readNodeEnv: NodeEnvReader = currentNodeEnv
+) {
+  if (!shouldLog(level, readNodeEnv(), options)) return;
+
+  if (context && Object.keys(context).length > 0) {
+    console[level](message, context);
+    return;
+  }
+
+  console[level](message);
+}
+
+export function createAppLogger(readNodeEnv: NodeEnvReader = currentNodeEnv) {
+  return {
+    debug(message: string, context?: LogContext, options?: LogOptions) {
+      writeLog('debug', message, context, options, readNodeEnv);
+    },
+    info(message: string, context?: LogContext, options?: LogOptions) {
+      writeLog('info', message, context, options, readNodeEnv);
+    },
+    warn(message: string, context?: LogContext, options?: LogOptions) {
+      writeLog('warn', message, context, options, readNodeEnv);
+    },
+    error(message: string, context?: LogContext, options?: LogOptions) {
+      writeLog('error', message, context, options, readNodeEnv);
+    },
+  };
+}
+
+export const appLogger = createAppLogger();

--- a/apps/web/tests/lib/logger.test.ts
+++ b/apps/web/tests/lib/logger.test.ts
@@ -1,0 +1,53 @@
+import { createAppLogger } from '@/lib/logger';
+
+describe('appLogger', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs structured warning context in tests', () => {
+    const appLogger = createAppLogger(() => 'test');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    appLogger.warn('FixedAACGrid skipped an out-of-bounds tile', {
+      tileId: 'tile-1',
+      row: 3,
+      column: 0,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith('FixedAACGrid skipped an out-of-bounds tile', {
+      tileId: 'tile-1',
+      row: 3,
+      column: 0,
+    });
+  });
+
+  it('does not hide expected diagnostics in tests when production logging is disabled', () => {
+    const appLogger = createAppLogger(() => 'test');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    appLogger.warn('Development-only warning', { feature: 'fixed-grid' }, { production: false });
+
+    expect(warnSpy).toHaveBeenCalledWith('Development-only warning', {
+      feature: 'fixed-grid',
+    });
+  });
+
+  it('suppresses development-only diagnostics in production', () => {
+    const appLogger = createAppLogger(() => 'production');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    appLogger.warn('Development-only warning', { feature: 'fixed-grid' }, { production: false });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps errors visible in production', () => {
+    const appLogger = createAppLogger(() => 'production');
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    appLogger.error('Failed to sync setting', { key: 'voice' });
+
+    expect(errorSpy).toHaveBeenCalledWith('Failed to sync setting', { key: 'voice' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a lightweight appLogger with structured context and environment-aware output
- preserve expected test diagnostics while allowing development-only logs to stay out of production
- migrate FixedAACGrid's out-of-bounds tile warning to the shared helper

Closes #663

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/lib/logger.test.ts tests/components/phrases/FixedAACGrid.test.tsx
- pnpm --filter @sayit/web test -- --runInBand
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build