### PR TITLE
Split settings context modules

### DIFF
--- a/apps/web/app/contexts/SettingsContext.tsx
+++ b/apps/web/app/contexts/SettingsContext.tsx
@@ -1,438 +1,96 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
-import { useQuery, useMutation } from 'convex/react';
-import { api } from '@/convex/_generated/api';
-import { TTSProviderType } from '@/lib/tts-provider';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useAuth } from './AuthContext';
+import {
+  defaultAllSettings,
+  pickSettings,
+  pickUIPreferences,
+  type AllSettings,
+  type Settings,
+  type SettingsContextType,
+  type UIPreferences,
+} from './settings/types';
+import {
+  loadSettingsFromLocalStorage,
+  saveSettingsToLocalStorage,
+} from './settings/storage';
+import { useSettingsSync } from './settings/useSettingsSync';
 
-type TextSize = number;
-type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
-type TypingDockMode = 'expanded' | 'fullscreen' | 'minimized';
-type MessageCaptureMode = 'disabled' | 'clearOnly' | 'speakOnly' | 'speakAndClearOnly' | 'speakAny';
-type TTSModelPreference = 'fast' | 'high_quality';
-
-const DOUBLE_ENTER_TIMEOUT_MIN_MS = 1000;
-const DOUBLE_ENTER_TIMEOUT_MAX_MS = 10000;
-
-interface Settings {
-  textSize: TextSize;
-  speechRate: number;
-  speechPitch: number;
-  speechVolume: number;
-  speechVoice: string;
-  enterKeyBehavior: EnterKeyBehavior;
-  doubleEnterEnabled: boolean;
-  doubleEnterAction: EnterKeyBehavior;
-  doubleEnterTimeoutMs: number;
-  ttsProvider: TTSProviderType;
-  ttsVoiceId: string;
-  ttsStability: number;
-  ttsSimilarityBoost: number;
-  ttsModelPreference: TTSModelPreference;
-  aiReplySuggestionsEnabled: boolean;
-  messageCaptureMode: MessageCaptureMode;
-  usePhraseBar: boolean;
-  speakPhrasesOnTap: boolean;
-}
-
-interface UIPreferences {
-  typingAreaVisible: boolean;
-  typingAreaExpanded: boolean;
-  selectedBoardId: string | null;
-  typingShareFontSize: number;
-  activeTypingTabId: string | null;
-  typingDockMode: TypingDockMode;
-}
-
-type AllSettings = Settings & UIPreferences;
-
-interface SettingsContextType {
-  settings: Settings;
-  uiPreferences: UIPreferences;
-  isLoading: boolean;
-  isSyncing: boolean;
-  updateSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
-  updateUIPreference: <K extends keyof UIPreferences>(key: K, value: UIPreferences[K]) => void;
-}
-
-const defaultSettings: Settings = {
-  textSize: 16,
-  speechRate: 1.0,
-  speechPitch: 1.0,
-  speechVolume: 1.0,
-  speechVoice: '',
-  enterKeyBehavior: 'newline',
-  doubleEnterEnabled: false,
-  doubleEnterAction: 'speak',
-  doubleEnterTimeoutMs: 1000,
-  ttsProvider: 'browser',
-  ttsVoiceId: '',
-  ttsStability: 0.5,
-  ttsSimilarityBoost: 0.5,
-  ttsModelPreference: 'fast',
-  aiReplySuggestionsEnabled: true,
-  messageCaptureMode: 'speakOnly',
-  usePhraseBar: false,
-  speakPhrasesOnTap: false,
-};
-
-const defaultUIPreferences: UIPreferences = {
-  typingAreaVisible: true,
-  typingAreaExpanded: false,
-  selectedBoardId: null,
-  typingShareFontSize: 18,
-  activeTypingTabId: null,
-  typingDockMode: 'expanded',
-};
+export type {
+  AllSettings,
+  EnterKeyBehavior,
+  MessageCaptureMode,
+  Settings,
+  SettingsContextType,
+  TextSize,
+  TTSModelPreference,
+  TypingDockMode,
+  UIPreferences,
+} from './settings/types';
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
 
