### PR TITLE
Regenerate Convex api.d.ts for boardTileHydration

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as aacLayout from "../aacLayout.js";
 import type * as audio from "../audio.js";
 import type * as audioLimits from "../audioLimits.js";
 import type * as boardAccess from "../boardAccess.js";
+import type * as boardTileHydration from "../boardTileHydration.js";
 import type * as boardTiles from "../boardTiles.js";
 import type * as caregiverClients from "../caregiverClients.js";
 import type * as connectionRequests from "../connectionRequests.js";
@@ -38,6 +39,7 @@ declare const fullApi: ApiFromModules<{
   audio: typeof audio;
   audioLimits: typeof audioLimits;
   boardAccess: typeof boardAccess;
+  boardTileHydration: typeof boardTileHydration;
   boardTiles: typeof boardTiles;
   caregiverClients: typeof caregiverClients;
   connectionRequests: typeof connectionRequests;


### PR DESCRIPTION
## Summary
- The `boardTileHydration` Convex module was added in `f31505a` but the generated `apps/web/convex/_generated/api.d.ts` was not refreshed at the time.
- Re-running `npx convex dev --once` adds the missing import so the typed API matches the deployed function set.

## Test plan
- [x] `npx convex dev --once` reports `Convex functions ready!` with no schema errors.
- [ ] CI build passes.