### PR TITLE
Share Convex board tile hydration

### DIFF
--- a/apps/web/convex/boardTileHydration.ts
+++ b/apps/web/convex/boardTileHydration.ts
@@ -1,0 +1,184 @@
+import type { Doc, Id } from './_generated/dataModel';
+import type { QueryCtx } from './_generated/server';
+
+export type LegacyPhraseLink = {
+  _id: Id<'boardTiles'>;
+  phraseId: Id<'phrases'>;
+  boardId: Id<'phraseBoards'>;
+  position: number;
+  phrase: Doc<'phrases'> | null;
+};
+
+type TileLayoutMetadata = {
+  cellRow?: number;
+  cellColumn?: number;
+  cellRowSpan?: number;
+  cellColumnSpan?: number;
+  tileRole?: Doc<'boardTiles'>['tileRole'];
+  wordClass?: Doc<'boardTiles'>['wordClass'];
+  isLocked?: boolean;
+};
+
+export type HydratedBoardTile =
+  | ({
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'phrase';
+      phrase: Doc<'phrases'> | null;
+    } & TileLayoutMetadata)
+  | ({
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'navigate';
+      targetBoardId: Id<'phraseBoards'>;
+      targetBoardName: string | null;
+    } & TileLayoutMetadata)
+  | ({
+      _id: Id<'boardTiles'>;
+      boardId: Id<'phraseBoards'>;
+      position: number;
+      kind: 'audio';
+      audioLabel: string;
+      audioStorageId: Id<'_storage'> | null;
+      audioUrl: string | null;
+      audioMimeType: string;
+      audioDurationMs: number;
+      audioByteSize: number;
+    } & TileLayoutMetadata);
+
+type BoardTileHydrationLoaders = {
+  getPhrase?: (phraseId: Id<'phrases'>) => Promise<Doc<'phrases'> | null>;
+  getBoard?: (boardId: Id<'phraseBoards'>) => Promise<Doc<'phraseBoards'> | null>;
+};
+
+function tileLayoutMetadata(row: Doc<'boardTiles'>): TileLayoutMetadata {
+  return {
+    cellRow: row.cellRow,
+    cellColumn: row.cellColumn,
+    cellRowSpan: row.cellRowSpan,
+    cellColumnSpan: row.cellColumnSpan,
+    tileRole: row.tileRole,
+    wordClass: row.wordClass,
+    isLocked: row.isLocked,
+  };
+}
+
+export function viewerCanReadBoard(
+  board: Doc<'phraseBoards'> | null,
+  viewerSubject: string
+): boolean {
+  if (!board) return false;
+  return board.userId === viewerSubject || board.forClientId === viewerSubject;
+}
+
+export async function loadHydratedBoardTiles(
+  ctx: QueryCtx,
+  boardId: Id<'phraseBoards'>,
+  viewerSubject: string,
+  loaders: BoardTileHydrationLoaders = {}
+): Promise<{ tiles: HydratedBoardTile[]; phraseLinks: LegacyPhraseLink[] }> {
+  const getPhrase = loaders.getPhrase ?? ((phraseId: Id<'phrases'>) => ctx.db.get(phraseId));
+  const getBoard = loaders.getBoard ?? ((targetBoardId: Id<'phraseBoards'>) => ctx.db.get(targetBoardId));
+
+  const rows = await ctx.db
+    .query('boardTiles')
+    .withIndex('by_board', (q) => q.eq('boardId', boardId))
+    .collect();
+
+  const sorted = [...rows].sort((a, b) => a.position - b.position);
+
+  const tiles: HydratedBoardTile[] = [];
+  const phraseLinks: LegacyPhraseLink[] = [];
+
+  for (const row of sorted) {
+    if (row.kind === 'phrase') {
+      const phrase = row.phraseId ? await getPhrase(row.phraseId) : null;
+      tiles.push({
+        _id: row._id,
+        boardId: row.boardId,
+        position: row.position,
+        kind: 'phrase',
+        phrase,
+        ...tileLayoutMetadata(row),
+      });
+      if (row.phraseId) {
+        phraseLinks.push({
+          _id: row._id,
+          phraseId: row.phraseId,
+          boardId: row.boardId,
+          position: row.position,
+          phrase,
+        });
+      }
+      continue;
+    }
+
+    if (row.kind === 'audio') {
+      if (
+        !row.audioLabel ||
+        !row.audioStorageId ||
+        !row.audioMimeType ||
+        typeof row.audioDurationMs !== 'number' ||
+        typeof row.audioByteSize !== 'number'
+      ) {
+        tiles.push({
+          _id: row._id,
+          boardId: row.boardId,
+          position: row.position,
+          kind: 'audio',
+          audioLabel: row.audioLabel ?? 'Audio tile',
+          audioStorageId: null,
+          audioUrl: null,
+          audioMimeType: row.audioMimeType ?? '',
+          audioDurationMs: row.audioDurationMs ?? 0,
+          audioByteSize: row.audioByteSize ?? 0,
+          ...tileLayoutMetadata(row),
+        });
+        continue;
+      }
+
+      tiles.push({
+        _id: row._id,
+        boardId: row.boardId,
+        position: row.position,
+        kind: 'audio',
+        audioLabel: row.audioLabel,
+        audioStorageId: row.audioStorageId,
+        audioUrl: await ctx.storage.getUrl(row.audioStorageId),
+        audioMimeType: row.audioMimeType,
+        audioDurationMs: row.audioDurationMs,
+        audioByteSize: row.audioByteSize,
+        ...tileLayoutMetadata(row),
+      });
+      continue;
+    }
+
+    if (!row.targetBoardId) {
+      tiles.push({
+        _id: row._id,
+        boardId: row.boardId,
+        position: row.position,
+        kind: 'navigate',
+        targetBoardId: row.boardId,
+        targetBoardName: null,
+        ...tileLayoutMetadata(row),
+      });
+      continue;
+    }
+
+    const target = await getBoard(row.targetBoardId);
+    tiles.push({
+      _id: row._id,
+      boardId: row.boardId,
+      position: row.position,
+      kind: 'navigate',
+      targetBoardId: row.targetBoardId,
+      targetBoardName: viewerCanReadBoard(target, viewerSubject) ? (target?.name ?? null) : null,
+      ...tileLayoutMetadata(row),
+    });
+  }
+
+  return { tiles, phraseLinks };
+}