-// Helper to convert textSize from old enum to number
-function normalizeTextSize(value: number | string): number {
-  if (typeof value === 'number') {
-    return value;
-  }
-  const enumMap: Record<string, number> = {
-    small: 12,
-    medium: 16,
-    large: 24,
-    xlarge: 32,
-  };
-  return enumMap[value] ?? 16;
-}
-
-function normalizeDoubleEnterTimeout(value: number | undefined): number {
-  if (!Number.isFinite(value)) {
-    return defaultSettings.doubleEnterTimeoutMs;
-  }
-
-  return Math.max(
-    DOUBLE_ENTER_TIMEOUT_MIN_MS,
-    Math.min(DOUBLE_ENTER_TIMEOUT_MAX_MS, value as number)
-  );
-}
-
-
-// Helper function to load settings from localStorage
-function loadFromLocalStorage(): AllSettings {
-  if (typeof window === 'undefined') {
-    return { ...defaultSettings, ...defaultUIPreferences };
-  }
-
-  // Load main settings
-  const savedSettings = localStorage.getItem('settings');
-  const parsedSettings = savedSettings ? JSON.parse(savedSettings) : {};
-
-  // Normalize textSize from old enum format if needed
-  if (parsedSettings.textSize !== undefined) {
-    parsedSettings.textSize = normalizeTextSize(parsedSettings.textSize);
-  }
-
-  if (parsedSettings.doubleEnterTimeoutMs !== undefined) {
-    parsedSettings.doubleEnterTimeoutMs = normalizeDoubleEnterTimeout(parsedSettings.doubleEnterTimeoutMs);
-  }
-
-  const settings = { ...defaultSettings, ...parsedSettings };
-
-  // Load UI preferences from various localStorage keys
-  const typingAreaVisible = localStorage.getItem('typingAreaVisible');
-  const typingAreaExpanded = localStorage.getItem('typingAreaExpanded');
-  const selectedBoardId = localStorage.getItem('selectedBoardId');
-  const typingShareFontSize = localStorage.getItem('typing-share-font-size');
-  const activeTypingTabId = localStorage.getItem('activeTypingTabId');
-  const typingDockMode = localStorage.getItem('typingDockMode');
-
-  const parsedFontSize = typingShareFontSize ? parseInt(typingShareFontSize, 10) : defaultUIPreferences.typingShareFontSize;
-  const validFontSize = !isNaN(parsedFontSize)
-    ? Math.max(12, Math.min(64, parsedFontSize))
-    : defaultUIPreferences.typingShareFontSize;
-
-  // Helper to safely parse JSON booleans
-  const parseBooleanSafely = (value: string | null, fallback: boolean): boolean => {
-    if (!value) return fallback;
-    try {
-      const parsed = JSON.parse(value);
-      return typeof parsed === 'boolean' ? parsed : fallback;
-    } catch {
-      return fallback;
-    }
-  };
-
-  // Parse typing dock mode
-  const validTypingDockModes = ['expanded', 'fullscreen', 'minimized'];
-  const parsedTypingDockMode = typingDockMode && validTypingDockModes.includes(typingDockMode)
-    ? typingDockMode as TypingDockMode
-    : defaultUIPreferences.typingDockMode;
-
-  const uiPreferences: UIPreferences = {
-    typingAreaVisible: parseBooleanSafely(typingAreaVisible, defaultUIPreferences.typingAreaVisible),
-    typingAreaExpanded: parseBooleanSafely(typingAreaExpanded, defaultUIPreferences.typingAreaExpanded),
-    selectedBoardId: selectedBoardId || defaultUIPreferences.selectedBoardId,
-    typingShareFontSize: validFontSize,
-    activeTypingTabId: activeTypingTabId || defaultUIPreferences.activeTypingTabId,
-    typingDockMode: parsedTypingDockMode,
-  };
-
-  return { ...settings, ...uiPreferences };
-}
-
-// Helper function to save to localStorage
-function saveToLocalStorage(allSettings: AllSettings) {
-  if (typeof window === 'undefined') return;
-
-  // Save main settings
-  const settings: Settings = {
-    textSize: allSettings.textSize,
-    speechRate: allSettings.speechRate,
-    speechPitch: allSettings.speechPitch,
-    speechVolume: allSettings.speechVolume,
-    speechVoice: allSettings.speechVoice,
-    enterKeyBehavior: allSettings.enterKeyBehavior,
-    doubleEnterEnabled: allSettings.doubleEnterEnabled,
-    doubleEnterAction: allSettings.doubleEnterAction,
-    doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(allSettings.doubleEnterTimeoutMs),
-    ttsProvider: allSettings.ttsProvider,
-    ttsVoiceId: allSettings.ttsVoiceId,
-    ttsStability: allSettings.ttsStability,
-    ttsSimilarityBoost: allSettings.ttsSimilarityBoost,
-    ttsModelPreference: allSettings.ttsModelPreference,
-    aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
-    messageCaptureMode: allSettings.messageCaptureMode,
-    usePhraseBar: allSettings.usePhraseBar,
-    speakPhrasesOnTap: allSettings.speakPhrasesOnTap,
-  };
-  localStorage.setItem('settings', JSON.stringify(settings));
-
-  // Save UI preferences to their respective keys (for backward compatibility)
-  localStorage.setItem('typingAreaVisible', JSON.stringify(allSettings.typingAreaVisible));
-  localStorage.setItem('typingAreaExpanded', JSON.stringify(allSettings.typingAreaExpanded));
-  if (allSettings.selectedBoardId) {
-    localStorage.setItem('selectedBoardId', allSettings.selectedBoardId);
-  } else {
-    localStorage.removeItem('selectedBoardId');
-  }
-  localStorage.setItem('typing-share-font-size', allSettings.typingShareFontSize.toString());
-  if (allSettings.activeTypingTabId) {
-    localStorage.setItem('activeTypingTabId', allSettings.activeTypingTabId);
-  } else {
-    localStorage.removeItem('activeTypingTabId');
-  }
-  localStorage.setItem('typingDockMode', allSettings.typingDockMode);
-}
-
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
-  const [allSettings, setAllSettings] = useState<AllSettings>({
-    ...defaultSettings,
-    ...defaultUIPreferences,
-  });
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSyncing, setIsSyncing] = useState(false);
-  const [hasMigrated, setHasMigrated] = useState(false);
+  const [allSettings, setAllSettings] = useState<AllSettings>(defaultAllSettings);
+  const hasSkippedInitialPersistRef = useRef(false);
+  const {
+    isLoading,
+    isSyncing,
+    syncSetting,
+    syncUIPreference,
+  } = useSettingsSync({ user, setAllSettings });
 
   useEffect(() => {
-    setAllSettings(loadFromLocalStorage());
+    setAllSettings(loadSettingsFromLocalStorage());
   }, []);
 
