### PR TITLE
Add typed phrase board data adapters

### DIFF
--- a/apps/web/lib/hooks/usePhraseBoardData.ts
+++ b/apps/web/lib/hooks/usePhraseBoardData.ts
@@ -3,8 +3,9 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 import { api } from '@/convex/_generated/api';
-import { Id } from '@/convex/_generated/dataModel';
+import type { Id } from '@/convex/_generated/dataModel';
 import { useAuth } from '@/app/contexts/AuthContext';
 import { useSettings } from '@/app/contexts/SettingsContext';
 import { useBoardNavStack } from '@/app/contexts/BoardNavStackContext';
@@ -12,7 +13,14 @@ import { useOnlineStatus } from './useOnlineStatus';
 import type { BoardSummary, BoardTileSummary, PhraseSummary, TileLayoutSummary } from '@/app/components/phrases/types';
 import type { TileRole, WordClass } from '@/lib/aacLayout';
 
-function tileLayoutSummary(tile: {
+type PhraseBoardsResult = FunctionReturnType<typeof api.phraseBoards.getPhraseBoards>;
+type ConvexBoardSummary = PhraseBoardsResult[number];
+type SelectedBoardData = NonNullable<FunctionReturnType<typeof api.phraseBoards.getPhraseBoard>>;
+type ConvexPhraseLink = SelectedBoardData['phrase_board_phrases'][number];
+type ConvexPhrase = NonNullable<ConvexPhraseLink['phrase']>;
+type ConvexBoardTile = SelectedBoardData['tiles'][number];
+
+type ConvexTileLayout = {
   cellRow?: unknown;
   cellColumn?: unknown;
   cellRowSpan?: unknown;
@@ -20,7 +28,9 @@ function tileLayoutSummary(tile: {
   tileRole?: unknown;
   wordClass?: unknown;
   isLocked?: unknown;
-}): TileLayoutSummary {
+};
+
+function tileLayoutSummary(tile: ConvexTileLayout): TileLayoutSummary {
   return {
     cellRow: typeof tile.cellRow === 'number' ? tile.cellRow : undefined,
     cellColumn: typeof tile.cellColumn === 'number' ? tile.cellColumn : undefined,
@@ -29,6 +39,84 @@ function tileLayoutSummary(tile: {
     tileRole: typeof tile.tileRole === 'string' ? tile.tileRole as TileRole : undefined,
     wordClass: typeof tile.wordClass === 'string' ? tile.wordClass as WordClass : undefined,
     isLocked: typeof tile.isLocked === 'boolean' ? tile.isLocked : undefined,
+  };
+}
+
+function hasPhrase(link: ConvexPhraseLink): link is ConvexPhraseLink & { phrase: ConvexPhrase } {
+  return link.phrase !== null;
+}
+
+export function toPhraseSummary(phrase: ConvexPhrase): PhraseSummary {
+  return {
+    id: String(phrase._id),
+    text: phrase.text,
+    symbolUrl: phrase.symbolUrl,
+    symbolStorageId: phrase.symbolStorageId ? String(phrase.symbolStorageId) : undefined,
+  };
+}
+
+export function toTileSummary(tile: ConvexBoardTile): BoardTileSummary | null {
+  if (tile.kind === 'phrase') {
+    if (!tile.phrase) return null;
+
+    return {
+      id: String(tile._id),
+      kind: 'phrase',
+      position: tile.position,
+      ...tileLayoutSummary(tile),
+      phrase: toPhraseSummary(tile.phrase),
+    };
+  }
+
+  if (tile.kind === 'audio') {
+    return {
+      id: String(tile._id),
+      kind: 'audio',
+      position: tile.position,
+      audioLabel: tile.audioLabel,
+      audioUrl: tile.audioUrl ?? null,
+      audioMimeType: tile.audioMimeType,
+      audioDurationMs: tile.audioDurationMs,
+      audioByteSize: tile.audioByteSize,
+      ...tileLayoutSummary(tile),
+    };
+  }
+
+  return {
+    id: String(tile._id),
+    kind: 'navigate',
+    position: tile.position,
+    targetBoardId: String(tile.targetBoardId),
+    targetBoardName: tile.targetBoardName ?? null,
+    ...tileLayoutSummary(tile),
+  };
+}
+
+export function toBoardSummary(
+  board: ConvexBoardSummary,
+  selectedBoardId: string | null,
+  phrases: PhraseSummary[],
+  tiles: BoardTileSummary[]
+): BoardSummary {
+  const isSelectedBoard = String(board._id) === selectedBoardId;
+
+  return {
+    id: String(board._id),
+    name: board.name,
+    position: board.position,
+    phrases: isSelectedBoard ? phrases : [],
+    tiles: isSelectedBoard ? tiles : undefined,
+    isShared: board.isShared,
+    isOwner: board.isOwner,
+    accessLevel: board.accessLevel,
+    sharedBy: board.sharedBy,
+    forClientId: board.forClientId,
+    forClientName: board.forClientName,
+    layoutMode: board.layoutMode ?? 'free',
+    gridRows: board.gridRows,
+    gridColumns: board.gridColumns,
+    layoutVersion: board.layoutVersion,
+    hiddenFromPicker: board.hiddenFromPicker,
   };
 }
 
@@ -124,81 +212,16 @@ export function usePhraseBoardData() {
 
 
   const phrases: PhraseSummary[] = selectedBoardData?.phrase_board_phrases
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ?.map((pbp: any) => pbp.phrase)
-    .filter(Boolean)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .map((phrase: any) => ({
-      id: String(phrase._id),
-      text: phrase.text,
-      symbolUrl: phrase.symbolUrl,
-      symbolStorageId: phrase.symbolStorageId ? String(phrase.symbolStorageId) : undefined,
-    })) || [];
+    ?.filter(hasPhrase)
+    .map((pbp) => toPhraseSummary(pbp.phrase)) || [];
 
    
   const tiles: BoardTileSummary[] = (selectedBoardData?.tiles ?? [])
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .map((tile: any): BoardTileSummary | null => {
-      if (tile.kind === 'phrase') {
-        if (!tile.phrase) return null; // skip orphaned phrase rows defensively
-        return {
-          id: String(tile._id),
-          kind: 'phrase',
-          position: tile.position,
-          ...tileLayoutSummary(tile),
-          phrase: {
-            id: String(tile.phrase._id),
-            text: tile.phrase.text,
-            symbolUrl: tile.phrase.symbolUrl,
-            symbolStorageId: tile.phrase.symbolStorageId ? String(tile.phrase.symbolStorageId) : undefined,
-          },
-        };
-      }
-      if (tile.kind === 'audio') {
-        return {
-          id: String(tile._id),
-          kind: 'audio',
-          position: tile.position,
-          audioLabel: tile.audioLabel,
-          audioUrl: tile.audioUrl ?? null,
-          audioMimeType: tile.audioMimeType,
-          audioDurationMs: tile.audioDurationMs,
-          audioByteSize: tile.audioByteSize,
-          ...tileLayoutSummary(tile),
-        };
-      }
-
-      // kind === 'navigate'
-      return {
-        id: String(tile._id),
-        kind: 'navigate',
-        position: tile.position,
-        targetBoardId: String(tile.targetBoardId),
-        targetBoardName: tile.targetBoardName ?? null,
-        ...tileLayoutSummary(tile),
-      };
-    })
+    .map(toTileSummary)
     .filter((t: BoardTileSummary | null): t is BoardTileSummary => t !== null);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const transformedBoards: BoardSummary[] = boards?.map((board: any) => ({
-    id: String(board._id),
-    name: board.name,
-    position: board.position,
-    phrases: board._id === selectedBoardId ? phrases : [],
-    tiles: board._id === selectedBoardId ? tiles : undefined,
-    isShared: board.isShared,
-    isOwner: board.isOwner,
-    accessLevel: board.accessLevel,
-    sharedBy: board.sharedBy,
-    forClientId: board.forClientId,
-    forClientName: board.forClientName,
-    layoutMode: board.layoutMode ?? 'free',
-    gridRows: board.gridRows,
-    gridColumns: board.gridColumns,
-    layoutVersion: board.layoutVersion,
-    hiddenFromPicker: board.hiddenFromPicker,
-  })) || [];
+  const transformedBoards: BoardSummary[] = boards
+    ?.map((board) => toBoardSummary(board, selectedBoardId, phrases, tiles)) || [];
 
   // `visibleBoards` is what picker UIs walk through — drill-down boards
   // imported from OBF vocabularies (CommuniKate, etc.) are flagged

--- a/apps/web/tests/lib/hooks/usePhraseBoardData.test.ts
+++ b/apps/web/tests/lib/hooks/usePhraseBoardData.test.ts
@@ -1,4 +1,13 @@
-import { preferredBoardSelection } from '@/lib/hooks/usePhraseBoardData';
+import {
+  preferredBoardSelection,
+  toBoardSummary,
+  toPhraseSummary,
+  toTileSummary,
+} from '@/lib/hooks/usePhraseBoardData';
+
+type PhraseInput = Parameters<typeof toPhraseSummary>[0];
+type TileInput = Parameters<typeof toTileSummary>[0];
+type BoardInput = Parameters<typeof toBoardSummary>[0];
 
 const boards = [
   { id: 'hidden-root', hiddenFromPicker: true },
@@ -45,5 +54,142 @@ describe('preferredBoardSelection', () => {
     expect(selection.selectedBoard?.id).toBe('hidden-b');
     expect(selection.preferredSelectedBoardId).toBe('hidden-b');
     expect(selection.validBoardIndex).toBe(0);
+  });
+});
+
+describe('phrase board adapters', () => {
+  it('maps Convex phrases to UI phrase summaries', () => {
+    const phrase = {
+      _id: 'phrase-1',
+      text: 'hello',
+      symbolUrl: 'https://example.com/hello.png',
+      symbolStorageId: 'storage-1',
+    } as unknown as PhraseInput;
+
+    expect(toPhraseSummary(phrase)).toEqual({
+      id: 'phrase-1',
+      text: 'hello',
+      symbolUrl: 'https://example.com/hello.png',
+      symbolStorageId: 'storage-1',
+    });
+  });
+
+  it('maps phrase, audio, and navigate tiles without loose casts in the hook', () => {
+    const phraseTile = {
+      _id: 'tile-phrase',
+      kind: 'phrase',
+      position: 0,
+      cellRow: 1,
+      cellColumn: 2,
+      tileRole: 'core',
+      wordClass: 'verb',
+      isLocked: true,
+      phrase: {
+        _id: 'phrase-1',
+        text: 'go',
+        symbolUrl: undefined,
+        symbolStorageId: undefined,
+      },
+    } as unknown as TileInput;
+    const audioTile = {
+      _id: 'tile-audio',
+      kind: 'audio',
+      position: 1,
+      audioLabel: 'Bell',
+      audioUrl: undefined,
+      audioMimeType: 'audio/webm',
+      audioDurationMs: 900,
+      audioByteSize: 1024,
+    } as unknown as TileInput;
+    const navigateTile = {
+      _id: 'tile-nav',
+      kind: 'navigate',
+      position: 2,
+      targetBoardId: 'board-target',
+      targetBoardName: null,
+    } as unknown as TileInput;
+
+    expect(toTileSummary(phraseTile)).toEqual({
+      id: 'tile-phrase',
+      kind: 'phrase',
+      position: 0,
+      cellRow: 1,
+      cellColumn: 2,
+      tileRole: 'core',
+      wordClass: 'verb',
+      isLocked: true,
+      phrase: {
+        id: 'phrase-1',
+        text: 'go',
+        symbolUrl: undefined,
+        symbolStorageId: undefined,
+      },
+    });
+    expect(toTileSummary(audioTile)).toMatchObject({
+      id: 'tile-audio',
+      kind: 'audio',
+      audioLabel: 'Bell',
+      audioUrl: null,
+    });
+    expect(toTileSummary(navigateTile)).toMatchObject({
+      id: 'tile-nav',
+      kind: 'navigate',
+      targetBoardId: 'board-target',
+      targetBoardName: null,
+    });
+  });
+
+  it('skips orphaned phrase tiles defensively', () => {
+    const orphanedTile = {
+      _id: 'tile-orphan',
+      kind: 'phrase',
+      position: 0,
+      phrase: null,
+    } as unknown as TileInput;
+
+    expect(toTileSummary(orphanedTile)).toBeNull();
+  });
+
+  it('attaches selected board phrases and tiles only to the selected board', () => {
+    const selectedBoard = {
+      _id: 'board-1',
+      name: 'Core',
+      position: 0,
+      isShared: false,
+      isOwner: true,
+      accessLevel: 'edit',
+      sharedBy: null,
+      forClientId: null,
+      forClientName: null,
+      layoutMode: undefined,
+      gridRows: undefined,
+      gridColumns: undefined,
+      layoutVersion: undefined,
+      hiddenFromPicker: false,
+    } as unknown as BoardInput;
+    const otherBoard = {
+      ...selectedBoard,
+      _id: 'board-2',
+      name: 'Other',
+    } as unknown as BoardInput;
+    const phrases = [{ id: 'phrase-1', text: 'go' }];
+    const tiles = [{
+      id: 'tile-1',
+      kind: 'phrase' as const,
+      position: 0,
+      phrase: phrases[0],
+    }];
+
+    expect(toBoardSummary(selectedBoard, 'board-1', phrases, tiles)).toMatchObject({
+      id: 'board-1',
+      layoutMode: 'free',
+      phrases,
+      tiles,
+    });
+    expect(toBoardSummary(otherBoard, 'board-1', phrases, tiles)).toMatchObject({
+      id: 'board-2',
+      phrases: [],
+      tiles: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- replace loose Convex result casts in usePhraseBoardData with typed adapter functions
- add focused adapter coverage for phrase, tile, and board summary conversion
- preserve selected-board attachment, orphaned phrase tile filtering, and default free-layout behavior

Closes #652

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/lib/hooks/usePhraseBoardData.test.ts
- pnpm --filter @sayit/web test -- --runInBand
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build