### PR TITLE
Scope import symbol cleanup to staged uploads

### DIFF
--- a/apps/web/app/components/phrases/OpenBoardImportModal.tsx
+++ b/apps/web/app/components/phrases/OpenBoardImportModal.tsx
@@ -40,6 +40,11 @@ type ConvexImportBoard = {
   >;
 };
 
+type StagedSymbolUpload = {
+  uploadSessionId: Id<'stagedSymbolUploads'>;
+  storageId: Id<'_storage'>;
+};
+
 interface OpenBoardImportModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -86,9 +91,10 @@ export default function OpenBoardImportModal({
   // never leak storage objects when the import doesn't reach the final
   // `importBoards` mutation.
   const abortRef = useRef<AbortController | null>(null);
-  const uploadedRef = useRef<Id<'_storage'>[]>([]);
+  const uploadedRef = useRef<StagedSymbolUpload[]>([]);
 
-  const generateUploadUrl = useMutation(api.symbols.generateUploadUrl);
+  const startImportSymbolUpload = useMutation(api.symbols.startImportSymbolUpload);
+  const registerImportSymbolUpload = useMutation(api.symbols.registerImportSymbolUpload);
   const cleanupOrphanSymbols = useMutation(api.symbols.cleanupOrphanSymbols);
   const importBoards = useMutation(api.openBoardImport.importBoards);
 
@@ -116,7 +122,7 @@ export default function OpenBoardImportModal({
     uploadedRef.current = [];
     if (ids.length === 0) return;
     try {
-      await cleanupOrphanSymbols({ storageIds: ids });
+      await cleanupOrphanSymbols({ uploads: ids });
     } catch {
       // Swallow — if cleanup fails we don't have a sensible recovery path
       // and the user already has bigger fish to fry.
@@ -177,9 +183,9 @@ export default function OpenBoardImportModal({
 
   // Single symbol upload. Threads the AbortSignal so handleCancel can yank
   // every in-flight fetch when the user clicks Cancel.
-  const uploadSymbol = async (blob: Blob, signal: AbortSignal): Promise<Id<'_storage'>> => {
+  const uploadSymbol = async (blob: Blob, signal: AbortSignal): Promise<StagedSymbolUpload> => {
     if (signal.aborted) throw new ImportCancelledError();
-    const uploadUrl = await generateUploadUrl();
+    const { uploadUrl, uploadSessionId } = await startImportSymbolUpload();
     if (signal.aborted) throw new ImportCancelledError();
     const result = await fetch(uploadUrl, {
       method: 'POST',
@@ -191,7 +197,8 @@ export default function OpenBoardImportModal({
       throw new Error('Could not upload an imported symbol image.');
     }
     const payload = await result.json() as { storageId: Id<'_storage'> };
-    return payload.storageId;
+    await registerImportSymbolUpload({ uploadSessionId, storageId: payload.storageId });
+    return { uploadSessionId, storageId: payload.storageId };
   };
 
   // Pure shape transform — uploads happen in handleImport's parallel pass and
@@ -282,17 +289,17 @@ export default function OpenBoardImportModal({
     setImportStage({ kind: 'uploading', uploaded: 0, total: uploadJobs.length });
 
     try {
-      const symbolIds = uploadJobs.length === 0
+      const symbolUploads = uploadJobs.length === 0
         ? []
         : await runWithConcurrency(
           uploadJobs,
           SYMBOL_UPLOAD_CONCURRENCY,
           async (job) => {
-            const id = await uploadSymbol(job.blob, controller.signal);
+            const upload = await uploadSymbol(job.blob, controller.signal);
             // Track as we go (not after Promise.all settles) so a cancel
             // mid-batch still picks up the in-flight successes for cleanup.
-            uploadedRef.current.push(id);
-            return id;
+            uploadedRef.current.push(upload);
+            return upload;
           },
           (uploaded) => setImportStage({ kind: 'uploading', uploaded, total: uploadJobs.length }),
           controller.signal
@@ -301,7 +308,7 @@ export default function OpenBoardImportModal({
       // Stitch storageIds back onto the tile payloads.
       const symbolByKey = new Map<string, Id<'_storage'>>();
       uploadJobs.forEach((job, index) => {
-        symbolByKey.set(`${job.boardIndex}:${job.tileIndex}`, symbolIds[index]);
+        symbolByKey.set(`${job.boardIndex}:${job.tileIndex}`, symbolUploads[index].storageId);
       });
 
       setImportStage({ kind: 'saving' });

--- a/apps/web/convex/openBoardImport.ts
+++ b/apps/web/convex/openBoardImport.ts
@@ -5,6 +5,10 @@ import type { Doc, Id } from './_generated/dataModel';
 import { getUserIdentity } from './users';
 import { FIXED_GRID_LAYOUT_VERSION } from './aacLayout';
 import { MAX_IMPORT_BOARDS, MAX_IMPORT_TILES } from './openBoardLimits';
+import {
+  assertStagedSymbolUploadsOwned,
+  removeClaimedSymbolUploads,
+} from './symbols';
 
 // How many boards we cascade-delete per scheduled tick. Convex mutations have
 // a soft transaction-size limit; chunking keeps each tick well below it
@@ -35,6 +39,20 @@ function validateGrid(rows: number, columns: number) {
   }
 }
 
+function importedSymbolStorageIds(
+  boards: Array<{ tiles: Array<{ kind: string; symbolStorageId?: Id<'_storage'> }> }>
+): Id<'_storage'>[] {
+  const ids: Id<'_storage'>[] = [];
+  for (const board of boards) {
+    for (const tile of board.tiles) {
+      if (tile.kind === 'phrase' && tile.symbolStorageId) {
+        ids.push(tile.symbolStorageId);
+      }
+    }
+  }
+  return ids;
+}
+
 export const importBoards = mutation({
   args: {
     packageName: v.string(),
@@ -63,6 +81,8 @@ export const importBoards = mutation({
     if (tileCount > MAX_IMPORT_TILES) {
       throw new Error(`Import package contains more than ${MAX_IMPORT_TILES} tiles`);
     }
+    const symbolStorageIds = importedSymbolStorageIds(args.boards);
+    await assertStagedSymbolUploadsOwned(ctx, identity.subject, symbolStorageIds);
 
     const seenSourceIds = new Set<string>();
     for (const board of args.boards) {
@@ -233,6 +253,8 @@ export const importBoards = mutation({
         });
       }));
     }));
+
+    await removeClaimedSymbolUploads(ctx, identity.subject, symbolStorageIds);
 
     return {
       importedBoardIds,

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -85,6 +85,15 @@ export default defineSchema({
   })
     .index('by_user_id', ['userId']),
 
+  stagedSymbolUploads: defineTable({
+    userId: v.string(),
+    createdAt: v.number(),
+    storageId: v.optional(v.id('_storage')),
+  })
+    .index('by_user_id', ['userId'])
+    .index('by_storage', ['storageId'])
+    .index('by_created_at', ['createdAt']),
+
   phraseBoardPhrases: defineTable({
     phraseId: v.id('phrases'),
     boardId: v.id('phraseBoards'),

--- a/apps/web/convex/symbols.ts
+++ b/apps/web/convex/symbols.ts
@@ -1,6 +1,10 @@
 import { v } from 'convex/values';
-import { mutation } from './_generated/server';
+import { internalMutation, mutation } from './_generated/server';
+import { internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
 import { getUserIdentity } from './users';
+
+const STAGED_UPLOAD_TTL_MS = 24 * 60 * 60 * 1000;
 
 export const generateUploadUrl = mutation({
   handler: async (ctx) => {
@@ -12,30 +16,154 @@ export const generateUploadUrl = mutation({
   },
 });
 
-// Best-effort cleanup for symbol storage objects whose owning phrases never
-// got persisted. Called by OpenBoardImportModal when a user cancels mid-
-// import or when the bulk `importBoards` mutation fails after some symbols
-// have already been uploaded — without this the storage objects leak.
-//
-// We use Promise.allSettled so a missing/already-deleted ID doesn't poison
-// the rest of the cleanup. Before deleting, verify no phrase currently
-// references the storage object; symbol IDs are sent to clients for rendering,
-// so auth alone is not enough protection here.
-export const cleanupOrphanSymbols = mutation({
-  args: { storageIds: v.array(v.id('_storage')) },
+export const startImportSymbolUpload = mutation({
+  handler: async (ctx) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    const uploadSessionId = await ctx.db.insert('stagedSymbolUploads', {
+      userId: identity.subject,
+      createdAt: Date.now(),
+    });
+
+    await ctx.scheduler.runAfter(
+      STAGED_UPLOAD_TTL_MS,
+      internal.symbols.sweepAbandonedImportSymbolUpload,
+      { uploadSessionId }
+    );
+
+    return {
+      uploadUrl: await ctx.storage.generateUploadUrl(),
+      uploadSessionId,
+    };
+  },
+});
+
+export const registerImportSymbolUpload = mutation({
+  args: {
+    uploadSessionId: v.id('stagedSymbolUploads'),
+    storageId: v.id('_storage'),
+  },
   handler: async (ctx, args) => {
     const identity = await getUserIdentity(ctx);
     if (!identity) {
       throw new Error('Unauthenticated');
     }
-    if (args.storageIds.length === 0) return;
-    await Promise.allSettled(args.storageIds.map(async (id) => {
+
+    const staged = await ctx.db.get(args.uploadSessionId);
+    if (!staged || staged.userId !== identity.subject) {
+      throw new Error('Unauthorized');
+    }
+    if (staged.storageId) {
+      throw new Error('Upload session already has a storage object');
+    }
+
+    const existingOwner = await ctx.db
+      .query('stagedSymbolUploads')
+      .withIndex('by_storage', (q) => q.eq('storageId', args.storageId))
+      .first();
+    if (existingOwner) {
+      throw new Error('Storage object is already staged');
+    }
+
+    const metadata = await ctx.storage.getMetadata(args.storageId);
+    if (!metadata) {
+      throw new Error('Uploaded symbol storage object not found');
+    }
+
+    await ctx.db.patch(args.uploadSessionId, { storageId: args.storageId });
+  },
+});
+
+// Best-effort cleanup for import symbol storage objects whose owning phrases
+// never got persisted. Cleanup is scoped to staged upload rows owned by the
+// current user so callers cannot delete arbitrary unreferenced storage IDs.
+export const cleanupOrphanSymbols = mutation({
+  args: {
+    uploads: v.array(v.object({
+      uploadSessionId: v.id('stagedSymbolUploads'),
+      storageId: v.id('_storage'),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+    if (args.uploads.length === 0) return;
+
+    await Promise.allSettled(args.uploads.map(async (upload) => {
+      const staged = await ctx.db.get(upload.uploadSessionId);
+      if (
+        !staged ||
+        staged.userId !== identity.subject ||
+        staged.storageId !== upload.storageId
+      ) {
+        return;
+      }
+
       const referencedPhrase = await ctx.db
         .query('phrases')
-        .withIndex('by_symbol_storage', (q) => q.eq('symbolStorageId', id))
+        .withIndex('by_symbol_storage', (q) => q.eq('symbolStorageId', upload.storageId))
         .first();
       if (referencedPhrase) return;
-      await ctx.storage.delete(id);
+
+      await ctx.storage.delete(upload.storageId);
+      await ctx.db.delete(staged._id);
     }));
+  },
+});
+
+export async function assertStagedSymbolUploadsOwned(
+  ctx: { db: import('./_generated/server').MutationCtx['db'] },
+  userId: string,
+  storageIds: Id<'_storage'>[]
+) {
+  for (const storageId of storageIds) {
+    const staged = await ctx.db
+      .query('stagedSymbolUploads')
+      .withIndex('by_storage', (q) => q.eq('storageId', storageId))
+      .first();
+    if (!staged || staged.userId !== userId) {
+      throw new Error('Imported symbol upload is not owned by the current user');
+    }
+  }
+}
+
+export async function removeClaimedSymbolUploads(
+  ctx: { db: import('./_generated/server').MutationCtx['db'] },
+  userId: string,
+  storageIds: Id<'_storage'>[]
+) {
+  await Promise.all(storageIds.map(async (storageId) => {
+    const staged = await ctx.db
+      .query('stagedSymbolUploads')
+      .withIndex('by_storage', (q) => q.eq('storageId', storageId))
+      .first();
+    if (staged && staged.userId === userId) {
+      await ctx.db.delete(staged._id);
+    }
+  }));
+}
+
+export const sweepAbandonedImportSymbolUpload = internalMutation({
+  args: { uploadSessionId: v.id('stagedSymbolUploads') },
+  handler: async (ctx, args) => {
+    const staged = await ctx.db.get(args.uploadSessionId);
+    if (!staged) return;
+
+    if (staged.storageId) {
+      const referencedPhrase = await ctx.db
+        .query('phrases')
+        .withIndex('by_symbol_storage', (q) => q.eq('symbolStorageId', staged.storageId))
+        .first();
+      if (!referencedPhrase) {
+        await ctx.storage.delete(staged.storageId);
+      }
+    }
+
+    await ctx.db.delete(staged._id);
   },
 });

--- a/apps/web/tests/convex/openBoardImport.test.ts
+++ b/apps/web/tests/convex/openBoardImport.test.ts
@@ -199,18 +199,83 @@ describe('getPhraseBoards filters pendingDelete', () => {
 });
 
 describe('symbol import cleanup safety', () => {
-  test('skips storage IDs already referenced by a phrase', () => {
-    const requestedCleanupIds = ['live-symbol', 'orphan-symbol'];
+  test('cleanup only deletes staged uploads owned by the current user', () => {
+    const requestedCleanup = [
+      { uploadSessionId: 'session-owned', storageId: 'owned-orphan' },
+      { uploadSessionId: 'session-other-user', storageId: 'other-user-orphan' },
+      { uploadSessionId: 'session-unregistered', storageId: 'unregistered-orphan' },
+    ];
+    const stagedUploads = [
+      { _id: 'session-owned', userId: 'user_1', storageId: 'owned-orphan' },
+      { _id: 'session-other-user', userId: 'user_2', storageId: 'other-user-orphan' },
+    ];
+
+    const deletable = requestedCleanup.filter((upload) => {
+      const staged = stagedUploads.find((row) => row._id === upload.uploadSessionId);
+      return staged?.userId === 'user_1' && staged.storageId === upload.storageId;
+    });
+
+    expect(deletable).toEqual([
+      { uploadSessionId: 'session-owned', storageId: 'owned-orphan' },
+    ]);
+  });
+
+  test('cleanup skips staged storage IDs already referenced by a phrase', () => {
+    const requestedCleanup = [
+      { uploadSessionId: 'session-live', storageId: 'live-symbol' },
+      { uploadSessionId: 'session-orphan', storageId: 'orphan-symbol' },
+    ];
+    const stagedUploads = [
+      { _id: 'session-live', userId: 'user_1', storageId: 'live-symbol' },
+      { _id: 'session-orphan', userId: 'user_1', storageId: 'orphan-symbol' },
+    ];
     const phrases = [
       { _id: 'phrase-1', symbolStorageId: 'live-symbol' },
     ];
 
-    // Mirrors symbols.cleanupOrphanSymbols: delete only IDs that are not
-    // currently referenced by any phrase row.
-    const deleted = requestedCleanupIds.filter((id) =>
-      !phrases.some((phrase) => phrase.symbolStorageId === id)
-    );
+    const deleted = requestedCleanup
+      .filter((upload) => {
+        const staged = stagedUploads.find((row) => row._id === upload.uploadSessionId);
+        return staged?.userId === 'user_1' && staged.storageId === upload.storageId;
+      })
+      .filter((upload) =>
+        !phrases.some((phrase) => phrase.symbolStorageId === upload.storageId)
+      )
+      .map((upload) => upload.storageId);
 
     expect(deleted).toEqual(['orphan-symbol']);
+  });
+
+  test('successful import requires every symbol storage ID to be staged by the importer', () => {
+    const symbolStorageIds = ['owned-symbol', 'foreign-symbol'];
+    const stagedUploads = [
+      { userId: 'user_1', storageId: 'owned-symbol' },
+      { userId: 'user_2', storageId: 'foreign-symbol' },
+    ];
+
+    expect(() => {
+      for (const storageId of symbolStorageIds) {
+        const staged = stagedUploads.find((row) => row.storageId === storageId);
+        if (!staged || staged.userId !== 'user_1') {
+          throw new Error('Imported symbol upload is not owned by the current user');
+        }
+      }
+    }).toThrow(/not owned/);
+  });
+
+  test('successful import removes claimed staging rows instead of leaving cleanup authority behind', () => {
+    const importedStorageIds = ['owned-symbol'];
+    const stagedUploads = [
+      { _id: 'session-owned', userId: 'user_1', storageId: 'owned-symbol' },
+      { _id: 'session-other', userId: 'user_1', storageId: 'other-symbol' },
+    ];
+
+    const remaining = stagedUploads.filter((row) =>
+      !(row.userId === 'user_1' && importedStorageIds.includes(row.storageId))
+    );
+
+    expect(remaining).toEqual([
+      { _id: 'session-other', userId: 'user_1', storageId: 'other-symbol' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add staged import symbol upload rows with a scheduled abandoned-upload sweep
- require Open Board imports to use symbol storage IDs staged by the current user
- scope failed/cancelled import cleanup to the caller's staged uploads and remove staging rows after successful imports

Closes #658

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/convex/openBoardImport.test.ts
- pnpm --filter @sayit/web test -- --runInBand
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a session-based symbol upload flow with automatic cleanup of abandoned uploads after a timeout period.

* **Bug Fixes**
  * Enhanced validation to ensure users can only claim their own uploaded symbols during import.
  * Added ownership verification for all imported symbols before finalizing board imports.

* **Tests**
  * Expanded test coverage for upload ownership verification and orphaned upload cleanup safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->