-  // Convex hooks - only query when authenticated
-  const convexSettings = useQuery(api.userSettings.getUserSettings, user ? {} : 'skip');
-  const initializeSettings = useMutation(api.userSettings.initializeSettings);
-  const updateSettingsMutation = useMutation(api.userSettings.updateSettings);
-
-  // Effect: Sync with Convex on mount/sign-in
   useEffect(() => {
-    if (!user) {
-      // Guest user - no Convex sync needed
-      setIsLoading(false);
-      setHasMigrated(false);
+    if (!hasSkippedInitialPersistRef.current) {
+      hasSkippedInitialPersistRef.current = true;
       return;
     }
 
-    if (convexSettings === undefined) {
-      // Still loading from Convex
-      setIsLoading(true);
-      return;
-    }
-
-    if (convexSettings === null && !hasMigrated) {
-      // No settings in Convex - migrate from localStorage
-      setIsLoading(true);
-      const localSettings = loadFromLocalStorage();
-
-      initializeSettings({
-        textSize: localSettings.textSize,
-        speechRate: localSettings.speechRate,
-        speechPitch: localSettings.speechPitch,
-        speechVolume: localSettings.speechVolume,
-        speechVoice: localSettings.speechVoice,
-        enterKeyBehavior: localSettings.enterKeyBehavior,
-        doubleEnterEnabled: localSettings.doubleEnterEnabled,
-        doubleEnterAction: localSettings.doubleEnterAction,
-        doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(localSettings.doubleEnterTimeoutMs),
-        ttsProvider: localSettings.ttsProvider,
-        ttsVoiceId: localSettings.ttsVoiceId,
-        ttsStability: localSettings.ttsStability,
-        ttsSimilarityBoost: localSettings.ttsSimilarityBoost,
-        ttsModelPreference: localSettings.ttsModelPreference,
-        aiReplySuggestionsEnabled: localSettings.aiReplySuggestionsEnabled,
-        messageCaptureMode: localSettings.messageCaptureMode,
-        usePhraseBar: localSettings.usePhraseBar,
-        speakPhrasesOnTap: localSettings.speakPhrasesOnTap,
-        typingAreaVisible: localSettings.typingAreaVisible,
-        typingAreaExpanded: localSettings.typingAreaExpanded,
-        selectedBoardId: localSettings.selectedBoardId ?? undefined,
-        typingShareFontSize: localSettings.typingShareFontSize,
-        activeTypingTabId: localSettings.activeTypingTabId ?? undefined,
-        typingDockMode: localSettings.typingDockMode,
-      })
-        .then(() => {
-          console.log('Settings migrated to Convex successfully');
-          setHasMigrated(true);
-          setIsLoading(false);
-        })
-        .catch((error) => {
-          console.error('Failed to migrate settings to Convex:', error);
-          setIsLoading(false);
-        });
-    } else if (convexSettings) {
-      // Settings exist in Convex - update from server
-      const serverTypingDockMode = convexSettings.typingDockMode as TypingDockMode | undefined;
-      const serverSettings: AllSettings = {
-        textSize: normalizeTextSize(convexSettings.textSize),
-        speechRate: convexSettings.speechRate,
-        speechPitch: convexSettings.speechPitch,
-        speechVolume: convexSettings.speechVolume,
-        speechVoice: convexSettings.speechVoice,
-        enterKeyBehavior: convexSettings.enterKeyBehavior,
-        doubleEnterEnabled: convexSettings.doubleEnterEnabled ?? defaultSettings.doubleEnterEnabled,
-        doubleEnterAction: (convexSettings.doubleEnterAction as EnterKeyBehavior) ?? defaultSettings.doubleEnterAction,
-        doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(convexSettings.doubleEnterTimeoutMs ?? defaultSettings.doubleEnterTimeoutMs),
-        ttsProvider: convexSettings.ttsProvider,
-        ttsVoiceId: convexSettings.ttsVoiceId,
-        ttsStability: convexSettings.ttsStability,
-        ttsSimilarityBoost: convexSettings.ttsSimilarityBoost,
-        ttsModelPreference: (convexSettings.ttsModelPreference as TTSModelPreference) ?? defaultSettings.ttsModelPreference,
-        aiReplySuggestionsEnabled: convexSettings.aiReplySuggestionsEnabled ?? defaultSettings.aiReplySuggestionsEnabled,
-        messageCaptureMode: convexSettings.messageCaptureMode ?? defaultSettings.messageCaptureMode,
-        usePhraseBar: convexSettings.usePhraseBar ?? defaultSettings.usePhraseBar,
-        speakPhrasesOnTap: convexSettings.speakPhrasesOnTap ?? defaultSettings.speakPhrasesOnTap,
-        typingAreaVisible: convexSettings.typingAreaVisible,
-        typingAreaExpanded: convexSettings.typingAreaExpanded,
-        selectedBoardId: convexSettings.selectedBoardId ?? null,
-        typingShareFontSize: convexSettings.typingShareFontSize,
-        activeTypingTabId: convexSettings.activeTypingTabId ?? null,
-        typingDockMode: serverTypingDockMode === 'fullscreen' || serverTypingDockMode === 'minimized'
-          ? serverTypingDockMode
-          : defaultUIPreferences.typingDockMode,
-      };
-
-      setAllSettings(serverSettings);
-      saveToLocalStorage(serverSettings);
-      setIsLoading(false);
-      setHasMigrated(true);
-    }
-  }, [user, convexSettings, hasMigrated, initializeSettings]);
+    saveSettingsToLocalStorage(allSettings);
+  }, [allSettings]);
 
   const updateSetting = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
     console.log(`Updating setting ${key} to:`, value);
 
