### PR TITLE
Replace destructive native confirms

### DIFF
--- a/apps/web/app/components/settings/ImportedPackagesSection.tsx
+++ b/apps/web/app/components/settings/ImportedPackagesSection.tsx
@@ -6,6 +6,7 @@ import { TrashIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { Button } from '@/app/components/ui/Button';
+import ConfirmDialog from '@/app/components/ui/ConfirmDialog';
 
 type Variant = 'sheet' | 'desktop';
 
@@ -21,22 +22,26 @@ export default function ImportedPackagesSection({ variant }: { variant: Variant 
   const packages = useQuery(api.phraseBoards.listImportedPackages);
   const deletePackage = useMutation(api.openBoardImport.deleteImportedPackage);
   const [deletingId, setDeletingId] = useState<Id<'importedPackages'> | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: Id<'importedPackages'>;
+    name: string;
+    boardCount: number;
+  } | null>(null);
 
-  const handleDelete = async (id: Id<'importedPackages'>, name: string, boardCount: number) => {
-    if (!confirm(
-      `Delete "${name}"? This removes all ${boardCount} board${boardCount === 1 ? '' : 's'} from this import. Phrases and symbols are removed in the background.`
-    )) {
-      return;
-    }
-    setDeletingId(id);
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+
+    setDeletingId(deleteTarget.id);
     try {
-      await deletePackage({ packageId: id });
+      await deletePackage({ packageId: deleteTarget.id });
+      setDeleteTarget(null);
     } catch (err) {
       // Re-throw to surface in the dev console; user-visible error UX would
       // require a toast system that isn't part of this section's scope.
       console.error('Failed to delete imported package:', err);
     } finally {
       setDeletingId(null);
+      setDeleteTarget(null);
     }
   };
 
@@ -92,7 +97,11 @@ export default function ImportedPackagesSection({ variant }: { variant: Variant 
               <Button
                 type="button"
                 variant="ghost"
-                onClick={() => handleDelete(pkg.id, pkg.name, pkg.boardCount)}
+                onClick={() => setDeleteTarget({
+                  id: pkg.id,
+                  name: pkg.name,
+                  boardCount: pkg.boardCount,
+                })}
                 disabled={isDeleting}
                 className="text-red-500 hover:text-red-600"
                 aria-label={`Delete ${pkg.name}`}
@@ -103,6 +112,17 @@ export default function ImportedPackagesSection({ variant }: { variant: Variant 
           );
         })}
       </ul>
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Delete Imported Vocabulary"
+        description={deleteTarget
+          ? `Delete "${deleteTarget.name}"? This removes all ${deleteTarget.boardCount} board${deleteTarget.boardCount === 1 ? '' : 's'} from this import. Phrases and symbols are removed in the background.`
+          : ''}
+        confirmLabel="Delete Vocabulary"
+        isBusy={deletingId !== null}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/apps/web/app/components/ui/ConfirmDialog.tsx
+++ b/apps/web/app/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import BottomSheet from './BottomSheet';
+import { Button } from './Button';
+
+type ConfirmDialogProps = {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  isBusy?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+};
+
+export default function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  isBusy = false,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={isBusy ? () => undefined : onCancel}
+      title={title}
+      snapPoints={[34]}
+      showHandle={false}
+      showCloseButton={!isBusy}
+      closeOnBackdropClick={!isBusy}
+    >
+      <div className="space-y-5 p-4">
+        <p className="text-sm leading-6 text-text-secondary">{description}</p>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={isBusy}>
+            {cancelLabel}
+          </Button>
+          <Button type="button" variant="destructive" onClick={onConfirm} disabled={isBusy}>
+            {isBusy ? 'Deleting...' : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/apps/web/app/phrases/boards/[boardId]/tiles/audio/[tileId]/edit/page.tsx
+++ b/apps/web/app/phrases/boards/[boardId]/tiles/audio/[tileId]/edit/page.tsx
@@ -9,6 +9,7 @@ import { Id } from '@/convex/_generated/dataModel';
 import Input from '@/app/components/ui/Input';
 import { Button } from '@/app/components/ui/Button';
 import PageHeader from '@/app/components/ui/PageHeader';
+import ConfirmDialog from '@/app/components/ui/ConfirmDialog';
 import AudioRecorderControl, { RecordedAudio } from '@/app/components/phrases/tiles/AudioRecorderControl';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
 import { MAX_AUDIO_LABEL_LENGTH } from '@/lib/audio/constants';
@@ -27,6 +28,7 @@ function EditAudioTileForm() {
 
   const [label, setLabel] = useState('');
   const [replacementRecording, setReplacementRecording] = useState<RecordedAudio | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -111,7 +113,6 @@ function EditAudioTileForm() {
 
   const handleDelete = async () => {
     if (!tileId) return;
-    if (!confirm('Delete this audio tile?')) return;
 
     setDeleting(true);
     setError(null);
@@ -123,6 +124,7 @@ function EditAudioTileForm() {
       setError(err instanceof Error ? err.message : 'Failed to delete audio tile.');
     } finally {
       setDeleting(false);
+      setIsDeleteDialogOpen(false);
     }
   };
 
@@ -187,7 +189,7 @@ function EditAudioTileForm() {
             <Button
               type="button"
               variant="ghost"
-              onClick={handleDelete}
+              onClick={() => setIsDeleteDialogOpen(true)}
               disabled={deleting || !isOnline || !existingTile}
             >
               {deleting ? 'Deleting...' : 'Delete'}
@@ -201,6 +203,15 @@ function EditAudioTileForm() {
           </div>
         </form>
       </div>
+      <ConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        title="Delete Audio Tile"
+        description={`Delete "${existingTile?.audioLabel ?? 'this audio tile'}"? This removes the audio tile and its recording from this board.`}
+        confirmLabel="Delete Tile"
+        isBusy={deleting}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/apps/web/app/phrases/boards/[boardId]/tiles/navigate/[tileId]/edit/page.tsx
+++ b/apps/web/app/phrases/boards/[boardId]/tiles/navigate/[tileId]/edit/page.tsx
@@ -8,6 +8,7 @@ import { Id } from '@/convex/_generated/dataModel';
 import { Button } from '@/app/components/ui/Button';
 import PageHeader from '@/app/components/ui/PageHeader';
 import BottomSheet from '@/app/components/ui/BottomSheet';
+import ConfirmDialog from '@/app/components/ui/ConfirmDialog';
 import { ChevronDownIcon, UserGroupIcon, CheckIcon } from '@heroicons/react/24/outline';
 
 function EditNavigateTileForm() {
@@ -18,6 +19,7 @@ function EditNavigateTileForm() {
 
   const [targetBoardId, setTargetBoardId] = useState<string | null>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -81,7 +83,7 @@ function EditNavigateTileForm() {
 
   const handleDelete = async () => {
     if (!tileId) return;
-    if (!confirm('Delete this navigate tile?')) return;
+
     setDeleting(true);
     setError(null);
     try {
@@ -92,6 +94,7 @@ function EditNavigateTileForm() {
       setError(err instanceof Error ? err.message : 'Failed to delete tile');
     } finally {
       setDeleting(false);
+      setIsDeleteDialogOpen(false);
     }
   };
 
@@ -139,7 +142,7 @@ function EditNavigateTileForm() {
             <Button
               type="button"
               variant="ghost"
-              onClick={handleDelete}
+              onClick={() => setIsDeleteDialogOpen(true)}
               disabled={deleting || !existingTile}
             >
               {deleting ? 'Deleting...' : 'Delete'}
@@ -194,6 +197,15 @@ function EditNavigateTileForm() {
           })}
         </div>
       </BottomSheet>
+      <ConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        title="Delete Navigate Tile"
+        description={`Delete "${existingTile?.label ?? 'this navigate tile'}"? This removes the navigation link from this board.`}
+        confirmLabel="Delete Tile"
+        isBusy={deleting}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/apps/web/app/phrases/boards/edit/[id]/page.tsx
+++ b/apps/web/app/phrases/boards/edit/[id]/page.tsx
@@ -9,6 +9,7 @@ import { use } from 'react';
 import Input from '@/app/components/ui/Input';
 import { Button } from '@/app/components/ui/Button';
 import PageHeader from '@/app/components/ui/PageHeader';
+import ConfirmDialog from '@/app/components/ui/ConfirmDialog';
 import { useAuth } from '@/app/contexts/AuthContext';
 import type { Id } from '@/convex/_generated/dataModel';
 
@@ -18,6 +19,7 @@ export default function EditBoardPage({ params }: { params: Promise<{ id: string
   const [hiddenFromPicker, setHiddenFromPicker] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
@@ -66,10 +68,6 @@ export default function EditBoardPage({ params }: { params: Promise<{ id: string
   const handleDelete = async () => {
     if (!board) return;
 
-    if (!confirm('Are you sure you want to delete this board? All phrases in this board will be deleted.')) {
-      return;
-    }
-
     setDeleting(true);
     setError(null);
 
@@ -83,6 +81,7 @@ export default function EditBoardPage({ params }: { params: Promise<{ id: string
       setError('Failed to delete board');
     } finally {
       setDeleting(false);
+      setIsDeleteDialogOpen(false);
     }
   };
 
@@ -146,7 +145,7 @@ export default function EditBoardPage({ params }: { params: Promise<{ id: string
             <Button
               type="button"
               variant="ghost"
-              onClick={handleDelete}
+              onClick={() => setIsDeleteDialogOpen(true)}
               className="text-red-600 hover:text-red-700"
               disabled={deleting}
             >
@@ -162,6 +161,15 @@ export default function EditBoardPage({ params }: { params: Promise<{ id: string
           </div>
         </form>
       </div>
+      <ConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        title="Delete Board"
+        description={`Delete "${board.name}"? This removes the board and all phrases in it.`}
+        confirmLabel="Delete Board"
+        isBusy={deleting}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/apps/web/tests/components/ui/ConfirmDialog.test.tsx
+++ b/apps/web/tests/components/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfirmDialog from '@/app/components/ui/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('renders destructive copy and calls confirm from the app dialog', async () => {
+    const onCancel = jest.fn();
+    const onConfirm = jest.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen
+        title="Delete Board"
+        description='Delete "Core"? This removes the board and all phrases in it.'
+        confirmLabel="Delete Board"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Delete Board' })).toBeInTheDocument();
+    expect(screen.getByText('Delete "Core"? This removes the board and all phrases in it.')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Board' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls cancel and disables actions while busy', async () => {
+    const onCancel = jest.fn();
+    const onConfirm = jest.fn();
+
+    const { rerender } = render(
+      <ConfirmDialog
+        isOpen
+        title="Delete Tile"
+        description='Delete "Food"? This removes the navigation link from this board.'
+        confirmLabel="Delete Tile"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ConfirmDialog
+        isOpen
+        title="Delete Tile"
+        description='Delete "Food"? This removes the navigation link from this board.'
+        confirmLabel="Delete Tile"
+        isBusy
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Deleting...' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared ConfirmDialog bottom-sheet primitive for destructive confirmations
- replace native confirm() usage in board deletion, navigate tile deletion, audio tile deletion, and imported vocabulary deletion flows
- add dialog tests for confirm, cancel, and busy states

Closes #659

## Verification
- rg -n \bconfirm\s*\(|window\.confirm|global\.confirm apps/web/app apps/web/lib -S
- pnpm --filter @sayit/web test -- --runInBand tests/components/ui/ConfirmDialog.test.tsx
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build
- pnpm --filter @sayit/web test -- --runInBand