--- a/apps/web/convex/boardTiles.ts
+++ b/apps/web/convex/boardTiles.ts
@@ -1,6 +1,6 @@
 import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
-import type { Doc, Id } from './_generated/dataModel';
+import type { Doc } from './_generated/dataModel';
 import type { MutationCtx } from './_generated/server';
 import { getUserIdentity } from './users';
 import { getBoardAccess } from './boardAccess';
@@ -16,6 +16,10 @@ import {
   normaliseFixedGridSpan,
   tileFixedGridRect,
 } from './aacLayout';
+import {
+  loadHydratedBoardTiles,
+  type HydratedBoardTile,
+} from './boardTileHydration';
 
 const tileRoleValidator = v.union(
   v.literal('core'),
@@ -88,57 +92,7 @@ async function assertFixedGridCellAvailable(
 // Query: list tiles on a board (polymorphic, hydrated)
 // ---------------------------------------------------------------------------
 
-type TileLayoutMetadata = {
-  cellRow?: number;
-  cellColumn?: number;
-  cellRowSpan?: number;
-  cellColumnSpan?: number;
-  tileRole?: Doc<'boardTiles'>['tileRole'];
-  wordClass?: Doc<'boardTiles'>['wordClass'];
-  isLocked?: boolean;
-};
-
-function tileLayoutMetadata(row: Doc<'boardTiles'>): TileLayoutMetadata {
-  return {
-    cellRow: row.cellRow,
-    cellColumn: row.cellColumn,
-    cellRowSpan: row.cellRowSpan,
-    cellColumnSpan: row.cellColumnSpan,
-    tileRole: row.tileRole,
-    wordClass: row.wordClass,
-    isLocked: row.isLocked,
-  };
-}
-
-export type ListedBoardTile =
-  | ({
-      _id: Id<'boardTiles'>;
-      boardId: Id<'phraseBoards'>;
-      position: number;
-      kind: 'phrase';
-      phrase: Doc<'phrases'> | null;
-    } & TileLayoutMetadata)
-  | ({
-      _id: Id<'boardTiles'>;
-      boardId: Id<'phraseBoards'>;
-      position: number;
-      kind: 'navigate';
-      targetBoardId: Id<'phraseBoards'>;
-      targetBoardName: string | null;
-    } & TileLayoutMetadata)
-  | ({
-      _id: Id<'boardTiles'>;
-      boardId: Id<'phraseBoards'>;
-      position: number;
-      kind: 'audio';
-      audioLabel: string;
-      /** null when the underlying storage object is missing/unrecoverable. */
-      audioStorageId: Id<'_storage'> | null;
-      audioUrl: string | null;
-      audioMimeType: string;
-      audioDurationMs: number;
-      audioByteSize: number;
-    } & TileLayoutMetadata);
+export type ListedBoardTile = HydratedBoardTile;
 
 export const listByBoard = query({
   args: { boardId: v.id('phraseBoards') },
@@ -149,103 +103,8 @@ export const listByBoard = query({
     const access = await getBoardAccess(ctx, args.boardId, identity.subject);
     if (!access || !access.canRead) return [];
 
-    const rows = await ctx.db
-      .query('boardTiles')
-      .withIndex('by_board', (q) => q.eq('boardId', args.boardId))
-      .collect();
-
-    const sorted = [...rows].sort((a, b) => a.position - b.position);
-
-    const hydrated: ListedBoardTile[] = await Promise.all(
-      sorted.map(async (row): Promise<ListedBoardTile> => {
-        if (row.kind === 'phrase') {
-          const phrase = row.phraseId ? await ctx.db.get(row.phraseId) : null;
-          return {
-            _id: row._id,
-            boardId: row.boardId,
-            position: row.position,
-            kind: 'phrase',
-            phrase: phrase ?? null,
-            ...tileLayoutMetadata(row),
-          };
-        }
-        if (row.kind === 'audio') {
-          // Defensive: a row could be missing one or more audio fields if it
-          // was written by an older client or partially hydrated. Surface a
-          // broken-state tile (audioUrl=null, audioStorageId=null) — the
-          // renderer keys on audioUrl===null and shows the disabled affordance.
-          if (
-            !row.audioLabel ||
-            !row.audioStorageId ||
-            !row.audioMimeType ||
-            typeof row.audioDurationMs !== 'number' ||
-            typeof row.audioByteSize !== 'number'
-          ) {
-            return {
-              _id: row._id,
-              boardId: row.boardId,
-              position: row.position,
-              kind: 'audio',
-              audioLabel: row.audioLabel ?? 'Audio tile',
-              audioStorageId: null,
-              audioUrl: null,
-              audioMimeType: row.audioMimeType ?? '',
-              audioDurationMs: row.audioDurationMs ?? 0,
-              audioByteSize: row.audioByteSize ?? 0,
-              ...tileLayoutMetadata(row),
-            };
-          }
-
-          const audioUrl = await ctx.storage.getUrl(row.audioStorageId);
-          return {
-            _id: row._id,
-            boardId: row.boardId,
-            position: row.position,
-            kind: 'audio',
-            audioLabel: row.audioLabel,
-            audioStorageId: row.audioStorageId,
-            audioUrl,
-            audioMimeType: row.audioMimeType,
-            audioDurationMs: row.audioDurationMs,
-            audioByteSize: row.audioByteSize,
-            ...tileLayoutMetadata(row),
-          };
-        }
-
-        // kind === 'navigate'
-        const targetBoardId = row.targetBoardId;
-        if (!targetBoardId) {
-          // Defensive: shouldn't happen given mutation guards, but treat as broken.
-          return {
-            _id: row._id,
-            boardId: row.boardId,
-            position: row.position,
-            kind: 'navigate',
-            targetBoardId: row.boardId, // self-ref to satisfy id type; renderer treats null name as broken
-            targetBoardName: null,
-            ...tileLayoutMetadata(row),
-          };
-        }
-        const target = await ctx.db.get(targetBoardId);
-        // Only expose the name when the viewer can actually read the target.
-        // Otherwise return null (renderer shows broken state) so we don't leak
-        // names of boards the viewer has no access to.
-        const canRead = target
-          ? target.userId === identity.subject || target.forClientId === identity.subject
-          : false;
-        return {
-          _id: row._id,
-          boardId: row.boardId,
-          position: row.position,
-          kind: 'navigate',
-          targetBoardId,
-          targetBoardName: canRead ? (target?.name ?? null) : null,
-          ...tileLayoutMetadata(row),
-        };
-      })
-    );
-
-    return hydrated;
+    const { tiles } = await loadHydratedBoardTiles(ctx, args.boardId, identity.subject);
+    return tiles;
   },
 });
 

--- a/apps/web/convex/phraseBoards.ts
+++ b/apps/web/convex/phraseBoards.ts
@@ -1,212 +1,10 @@
 import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import type { Doc, Id } from './_generated/dataModel';
-import type { QueryCtx } from './_generated/server';
 import { getUserIdentity } from './users';
 import { nextFixedGridCell } from './aacLayout';
+import { loadHydratedBoardTiles } from './boardTileHydration';
 
-// ---------------------------------------------------------------------------
-// Shared loaders for tile data (read from boardTiles).
-//
-// The `phrase_board_phrases` field on board query results is preserved for
-// backward compatibility — it returns *only phrase-kind tiles* in the legacy
-// shape. New consumers should read the polymorphic `tiles` field instead.
-// ---------------------------------------------------------------------------
-
-type LegacyPhraseLink = {
-  _id: Id<'boardTiles'>;
-  phraseId: Id<'phrases'>;
-  boardId: Id<'phraseBoards'>;
-  position: number;
-  phrase: Doc<'phrases'> | null;
-};
-
-type PolymorphicBoardTile =
-  | {
-      _id: Id<'boardTiles'>;
-      boardId: Id<'phraseBoards'>;
-      position: number;
-      kind: 'phrase';
-      phrase: Doc<'phrases'> | null;
-      cellRow?: number;
-      cellColumn?: number;
-      cellRowSpan?: number;
-      cellColumnSpan?: number;
-      tileRole?: Doc<'boardTiles'>['tileRole'];
-      wordClass?: Doc<'boardTiles'>['wordClass'];
-      isLocked?: boolean;
-    }
-  | {
-      _id: Id<'boardTiles'>;
-      boardId: Id<'phraseBoards'>;
-      position: number;
-      kind: 'navigate';
-      targetBoardId: Id<'phraseBoards'>;
-      targetBoardName: string | null;
-      cellRow?: number;
-      cellColumn?: number;
-      cellRowSpan?: number;
-      cellColumnSpan?: number;
-      tileRole?: Doc<'boardTiles'>['tileRole'];
-      wordClass?: Doc<'boardTiles'>['wordClass'];
-      isLocked?: boolean;
-    }
-  | {
-      _id: Id<'boardTiles'>;
-      boardId: Id<'phraseBoards'>;
-      position: number;
-      kind: 'audio';
-      audioLabel: string;
-      /** null when the underlying storage object is missing/unrecoverable. */
-      audioStorageId: Id<'_storage'> | null;
-      audioUrl: string | null;
-      audioMimeType: string;
-      audioDurationMs: number;
-      audioByteSize: number;
-      cellRow?: number;
-      cellColumn?: number;
-      cellRowSpan?: number;
-      cellColumnSpan?: number;
-      tileRole?: Doc<'boardTiles'>['tileRole'];
-      wordClass?: Doc<'boardTiles'>['wordClass'];
-      isLocked?: boolean;
-    };
-
-function tileLayoutMetadata(row: Doc<'boardTiles'>) {
-  return {
-    cellRow: row.cellRow,
-    cellColumn: row.cellColumn,
-    cellRowSpan: row.cellRowSpan,
-    cellColumnSpan: row.cellColumnSpan,
-    tileRole: row.tileRole,
-    wordClass: row.wordClass,
-    isLocked: row.isLocked,
-  };
-}
-
-function viewerCanReadBoard(
-  board: Doc<'phraseBoards'> | null,
-  viewerSubject: string
-): boolean {
-  if (!board) return false;
-  return board.userId === viewerSubject || board.forClientId === viewerSubject;
-}
-
-async function loadHydratedBoardTiles(
-  ctx: QueryCtx,
-  boardId: Id<'phraseBoards'>,
-  viewerSubject: string,
-  getCachedPhrase: (phraseId: Id<'phrases'>) => Promise<Doc<'phrases'> | null>,
-  getCachedBoard: (boardId: Id<'phraseBoards'>) => Promise<Doc<'phraseBoards'> | null>
-): Promise<{ tiles: PolymorphicBoardTile[]; phraseLinks: LegacyPhraseLink[] }> {
-  const rows = await ctx.db
-    .query('boardTiles')
-    .withIndex('by_board', (q) => q.eq('boardId', boardId))
-    .collect();
-
-  const sorted = [...rows].sort((a, b) => a.position - b.position);
-
-  const tiles: PolymorphicBoardTile[] = [];
-  const phraseLinks: LegacyPhraseLink[] = [];
-
-  for (const row of sorted) {
-    if (row.kind === 'phrase') {
-      const phrase = row.phraseId ? await getCachedPhrase(row.phraseId) : null;
-      tiles.push({
-        _id: row._id,
-        boardId: row.boardId,
-        position: row.position,
-        kind: 'phrase',
-        phrase,
-        ...tileLayoutMetadata(row),
-      });
-      if (row.phraseId) {
-        phraseLinks.push({
-          _id: row._id,
-          phraseId: row.phraseId,
-          boardId: row.boardId,
-          position: row.position,
-          phrase,
-        });
-      }
-      continue;
-    }
-
-    if (row.kind === 'audio') {
-      // Defensive: surface a broken-state tile if the row is missing one or
-      // more required audio fields. Renderer keys on audioUrl===null.
-      if (
-        !row.audioLabel ||
-        !row.audioStorageId ||
-        !row.audioMimeType ||
-        typeof row.audioDurationMs !== 'number' ||
-        typeof row.audioByteSize !== 'number'
-      ) {
-        tiles.push({
-          _id: row._id,
-          boardId: row.boardId,
-          position: row.position,
-          kind: 'audio',
-          audioLabel: row.audioLabel ?? 'Audio tile',
-          audioStorageId: null,
-          audioUrl: null,
-          audioMimeType: row.audioMimeType ?? '',
-          audioDurationMs: row.audioDurationMs ?? 0,
-          audioByteSize: row.audioByteSize ?? 0,
-          ...tileLayoutMetadata(row),
-        });
-        continue;
-      }
-
-      tiles.push({
-        _id: row._id,
-        boardId: row.boardId,
-        position: row.position,
-        kind: 'audio',
-        audioLabel: row.audioLabel,
-        audioStorageId: row.audioStorageId,
-        audioUrl: await ctx.storage.getUrl(row.audioStorageId),
-        audioMimeType: row.audioMimeType,
-        audioDurationMs: row.audioDurationMs,
-        audioByteSize: row.audioByteSize,
-        ...tileLayoutMetadata(row),
-      });
-      continue;
-    }
-
-    // kind === 'navigate'
-    if (!row.targetBoardId) {
-      // Defensive: shouldn't happen, but emit a broken-state tile if it does.
-      tiles.push({
-        _id: row._id,
-        boardId: row.boardId,
-        position: row.position,
-        kind: 'navigate',
-        targetBoardId: row.boardId,
-        targetBoardName: null,
-        ...tileLayoutMetadata(row),
-      });
-      continue;
-    }
-    const target = await getCachedBoard(row.targetBoardId);
-    // Only expose the target name when the viewer can actually read the
-    // target board. Otherwise fall back to the broken-state shape so we
-    // don't leak names of boards the viewer has no access to (e.g. a
-    // caregiver's private board referenced from a client-shared board).
-    const canRead = viewerCanReadBoard(target, viewerSubject);
-    tiles.push({
-      _id: row._id,
-      boardId: row.boardId,
-      position: row.position,
-      kind: 'navigate',
-      targetBoardId: row.targetBoardId,
-      targetBoardName: canRead ? (target?.name ?? null) : null,
-      ...tileLayoutMetadata(row),
-    });
-  }
-
-  return { tiles, phraseLinks };
-}
 
 // Query: Get all phrase boards for current user (owned + assigned to them)
 export const getPhraseBoards = query({
@@ -273,7 +71,10 @@ export const getPhraseBoards = query({
     const ownedBoardsWithInfo = await Promise.all(
       ownedBoards.map(async (board) => {
         const { tiles, phraseLinks } = await loadHydratedBoardTiles(
-          ctx, board._id, identity.subject, getCachedPhrase, getCachedBoard
+          ctx,
+          board._id,
+          identity.subject,
+          { getPhrase: getCachedPhrase, getBoard: getCachedBoard }
         );
 
         // Get client name if this board is for a client
@@ -300,7 +101,10 @@ export const getPhraseBoards = query({
     const assignedBoardsWithInfo = await Promise.all(
       assignedBoards.map(async (board) => {
         const { tiles, phraseLinks } = await loadHydratedBoardTiles(
-          ctx, board._id, identity.subject, getCachedPhrase, getCachedBoard
+          ctx,
+          board._id,
+          identity.subject,
+          { getPhrase: getCachedPhrase, getBoard: getCachedBoard }
         );
 
         // Get caregiver name
@@ -385,7 +189,10 @@ export const getPhraseBoard = query({
     }
 
     const { tiles, phraseLinks } = await loadHydratedBoardTiles(
-      ctx, args.id, identity.subject, getCachedPhrase, getCachedBoard
+      ctx,
+      args.id,
+      identity.subject,
+      { getPhrase: getCachedPhrase, getBoard: getCachedBoard }
     );
 
     // Get caregiver name for assigned clients

--- a/apps/web/tests/convex/boardTileHydration.test.ts
+++ b/apps/web/tests/convex/boardTileHydration.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import {
+  loadHydratedBoardTiles,
+  viewerCanReadBoard,
+} from '@/convex/boardTileHydration';
+
+function createCtx(rows: unknown[]) {
+  return {
+    db: {
+      query: jest.fn().mockReturnValue({
+        withIndex: jest.fn().mockReturnValue({
+          collect: jest.fn().mockResolvedValue(rows),
+        }),
+      }),
+    },
+    storage: {
+      getUrl: jest.fn().mockResolvedValue('https://files.example/audio.webm'),
+    },
+  };
+}
+
+describe('boardTileHydration', () => {
+  test('hydrates broken audio tiles into disabled audio state', async () => {
+    const ctx = createCtx([
+      {
+        _id: 'tile-audio',
+        boardId: 'board-1',
+        position: 0,
+        kind: 'audio',
+        audioLabel: undefined,
+        audioStorageId: undefined,
+        audioMimeType: undefined,
+        audioDurationMs: undefined,
+        audioByteSize: undefined,
+      },
+    ]);
+
+    const { tiles } = await loadHydratedBoardTiles(ctx as never, 'board-1' as never, 'user-1');
+
+    expect(tiles).toEqual([
+      expect.objectContaining({
+        _id: 'tile-audio',
+        kind: 'audio',
+        audioLabel: 'Audio tile',
+        audioStorageId: null,
+        audioUrl: null,
+        audioMimeType: '',
+        audioDurationMs: 0,
+        audioByteSize: 0,
+      }),
+    ]);
+    expect(ctx.storage.getUrl).not.toHaveBeenCalled();
+  });
+
+  test('hydrates complete audio tiles with storage URL', async () => {
+    const ctx = createCtx([
+      {
+        _id: 'tile-audio',
+        boardId: 'board-1',
+        position: 0,
+        kind: 'audio',
+        audioLabel: 'Greeting',
+        audioStorageId: 'storage-1',
+        audioMimeType: 'audio/webm',
+        audioDurationMs: 1200,
+        audioByteSize: 2048,
+      },
+    ]);
+
+    const { tiles } = await loadHydratedBoardTiles(ctx as never, 'board-1' as never, 'user-1');
+
+    expect(tiles[0]).toMatchObject({
+      kind: 'audio',
+      audioLabel: 'Greeting',
+      audioUrl: 'https://files.example/audio.webm',
+    });
+    expect(ctx.storage.getUrl).toHaveBeenCalledWith('storage-1');
+  });
+
+  test('does not expose navigate target names the viewer cannot read', async () => {
+    const ctx = createCtx([
+      {
+        _id: 'tile-nav',
+        boardId: 'board-1',
+        position: 0,
+        kind: 'navigate',
+        targetBoardId: 'private-board',
+      },
+    ]);
+
+    const { tiles } = await loadHydratedBoardTiles(
+      ctx as never,
+      'board-1' as never,
+      'viewer-1',
+      {
+        getBoard: async () => ({
+          _id: 'private-board',
+          userId: 'owner-1',
+          name: 'Private',
+          position: 0,
+        }) as never,
+      }
+    );
+
+    expect(tiles[0]).toMatchObject({
+      kind: 'navigate',
+      targetBoardId: 'private-board',
+      targetBoardName: null,
+    });
+  });
+
+  test('exposes navigate target names when the viewer can read the board', async () => {
+    expect(viewerCanReadBoard({
+      _id: 'target-board',
+      userId: 'owner-1',
+      forClientId: 'viewer-1',
+      name: 'Shared',
+      position: 0,
+    } as never, 'viewer-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared Convex board tile hydration into boardTileHydration.ts
- use the shared loader from phraseBoards queries and boardTiles.listByBoard
- preserve legacy phrase_board_phrases output and navigate target-name access checks
- add focused helper tests for broken audio, audio URLs, and navigate target visibility

Closes #651

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/convex/boardTileHydration.test.ts tests/convex/boardTiles.test.ts tests/convex/phraseBoards.test.ts
- pnpm --filter @sayit/web test -- --runInBand
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build