### PR TITLE
Share cloud TTS audio lifecycle

### DIFF
--- a/apps/web/lib/azure-tts.ts
+++ b/apps/web/lib/azure-tts.ts
@@ -1,5 +1,6 @@
 import { TextToSpeech as WebSpeechTTS } from './tts';
 import { BaseTTSCallbacks } from './tts-types';
+import { CloudTTSLifecycle } from './cloud-tts-lifecycle';
 
 export interface AzureVoice {
   voice_id: string;
@@ -18,14 +19,11 @@ export interface AzureVoice {
 export class AzureTTS {
   private static instance: AzureTTS;
   private voices: AzureVoice[] = [];
-  private audio: HTMLAudioElement | null = null;
-  private isSpeaking: boolean = false;
   private isAvailableFlag: boolean = false;
   private voicesLoaded: boolean = false;
   private loadingVoices: Promise<void> | null = null;
-  private currentSessionId: number = 0;
-  private abortController: AbortController | null = null;
   private fallbackTTS: WebSpeechTTS;
+  private lifecycle = new CloudTTSLifecycle();
 
   private callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: AzureVoice[]) => void } = {};
 
@@ -96,13 +94,7 @@ export class AzureTTS {
   public async speak(text: string, options?: {
     voiceId?: string;
   }) {
-    this.stop();
-
-    this.currentSessionId++;
-    const sessionId = this.currentSessionId;
-    const isSessionActive = () => sessionId === this.currentSessionId;
-
-    this.abortController = new AbortController();
+    const session = this.lifecycle.beginSession(this.callbacks);
 
     // Load voices if needed
     if (!this.isAvailableFlag) {
@@ -110,7 +102,7 @@ export class AzureTTS {
         await this.loadVoices();
       }
 
-      if (!isSessionActive()) return;
+      if (!session.isActive()) return;
 
       if (!this.isAvailableFlag) {
         console.warn('Azure TTS is not available, falling back to browser TTS');
@@ -127,11 +119,10 @@ export class AzureTTS {
     }
 
     try {
-      this.callbacks.onStart?.();
-      this.isSpeaking = true;
+      this.lifecycle.markStarted(this.callbacks);
 
-      if (!isSessionActive()) {
-        this.isSpeaking = false;
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
         return;
       }
 
@@ -139,11 +130,11 @@ export class AzureTTS {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text, voiceId }),
-        signal: this.abortController.signal,
+        signal: session.signal,
       });
 
-      if (!isSessionActive()) {
-        this.isSpeaking = false;
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
         return;
       }
 
@@ -153,40 +144,16 @@ export class AzureTTS {
 
       const blob = await response.blob();
 
-      if (!isSessionActive()) {
-        this.isSpeaking = false;
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
         return;
       }
 
-      const audioUrl = URL.createObjectURL(blob);
-      this.audio = new Audio(audioUrl);
-
-      // Call play() immediately (before any await) to stay within the user gesture window
-      const playPromise = this.audio.play();
-
-      this.audio.onended = () => {
-        if (!isSessionActive()) return;
-        this.isSpeaking = false;
-        this.callbacks.onEnd?.();
-        URL.revokeObjectURL(audioUrl);
-      };
-
-      this.audio.onerror = () => {
-        if (!isSessionActive()) return;
-        this.isSpeaking = false;
-        const mediaError = this.audio?.error;
-        const message = mediaError
-          ? `Audio playback error (code ${mediaError.code}): ${mediaError.message}`
-          : 'Audio playback error';
-        this.callbacks.onError?.(new Error(message));
-        URL.revokeObjectURL(audioUrl);
-      };
-
-      await playPromise;
+      await this.lifecycle.playBlob(blob, this.callbacks, session.isActive);
     } catch (error) {
-      this.isSpeaking = false;
+      this.lifecycle.markInactive();
 
-      if (!isSessionActive()) return;
+      if (!session.isActive()) return;
 
       const err = error as Error & { name?: string };
       if (err?.name === 'AbortError') return;
@@ -198,51 +165,15 @@ export class AzureTTS {
   }
 
   public stop() {
-    this.currentSessionId++;
-
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
-    }
-
-    if (this.audio) {
-      this.audio.onended = null;
-      this.audio.onerror = null;
-      this.audio.pause();
-
-      const audioToClean = this.audio;
-      setTimeout(() => {
-        const audioSrc = audioToClean.src;
-        audioToClean.src = '';
-        if (audioSrc && audioSrc.startsWith('blob:')) {
-          URL.revokeObjectURL(audioSrc);
-        }
-      }, 100);
-
-      this.audio = null;
-    }
-
-    const wasSpeaking = this.isSpeaking;
-    this.isSpeaking = false;
-
-    if (wasSpeaking) {
-      this.callbacks.onEnd?.();
-    }
+    this.lifecycle.stop(this.callbacks);
   }
 
   public pause() {
-    if (this.audio) {
-      this.audio.pause();
-    }
+    this.lifecycle.pause();
   }
 
   public resume() {
-    if (this.audio) {
-      this.audio.play().catch(error => {
-        console.error('Error resuming Azure audio:', error);
-        this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
-      });
-    }
+    this.lifecycle.resume(this.callbacks, 'Error resuming Azure audio:');
   }
 
   public isAvailable(): boolean {

--- a/apps/web/lib/cloud-tts-lifecycle.ts
+++ b/apps/web/lib/cloud-tts-lifecycle.ts
@@ -1,0 +1,116 @@
+import type { BaseTTSCallbacks } from './tts-types';
+
+type ActiveSession = {
+  signal: AbortSignal;
+  isActive: () => boolean;
+};
+
+export class CloudTTSLifecycle {
+  private audio: HTMLAudioElement | null = null;
+  private abortController: AbortController | null = null;
+  private currentSessionId = 0;
+  private isSpeaking = false;
+
+  public beginSession(callbacks: BaseTTSCallbacks): ActiveSession {
+    this.stop(callbacks);
+
+    const sessionId = ++this.currentSessionId;
+    this.abortController = new AbortController();
+
+    return {
+      signal: this.abortController.signal,
+      isActive: () => sessionId === this.currentSessionId,
+    };
+  }
+
+  public markStarted(callbacks: BaseTTSCallbacks) {
+    callbacks.onStart?.();
+    this.isSpeaking = true;
+  }
+
+  public markInactive() {
+    this.isSpeaking = false;
+  }
+
+  public async playBlob(
+    blob: Blob,
+    callbacks: BaseTTSCallbacks,
+    isSessionActive: () => boolean
+  ) {
+    if (!isSessionActive()) {
+      this.isSpeaking = false;
+      return;
+    }
+
+    const audioUrl = URL.createObjectURL(blob);
+    this.audio = new Audio(audioUrl);
+
+    const playPromise = this.audio.play();
+
+    this.audio.onended = () => {
+      if (!isSessionActive()) return;
+      this.isSpeaking = false;
+      URL.revokeObjectURL(audioUrl);
+      callbacks.onEnd?.();
+    };
+
+    this.audio.onerror = () => {
+      if (!isSessionActive()) return;
+      this.isSpeaking = false;
+      const mediaError = this.audio?.error;
+      URL.revokeObjectURL(audioUrl);
+      const message = mediaError
+        ? `Audio playback error (code ${mediaError.code}): ${mediaError.message}`
+        : 'Audio playback error';
+
+      callbacks.onError?.(
+        new Error(message)
+      );
+    };
+
+    await playPromise;
+  }
+
+  public stop(callbacks: BaseTTSCallbacks) {
+    this.currentSessionId++;
+
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+
+    if (this.audio) {
+      this.audio.onended = null;
+      this.audio.onerror = null;
+      this.audio.pause();
+
+      const audioToClean = this.audio;
+      const audioSrc = audioToClean.src;
+      setTimeout(() => {
+        audioToClean.src = '';
+        if (audioSrc && audioSrc.startsWith('blob:')) {
+          URL.revokeObjectURL(audioSrc);
+        }
+      }, 100);
+
+      this.audio = null;
+    }
+
+    const wasSpeaking = this.isSpeaking;
+    this.isSpeaking = false;
+    if (wasSpeaking) {
+      callbacks.onEnd?.();
+    }
+  }
+
+  public pause() {
+    this.audio?.pause();
+  }
+
+  public resume(callbacks: BaseTTSCallbacks, message: string) {
+    this.audio?.play().catch(error => {
+      console.error(message, error);
+      callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+    });
+  }
+}

--- a/apps/web/lib/elevenlabs-tts.ts
+++ b/apps/web/lib/elevenlabs-tts.ts
@@ -1,3 +1,4 @@
+import { CloudTTSLifecycle } from './cloud-tts-lifecycle';
 import { TextToSpeech as WebSpeechTTS } from './tts';
 import { BaseTTSCallbacks } from './tts-types';
 
@@ -8,32 +9,20 @@ export interface Voice {
   languageCodes?: { bcp47: string; iso639_3: string; display: string }[];
 }
 
-
 /**
- * ElevenLabs Text-to-Speech Provider
+ * ElevenLabs Text-to-Speech Provider.
  *
  * Fetches audio from the server-side proxy route (/api/text-to-speech) and
- * plays it via HTMLAudioElement with Blob URLs. Uses session-based cancellation
- * to safely handle rapid speak/stop sequences.
+ * delegates browser audio/session handling to CloudTTSLifecycle.
  */
 export class ElevenLabsTTS {
   private static instance: ElevenLabsTTS;
   private voices: Voice[] = [];
-  private audio: HTMLAudioElement | null = null;
-  private isSpeaking = false;
   private isAvailableFlag = false;
   private voicesLoaded = false;
   private loadingVoices: Promise<void> | null = null;
-
-  /**
-   * Session ID for cancellation tracking.
-   * Incremented on each speak() or stop() call so stale async operations
-   * exit gracefully rather than triggering callbacks.
-   */
-  private currentSessionId = 0;
-
   private fallbackTTS: WebSpeechTTS;
-  private abortController: AbortController | null = null;
+  private lifecycle = new CloudTTSLifecycle();
   private lastRequestTime = 0;
 
   private callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: Voice[]) => void } = {};
@@ -108,21 +97,14 @@ export class ElevenLabsTTS {
     streaming?: boolean;
     modelId?: string;
   }) {
-    this.stop();
-
-    this.currentSessionId++;
-    const sessionId = this.currentSessionId;
-    const isSessionActive = () => sessionId === this.currentSessionId;
-
+    const session = this.lifecycle.beginSession(this.callbacks);
     this.lastRequestTime = Date.now();
-    this.abortController = new AbortController();
 
-    // Load voices if needed
     if (!this.isAvailableFlag) {
       if (!this.voicesLoaded) {
         await this.loadVoices();
       }
-      if (!isSessionActive()) return;
+      if (!session.isActive()) return;
       if (!this.isAvailableFlag) {
         console.warn('ElevenLabs not available, falling back to browser TTS');
         this.fallbackTTS.speak(text);
@@ -130,18 +112,18 @@ export class ElevenLabsTTS {
       }
     }
 
-    // Resolve voice ID
     let voiceId = options?.voiceId;
     const voiceExists = voiceId && this.voices.some(v => v.voice_id === voiceId);
     if (!voiceExists) {
-      voiceId = this.voices[0]?.voice_id ?? '21m00Tcm4TlvDq8ikWAM'; // Rachel fallback
+      voiceId = this.voices[0]?.voice_id ?? '21m00Tcm4TlvDq8ikWAM';
     }
 
     try {
-      this.callbacks.onStart?.();
-      this.isSpeaking = true;
-
-      if (!isSessionActive()) { this.isSpeaking = false; return; }
+      this.lifecycle.markStarted(this.callbacks);
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
+        return;
+      }
 
       const response = await fetch('/api/text-to-speech', {
         method: 'POST',
@@ -154,47 +136,29 @@ export class ElevenLabsTTS {
           streaming: true,
           modelId: options?.modelId,
         }),
-        signal: this.abortController.signal,
+        signal: session.signal,
       });
 
-      if (!isSessionActive()) { this.isSpeaking = false; return; }
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
+        return;
+      }
       if (!response.ok) throw new Error(`API request failed: ${response.statusText}`);
 
-      // Accumulate streaming response into a blob before playing
       const blob = await response.blob();
-      if (!isSessionActive()) { this.isSpeaking = false; return; }
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
+        return;
+      }
 
-      const audioUrl = URL.createObjectURL(blob);
-      this.audio = new Audio(audioUrl);
-
-      // play() must be called synchronously after Audio() while still in the
-      // microtask chain of the user gesture — Chrome's autoplay policy will
-      // block it if we set up event handlers first and play() fires too late.
-      const playPromise = this.audio.play();
-
-      this.audio.onended = () => {
-        if (!isSessionActive()) return;
-        this.isSpeaking = false;
-        URL.revokeObjectURL(audioUrl);
-        this.callbacks.onEnd?.();
-      };
-
-      this.audio.onerror = () => {
-        if (!isSessionActive()) return;
-        this.isSpeaking = false;
-        const err = this.audio?.error;
-        URL.revokeObjectURL(audioUrl);
-        this.callbacks.onError?.(
-          new Error(err ? `Audio error (${err.code}): ${err.message}` : 'Audio playback error')
-        );
-      };
-
-      await playPromise;
+      await this.lifecycle.playBlob(blob, this.callbacks, session.isActive);
     } catch (error) {
-      this.isSpeaking = false;
-      if (!isSessionActive()) return;
+      this.lifecycle.markInactive();
+      if (!session.isActive()) return;
+
       const err = error as Error & { name?: string };
       if (err?.name === 'AbortError') return;
+
       const isRapid = Date.now() - this.lastRequestTime < 2000;
       console.error('ElevenLabs TTS error:', error);
       if (!isRapid) {
@@ -205,40 +169,15 @@ export class ElevenLabsTTS {
   }
 
   public stop() {
-    this.currentSessionId++;
-
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
-    }
-
-    if (this.audio) {
-      this.audio.onended = null;
-      this.audio.onerror = null;
-      this.audio.pause();
-      const src = this.audio.src;
-      const audioEl = this.audio;
-      setTimeout(() => {
-        audioEl.src = '';
-        if (src.startsWith('blob:')) URL.revokeObjectURL(src);
-      }, 100);
-      this.audio = null;
-    }
-
-    const wasSpeaking = this.isSpeaking;
-    this.isSpeaking = false;
-    if (wasSpeaking) this.callbacks.onEnd?.();
+    this.lifecycle.stop(this.callbacks);
   }
 
   public pause() {
-    this.audio?.pause();
+    this.lifecycle.pause();
   }
 
   public resume() {
-    this.audio?.play().catch(err => {
-      console.error('Error resuming audio:', err);
-      this.callbacks.onError?.(err instanceof Error ? err : new Error(String(err)));
-    });
+    this.lifecycle.resume(this.callbacks, 'Error resuming audio:');
   }
 
   public isAvailable(): boolean {

--- a/apps/web/lib/gemini-tts.ts
+++ b/apps/web/lib/gemini-tts.ts
@@ -1,5 +1,6 @@
 import { TextToSpeech as WebSpeechTTS } from './tts';
 import { BaseTTSCallbacks } from './tts-types';
+import { CloudTTSLifecycle } from './cloud-tts-lifecycle';
 
 export interface GeminiVoice {
   voice_id: string;
@@ -18,14 +19,11 @@ export interface GeminiVoice {
 export class GeminiTTS {
   private static instance: GeminiTTS;
   private voices: GeminiVoice[] = [];
-  private audio: HTMLAudioElement | null = null;
-  private isSpeaking: boolean = false;
   private isAvailableFlag: boolean = false;
   private voicesLoaded: boolean = false;
   private loadingVoices: Promise<void> | null = null;
-  private currentSessionId: number = 0;
-  private abortController: AbortController | null = null;
   private fallbackTTS: WebSpeechTTS;
+  private lifecycle = new CloudTTSLifecycle();
 
   private callbacks: BaseTTSCallbacks & { onVoicesChanged?: (voices: GeminiVoice[]) => void } = {};
 
@@ -97,20 +95,14 @@ export class GeminiTTS {
   public async speak(text: string, options?: {
     voiceId?: string;
   }) {
-    this.stop();
-
-    this.currentSessionId++;
-    const sessionId = this.currentSessionId;
-    const isSessionActive = () => sessionId === this.currentSessionId;
-
-    this.abortController = new AbortController();
+    const session = this.lifecycle.beginSession(this.callbacks);
 
     if (!this.isAvailableFlag) {
       if (!this.voicesLoaded) {
         await this.loadVoices();
       }
 
-      if (!isSessionActive()) return;
+      if (!session.isActive()) return;
 
       if (!this.isAvailableFlag) {
         console.warn('Gemini TTS is not available, falling back to browser TTS');
@@ -126,11 +118,10 @@ export class GeminiTTS {
     }
 
     try {
-      this.callbacks.onStart?.();
-      this.isSpeaking = true;
+      this.lifecycle.markStarted(this.callbacks);
 
-      if (!isSessionActive()) {
-        this.isSpeaking = false;
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
         return;
       }
 
@@ -138,11 +129,11 @@ export class GeminiTTS {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text, voiceId }),
-        signal: this.abortController.signal,
+        signal: session.signal,
       });
 
-      if (!isSessionActive()) {
-        this.isSpeaking = false;
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
         return;
       }
 
@@ -152,39 +143,16 @@ export class GeminiTTS {
 
       const blob = await response.blob();
 
-      if (!isSessionActive()) {
-        this.isSpeaking = false;
+      if (!session.isActive()) {
+        this.lifecycle.markInactive();
         return;
       }
 
-      const audioUrl = URL.createObjectURL(blob);
-      this.audio = new Audio(audioUrl);
-
-      const playPromise = this.audio.play();
-
-      this.audio.onended = () => {
-        if (!isSessionActive()) return;
-        this.isSpeaking = false;
-        this.callbacks.onEnd?.();
-        URL.revokeObjectURL(audioUrl);
-      };
-
-      this.audio.onerror = () => {
-        if (!isSessionActive()) return;
-        this.isSpeaking = false;
-        const mediaError = this.audio?.error;
-        const message = mediaError
-          ? `Audio playback error (code ${mediaError.code}): ${mediaError.message}`
-          : 'Audio playback error';
-        this.callbacks.onError?.(new Error(message));
-        URL.revokeObjectURL(audioUrl);
-      };
-
-      await playPromise;
+      await this.lifecycle.playBlob(blob, this.callbacks, session.isActive);
     } catch (error) {
-      this.isSpeaking = false;
+      this.lifecycle.markInactive();
 
-      if (!isSessionActive()) return;
+      if (!session.isActive()) return;
 
       const err = error as Error & { name?: string };
       if (err?.name === 'AbortError') return;
@@ -196,51 +164,15 @@ export class GeminiTTS {
   }
 
   public stop() {
-    this.currentSessionId++;
-
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
-    }
-
-    if (this.audio) {
-      this.audio.onended = null;
-      this.audio.onerror = null;
-      this.audio.pause();
-
-      const audioToClean = this.audio;
-      setTimeout(() => {
-        const audioSrc = audioToClean.src;
-        audioToClean.src = '';
-        if (audioSrc && audioSrc.startsWith('blob:')) {
-          URL.revokeObjectURL(audioSrc);
-        }
-      }, 100);
-
-      this.audio = null;
-    }
-
-    const wasSpeaking = this.isSpeaking;
-    this.isSpeaking = false;
-
-    if (wasSpeaking) {
-      this.callbacks.onEnd?.();
-    }
+    this.lifecycle.stop(this.callbacks);
   }
 
   public pause() {
-    if (this.audio) {
-      this.audio.pause();
-    }
+    this.lifecycle.pause();
   }
 
   public resume() {
-    if (this.audio) {
-      this.audio.play().catch(error => {
-        console.error('Error resuming Gemini audio:', error);
-        this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
-      });
-    }
+    this.lifecycle.resume(this.callbacks, 'Error resuming Gemini audio:');
   }
 
   public isAvailable(): boolean {


### PR DESCRIPTION
## Summary
- add a shared CloudTTSLifecycle helper for cloud provider audio playback, cancellation, and stop/pause/resume handling
- update ElevenLabs, Azure, and Gemini providers to delegate browser audio/session lifecycle work to the shared helper
- keep provider-specific voice loading, API routes, payloads, and browser TTS fallback behavior isolated in each provider

Closes #654

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/lib/elevenlabs-tts.test.ts tests/lib/gemini-tts.test.ts tests/lib/tts-provider.test.ts
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build
- pnpm --filter @sayit/web test -- --runInBand