-    // Use functional update to avoid depending on allSettings
     setAllSettings((prev) => {
-      const newAllSettings = { ...prev, [key]: value };
-
-      // 2. Update localStorage immediately (for offline support)
-      saveToLocalStorage(newAllSettings);
-
-      return newAllSettings;
+      return { ...prev, [key]: value };
     });
 
-    // 3. If authenticated, sync to Convex in background
-    if (user) {
-      setIsSyncing(true);
-      updateSettingsMutation({
-        [key]: value,
-        lastSyncedAt: Date.now(),
-      })
-        .then(() => {
-          setIsSyncing(false);
-        })
-        .catch((error) => {
-          console.error('Failed to sync setting to Convex:', error);
-          setIsSyncing(false);
-          // Don't revert - keep optimistic update
-        });
-    }
-  }, [user, updateSettingsMutation]);
+    syncSetting(key, value);
+  }, [syncSetting]);
 
-  const updateUIPreference = useCallback(<K extends keyof UIPreferences>(key: K, value: UIPreferences[K]) => {
+  const updateUIPreference = useCallback(<K extends keyof UIPreferences>(
+    key: K,
+    value: UIPreferences[K]
+  ) => {
     console.log(`Updating UI preference ${key} to:`, value);
 
-    // Use functional update to avoid depending on allSettings
     setAllSettings((prev) => {
-      const newAllSettings = { ...prev, [key]: value };
-
-      // 2. Update localStorage immediately (for offline support)
-      saveToLocalStorage(newAllSettings);
-
-      return newAllSettings;
+      return { ...prev, [key]: value };
     });
 
-    // 3. If authenticated, sync to Convex in background
-    if (user) {
-      setIsSyncing(true);
-      // Convert null to undefined for Convex (v.optional only accepts undefined, not null)
-      const convexValue = value === null ? undefined : value;
-      updateSettingsMutation({
-        [key]: convexValue,
-        lastSyncedAt: Date.now(),
-      })
-        .then(() => {
-          setIsSyncing(false);
-        })
-        .catch((error) => {
-          console.error('Failed to sync UI preference to Convex:', error);
-          setIsSyncing(false);
-          // Don't revert - keep optimistic update
-        });
-    }
-  }, [user, updateSettingsMutation]);
-
-  const settings: Settings = {
-    textSize: allSettings.textSize,
-    speechRate: allSettings.speechRate,
-    speechPitch: allSettings.speechPitch,
-    speechVolume: allSettings.speechVolume,
-    speechVoice: allSettings.speechVoice,
-    enterKeyBehavior: allSettings.enterKeyBehavior,
-    doubleEnterEnabled: allSettings.doubleEnterEnabled,
-    doubleEnterAction: allSettings.doubleEnterAction,
-    doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(allSettings.doubleEnterTimeoutMs),
-    ttsProvider: allSettings.ttsProvider,
-    ttsVoiceId: allSettings.ttsVoiceId,
-    ttsStability: allSettings.ttsStability,
-    ttsSimilarityBoost: allSettings.ttsSimilarityBoost,
-    ttsModelPreference: allSettings.ttsModelPreference,
-    aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
-    messageCaptureMode: allSettings.messageCaptureMode,
-    usePhraseBar: allSettings.usePhraseBar,
-    speakPhrasesOnTap: allSettings.speakPhrasesOnTap,
-  };
-
-  const uiPreferences: UIPreferences = {
-    typingAreaVisible: allSettings.typingAreaVisible,
-    typingAreaExpanded: allSettings.typingAreaExpanded,
-    selectedBoardId: allSettings.selectedBoardId,
-    typingShareFontSize: allSettings.typingShareFontSize,
-    activeTypingTabId: allSettings.activeTypingTabId,
-    typingDockMode: allSettings.typingDockMode,
-  };
+    syncUIPreference(key, value);
+  }, [syncUIPreference]);
 
   return (
     <SettingsContext.Provider
       value={{
-        settings,
-        uiPreferences,
+        settings: pickSettings(allSettings),
+        uiPreferences: pickUIPreferences(allSettings),
         isLoading,
         isSyncing,
         updateSetting,

--- a/apps/web/app/contexts/settings/storage.ts
+++ b/apps/web/app/contexts/settings/storage.ts
@@ -1,0 +1,128 @@
+import {
+  defaultAllSettings,
+  defaultSettings,
+  defaultUIPreferences,
+  isTypingDockMode,
+  normalizeDoubleEnterTimeout,
+  normalizeTextSize,
+  pickSettings,
+  type AllSettings,
+  type TypingDockMode,
+  type UIPreferences,
+} from './types';
+
+function safeParseObject(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseBooleanSafely(value: string | null, fallback: boolean): boolean {
+  if (!value) return fallback;
+
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'boolean' ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function parseTypingShareFontSize(value: string | null): number {
+  const parsedFontSize = value
+    ? parseInt(value, 10)
+    : defaultUIPreferences.typingShareFontSize;
+
+  return !isNaN(parsedFontSize)
+    ? Math.max(12, Math.min(64, parsedFontSize))
+    : defaultUIPreferences.typingShareFontSize;
+}
+
+function normalizeStoredSettings(parsedSettings: Record<string, unknown>) {
+  const normalized = { ...parsedSettings };
+
+  if (normalized.textSize !== undefined) {
+    normalized.textSize = normalizeTextSize(normalized.textSize as number | string);
+  }
+
+  if (normalized.doubleEnterTimeoutMs !== undefined) {
+    normalized.doubleEnterTimeoutMs = normalizeDoubleEnterTimeout(
+      normalized.doubleEnterTimeoutMs as number | undefined
+    );
+  }
+
+  return normalized;
+}
+
+function loadUIPreferencesFromStorage(storage: Storage): UIPreferences {
+  const typingDockMode = storage.getItem('typingDockMode');
+  const parsedTypingDockMode: TypingDockMode = isTypingDockMode(typingDockMode)
+    ? typingDockMode
+    : defaultUIPreferences.typingDockMode;
+
+  return {
+    typingAreaVisible: parseBooleanSafely(
+      storage.getItem('typingAreaVisible'),
+      defaultUIPreferences.typingAreaVisible
+    ),
+    typingAreaExpanded: parseBooleanSafely(
+      storage.getItem('typingAreaExpanded'),
+      defaultUIPreferences.typingAreaExpanded
+    ),
+    selectedBoardId: storage.getItem('selectedBoardId') || defaultUIPreferences.selectedBoardId,
+    typingShareFontSize: parseTypingShareFontSize(storage.getItem('typing-share-font-size')),
+    activeTypingTabId: storage.getItem('activeTypingTabId') || defaultUIPreferences.activeTypingTabId,
+    typingDockMode: parsedTypingDockMode,
+  };
+}
+
+export function loadSettingsFromLocalStorage(storage?: Storage): AllSettings {
+  if (typeof window === 'undefined' && !storage) {
+    return defaultAllSettings;
+  }
+
+  const localStorageRef = storage ?? window.localStorage;
+  const parsedSettings = normalizeStoredSettings(
+    safeParseObject(localStorageRef.getItem('settings'))
+  );
+
+  return {
+    ...defaultSettings,
+    ...parsedSettings,
+    ...loadUIPreferencesFromStorage(localStorageRef),
+  } as AllSettings;
+}
+
+export function saveSettingsToLocalStorage(allSettings: AllSettings, storage?: Storage) {
+  if (typeof window === 'undefined' && !storage) return;
+
+  const localStorageRef = storage ?? window.localStorage;
+  const settings = pickSettings(allSettings);
+
+  localStorageRef.setItem('settings', JSON.stringify(settings));
+  localStorageRef.setItem('typingAreaVisible', JSON.stringify(allSettings.typingAreaVisible));
+  localStorageRef.setItem('typingAreaExpanded', JSON.stringify(allSettings.typingAreaExpanded));
+
+  if (allSettings.selectedBoardId) {
+    localStorageRef.setItem('selectedBoardId', allSettings.selectedBoardId);
+  } else {
+    localStorageRef.removeItem('selectedBoardId');
+  }
+
+  localStorageRef.setItem('typing-share-font-size', allSettings.typingShareFontSize.toString());
+
+  if (allSettings.activeTypingTabId) {
+    localStorageRef.setItem('activeTypingTabId', allSettings.activeTypingTabId);
+  } else {
+    localStorageRef.removeItem('activeTypingTabId');
+  }
+
+  localStorageRef.setItem('typingDockMode', allSettings.typingDockMode);
+}

--- a/apps/web/app/contexts/settings/types.ts
+++ b/apps/web/app/contexts/settings/types.ts
@@ -1,0 +1,150 @@
+import type { TTSProviderType } from '@/lib/tts-provider';
+
+export type TextSize = number;
+export type EnterKeyBehavior = 'newline' | 'speak' | 'clear' | 'speakAndClear';
+export type TypingDockMode = 'expanded' | 'fullscreen' | 'minimized';
+export type MessageCaptureMode = 'disabled' | 'clearOnly' | 'speakOnly' | 'speakAndClearOnly' | 'speakAny';
+export type TTSModelPreference = 'fast' | 'high_quality';
+
+export const DOUBLE_ENTER_TIMEOUT_MIN_MS = 1000;
+export const DOUBLE_ENTER_TIMEOUT_MAX_MS = 10000;
+
+export interface Settings {
+  textSize: TextSize;
+  speechRate: number;
+  speechPitch: number;
+  speechVolume: number;
+  speechVoice: string;
+  enterKeyBehavior: EnterKeyBehavior;
+  doubleEnterEnabled: boolean;
+  doubleEnterAction: EnterKeyBehavior;
+  doubleEnterTimeoutMs: number;
+  ttsProvider: TTSProviderType;
+  ttsVoiceId: string;
+  ttsStability: number;
+  ttsSimilarityBoost: number;
+  ttsModelPreference: TTSModelPreference;
+  aiReplySuggestionsEnabled: boolean;
+  messageCaptureMode: MessageCaptureMode;
+  usePhraseBar: boolean;
+  speakPhrasesOnTap: boolean;
+}
+
+export interface UIPreferences {
+  typingAreaVisible: boolean;
+  typingAreaExpanded: boolean;
+  selectedBoardId: string | null;
+  typingShareFontSize: number;
+  activeTypingTabId: string | null;
+  typingDockMode: TypingDockMode;
+}
+
+export type AllSettings = Settings & UIPreferences;
+
+export interface SettingsContextType {
+  settings: Settings;
+  uiPreferences: UIPreferences;
+  isLoading: boolean;
+  isSyncing: boolean;
+  updateSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  updateUIPreference: <K extends keyof UIPreferences>(key: K, value: UIPreferences[K]) => void;
+}
+
+export const defaultSettings: Settings = {
+  textSize: 16,
+  speechRate: 1.0,
+  speechPitch: 1.0,
+  speechVolume: 1.0,
+  speechVoice: '',
+  enterKeyBehavior: 'newline',
+  doubleEnterEnabled: false,
+  doubleEnterAction: 'speak',
+  doubleEnterTimeoutMs: 1000,
+  ttsProvider: 'browser',
+  ttsVoiceId: '',
+  ttsStability: 0.5,
+  ttsSimilarityBoost: 0.5,
+  ttsModelPreference: 'fast',
+  aiReplySuggestionsEnabled: true,
+  messageCaptureMode: 'speakOnly',
+  usePhraseBar: false,
+  speakPhrasesOnTap: false,
+};
+
+export const defaultUIPreferences: UIPreferences = {
+  typingAreaVisible: true,
+  typingAreaExpanded: false,
+  selectedBoardId: null,
+  typingShareFontSize: 18,
+  activeTypingTabId: null,
+  typingDockMode: 'expanded',
+};
+
+export const defaultAllSettings: AllSettings = {
+  ...defaultSettings,
+  ...defaultUIPreferences,
+};
+
+export function normalizeTextSize(value: number | string): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const enumMap: Record<string, number> = {
+    small: 12,
+    medium: 16,
+    large: 24,
+    xlarge: 32,
+  };
+
+  return enumMap[value] ?? defaultSettings.textSize;
+}
+
+export function normalizeDoubleEnterTimeout(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return defaultSettings.doubleEnterTimeoutMs;
+  }
+
+  return Math.max(
+    DOUBLE_ENTER_TIMEOUT_MIN_MS,
+    Math.min(DOUBLE_ENTER_TIMEOUT_MAX_MS, value as number)
+  );
+}
+
+export function isTypingDockMode(value: unknown): value is TypingDockMode {
+  return value === 'expanded' || value === 'fullscreen' || value === 'minimized';
+}
+
+export function pickSettings(allSettings: AllSettings): Settings {
+  return {
+    textSize: allSettings.textSize,
+    speechRate: allSettings.speechRate,
+    speechPitch: allSettings.speechPitch,
+    speechVolume: allSettings.speechVolume,
+    speechVoice: allSettings.speechVoice,
+    enterKeyBehavior: allSettings.enterKeyBehavior,
+    doubleEnterEnabled: allSettings.doubleEnterEnabled,
+    doubleEnterAction: allSettings.doubleEnterAction,
+    doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(allSettings.doubleEnterTimeoutMs),
+    ttsProvider: allSettings.ttsProvider,
+    ttsVoiceId: allSettings.ttsVoiceId,
+    ttsStability: allSettings.ttsStability,
+    ttsSimilarityBoost: allSettings.ttsSimilarityBoost,
+    ttsModelPreference: allSettings.ttsModelPreference,
+    aiReplySuggestionsEnabled: allSettings.aiReplySuggestionsEnabled,
+    messageCaptureMode: allSettings.messageCaptureMode,
+    usePhraseBar: allSettings.usePhraseBar,
+    speakPhrasesOnTap: allSettings.speakPhrasesOnTap,
+  };
+}
+
+export function pickUIPreferences(allSettings: AllSettings): UIPreferences {
+  return {
+    typingAreaVisible: allSettings.typingAreaVisible,
+    typingAreaExpanded: allSettings.typingAreaExpanded,
+    selectedBoardId: allSettings.selectedBoardId,
+    typingShareFontSize: allSettings.typingShareFontSize,
+    activeTypingTabId: allSettings.activeTypingTabId,
+    typingDockMode: allSettings.typingDockMode,
+  };
+}

--- a/apps/web/app/contexts/settings/useSettingsSync.ts
+++ b/apps/web/app/contexts/settings/useSettingsSync.ts
@@ -1,0 +1,217 @@
+'use client';
+
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import {
+  defaultSettings,
+  defaultUIPreferences,
+  isTypingDockMode,
+  normalizeDoubleEnterTimeout,
+  normalizeTextSize,
+  type AllSettings,
+  type EnterKeyBehavior,
+  type MessageCaptureMode,
+  type Settings,
+  type TTSModelPreference,
+  type UIPreferences,
+} from './types';
+import {
+  loadSettingsFromLocalStorage,
+  saveSettingsToLocalStorage,
+} from './storage';
+
+type AuthUser = {
+  id?: string;
+} | null | undefined;
+
+type ConvexSettings = {
+  textSize: number | string;
+  speechRate: number;
+  speechPitch: number;
+  speechVolume: number;
+  speechVoice: string;
+  enterKeyBehavior: EnterKeyBehavior;
+  doubleEnterEnabled?: boolean;
+  doubleEnterAction?: EnterKeyBehavior;
+  doubleEnterTimeoutMs?: number;
+  ttsProvider: Settings['ttsProvider'];
+  ttsVoiceId: string;
+  ttsStability: number;
+  ttsSimilarityBoost: number;
+  ttsModelPreference?: TTSModelPreference;
+  aiReplySuggestionsEnabled?: boolean;
+  messageCaptureMode?: MessageCaptureMode;
+  usePhraseBar?: boolean;
+  speakPhrasesOnTap?: boolean;
+  typingAreaVisible: boolean;
+  typingAreaExpanded: boolean;
+  selectedBoardId?: string;
+  typingShareFontSize: number;
+  activeTypingTabId?: string;
+  typingDockMode?: string;
+};
+
+type UseSettingsSyncOptions = {
+  user: AuthUser;
+  setAllSettings: Dispatch<SetStateAction<AllSettings>>;
+};
+
+function buildInitializeSettingsPayload(localSettings: AllSettings) {
+  return {
+    textSize: localSettings.textSize,
+    speechRate: localSettings.speechRate,
+    speechPitch: localSettings.speechPitch,
+    speechVolume: localSettings.speechVolume,
+    speechVoice: localSettings.speechVoice,
+    enterKeyBehavior: localSettings.enterKeyBehavior,
+    doubleEnterEnabled: localSettings.doubleEnterEnabled,
+    doubleEnterAction: localSettings.doubleEnterAction,
+    doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(localSettings.doubleEnterTimeoutMs),
+    ttsProvider: localSettings.ttsProvider,
+    ttsVoiceId: localSettings.ttsVoiceId,
+    ttsStability: localSettings.ttsStability,
+    ttsSimilarityBoost: localSettings.ttsSimilarityBoost,
+    ttsModelPreference: localSettings.ttsModelPreference,
+    aiReplySuggestionsEnabled: localSettings.aiReplySuggestionsEnabled,
+    messageCaptureMode: localSettings.messageCaptureMode,
+    usePhraseBar: localSettings.usePhraseBar,
+    speakPhrasesOnTap: localSettings.speakPhrasesOnTap,
+    typingAreaVisible: localSettings.typingAreaVisible,
+    typingAreaExpanded: localSettings.typingAreaExpanded,
+    selectedBoardId: localSettings.selectedBoardId ?? undefined,
+    typingShareFontSize: localSettings.typingShareFontSize,
+    activeTypingTabId: localSettings.activeTypingTabId ?? undefined,
+    typingDockMode: localSettings.typingDockMode,
+  };
+}
+
+function mergeConvexSettings(convexSettings: ConvexSettings): AllSettings {
+  return {
+    textSize: normalizeTextSize(convexSettings.textSize),
+    speechRate: convexSettings.speechRate,
+    speechPitch: convexSettings.speechPitch,
+    speechVolume: convexSettings.speechVolume,
+    speechVoice: convexSettings.speechVoice,
+    enterKeyBehavior: convexSettings.enterKeyBehavior,
+    doubleEnterEnabled: convexSettings.doubleEnterEnabled ?? defaultSettings.doubleEnterEnabled,
+    doubleEnterAction: convexSettings.doubleEnterAction ?? defaultSettings.doubleEnterAction,
+    doubleEnterTimeoutMs: normalizeDoubleEnterTimeout(
+      convexSettings.doubleEnterTimeoutMs ?? defaultSettings.doubleEnterTimeoutMs
+    ),
+    ttsProvider: convexSettings.ttsProvider,
+    ttsVoiceId: convexSettings.ttsVoiceId,
+    ttsStability: convexSettings.ttsStability,
+    ttsSimilarityBoost: convexSettings.ttsSimilarityBoost,
+    ttsModelPreference: convexSettings.ttsModelPreference ?? defaultSettings.ttsModelPreference,
+    aiReplySuggestionsEnabled: convexSettings.aiReplySuggestionsEnabled ?? defaultSettings.aiReplySuggestionsEnabled,
+    messageCaptureMode: convexSettings.messageCaptureMode ?? defaultSettings.messageCaptureMode,
+    usePhraseBar: convexSettings.usePhraseBar ?? defaultSettings.usePhraseBar,
+    speakPhrasesOnTap: convexSettings.speakPhrasesOnTap ?? defaultSettings.speakPhrasesOnTap,
+    typingAreaVisible: convexSettings.typingAreaVisible,
+    typingAreaExpanded: convexSettings.typingAreaExpanded,
+    selectedBoardId: convexSettings.selectedBoardId ?? null,
+    typingShareFontSize: convexSettings.typingShareFontSize,
+    activeTypingTabId: convexSettings.activeTypingTabId ?? null,
+    typingDockMode: isTypingDockMode(convexSettings.typingDockMode)
+      ? convexSettings.typingDockMode
+      : defaultUIPreferences.typingDockMode,
+  };
+}
+
+export function useSettingsSync({
+  user,
+  setAllSettings,
+}: UseSettingsSyncOptions) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [hasMigrated, setHasMigrated] = useState(false);
+
+  const convexSettings = useQuery(api.userSettings.getUserSettings, user ? {} : 'skip');
+  const initializeSettings = useMutation(api.userSettings.initializeSettings);
+  const updateSettingsMutation = useMutation(api.userSettings.updateSettings);
+
+  useEffect(() => {
+    if (!user) {
+      setIsLoading(false);
+      setHasMigrated(false);
+      return;
+    }
+
+    if (convexSettings === undefined) {
+      setIsLoading(true);
+      return;
+    }
+
+    if (convexSettings === null && !hasMigrated) {
+      setIsLoading(true);
+      const localSettings = loadSettingsFromLocalStorage();
+
+      initializeSettings(buildInitializeSettingsPayload(localSettings))
+        .then(() => {
+          console.log('Settings migrated to Convex successfully');
+          setHasMigrated(true);
+          setIsLoading(false);
+        })
+        .catch((error) => {
+          console.error('Failed to migrate settings to Convex:', error);
+          setIsLoading(false);
+        });
+      return;
+    }
+
+    if (convexSettings) {
+      const serverSettings = mergeConvexSettings(convexSettings as ConvexSettings);
+
+      setAllSettings(serverSettings);
+      saveSettingsToLocalStorage(serverSettings);
+      setIsLoading(false);
+      setHasMigrated(true);
+    }
+  }, [user, convexSettings, hasMigrated, initializeSettings, setAllSettings]);
+
+  const syncSetting = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
+    if (!user) return;
+
+    setIsSyncing(true);
+    updateSettingsMutation({
+      [key]: value,
+      lastSyncedAt: Date.now(),
+    })
+      .then(() => {
+        setIsSyncing(false);
+      })
+      .catch((error) => {
+        console.error('Failed to sync setting to Convex:', error);
+        setIsSyncing(false);
+      });
+  }, [user, updateSettingsMutation]);
+
+  const syncUIPreference = useCallback(<K extends keyof UIPreferences>(
+    key: K,
+    value: UIPreferences[K]
+  ) => {
+    if (!user) return;
+
+    setIsSyncing(true);
+    const convexValue = value === null ? undefined : value;
+    updateSettingsMutation({
+      [key]: convexValue,
+      lastSyncedAt: Date.now(),
+    })
+      .then(() => {
+        setIsSyncing(false);
+      })
+      .catch((error) => {
+        console.error('Failed to sync UI preference to Convex:', error);
+        setIsSyncing(false);
+      });
+  }, [user, updateSettingsMutation]);
+
+  return {
+    isLoading,
+    isSyncing,
+    syncSetting,
+    syncUIPreference,
+  };
+}

