### PR TITLE
release: v4.1.0

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary
- Version bump to **v4.1.0** in lockstep across `package.json`, `apps/web/package.json`, and `apps/landing/package.json`.
- Closes milestone [v4.1.0](https://github.com/enaboapps/sayit-web/milestone/118) (14 issues).

## Pre-release checks
- [x] `pnpm test` — 449 / 449 passing
- [x] `pnpm lint` — clean (web + landing)
- [x] `pnpm build` — passing on prior PR (#678)

## Post-merge
- Tag `v4.1.0` on `main` to trigger the Release workflow (Convex deploy, web deploy, landing deploy, GitHub Release).
- Close milestone v4.1.0 (#118).