--- a/apps/web/tests/contexts/settingsStorage.test.ts
+++ b/apps/web/tests/contexts/settingsStorage.test.ts
@@ -1,0 +1,93 @@
+import {
+  loadSettingsFromLocalStorage,
+  saveSettingsToLocalStorage,
+} from '@/app/contexts/settings/storage';
+import {
+  defaultAllSettings,
+  type AllSettings,
+} from '@/app/contexts/settings/types';
+
+function createStorage(initial: Record<string, string> = {}): Storage {
+  let store = { ...initial };
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    key: jest.fn((index: number) => Object.keys(store)[index] ?? null),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+}
+
+describe('settings storage helpers', () => {
+  it('falls back to defaults when stored settings JSON is malformed', () => {
+    const storage = createStorage({
+      settings: '{not-json',
+      typingAreaVisible: 'not-json',
+      'typing-share-font-size': 'bad',
+      typingDockMode: 'invalid',
+    });
+
+    const loaded = loadSettingsFromLocalStorage(storage);
+
+    expect(loaded.textSize).toBe(defaultAllSettings.textSize);
+    expect(loaded.typingAreaVisible).toBe(defaultAllSettings.typingAreaVisible);
+    expect(loaded.typingShareFontSize).toBe(defaultAllSettings.typingShareFontSize);
+    expect(loaded.typingDockMode).toBe(defaultAllSettings.typingDockMode);
+  });
+
+  it('normalizes legacy and bounded setting values from storage', () => {
+    const storage = createStorage({
+      settings: JSON.stringify({
+        textSize: 'large',
+        doubleEnterTimeoutMs: 20000,
+      }),
+      typingAreaVisible: 'false',
+      typingAreaExpanded: 'true',
+      'typing-share-font-size': '100',
+      typingDockMode: 'fullscreen',
+    });
+
+    const loaded = loadSettingsFromLocalStorage(storage);
+
+    expect(loaded.textSize).toBe(24);
+    expect(loaded.doubleEnterTimeoutMs).toBe(10000);
+    expect(loaded.typingAreaVisible).toBe(false);
+    expect(loaded.typingAreaExpanded).toBe(true);
+    expect(loaded.typingShareFontSize).toBe(64);
+    expect(loaded.typingDockMode).toBe('fullscreen');
+  });
+
+  it('persists settings and removes nullable preference keys when cleared', () => {
+    const storage = createStorage({
+      selectedBoardId: 'old-board',
+      activeTypingTabId: 'old-tab',
+    });
+    const settings: AllSettings = {
+      ...defaultAllSettings,
+      textSize: 32,
+      selectedBoardId: null,
+      activeTypingTabId: null,
+      typingDockMode: 'minimized',
+    };
+
+    saveSettingsToLocalStorage(settings, storage);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'settings',
+      expect.stringContaining('"textSize":32')
+    );
+    expect(storage.removeItem).toHaveBeenCalledWith('selectedBoardId');
+    expect(storage.removeItem).toHaveBeenCalledWith('activeTypingTabId');
+    expect(storage.setItem).toHaveBeenCalledWith('typingDockMode', 'minimized');
+  });
+});


### PR DESCRIPTION
## Summary
- move settings types, defaults, normalization, and context value selectors into a dedicated settings module
- move localStorage read/write and defensive parsing into a storage helper
- extract Convex migration and sync behavior into useSettingsSync while keeping useSettings() API stable
- add storage helper tests for malformed localStorage and value normalization

Closes #653

## Verification
- pnpm --filter @sayit/web test -- --runInBand tests/contexts/settingsStorage.test.ts
- pnpm --filter @sayit/web lint
- pnpm --filter @sayit/web build
- pnpm --filter @sayit/web test -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured settings management for improved server synchronization and local storage persistence
  * Enhanced settings persistence with validation and normalization of user preferences (text size, typing modes, enter key behavior)
  * Settings now reliably sync between local storage and server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->