### PR TITLE
release: v4.2.0

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/tests/components/Composer.test.tsx
+++ b/apps/web/tests/components/Composer.test.tsx
@@ -14,7 +14,11 @@ jest.mock('nanoid', () => {
   };
 });
 
-const mockUpdateSettingsMutation = jest.fn();
+// Return a resolved promise so the debounced `.catch(...)` in useTypingTabs'
+// setTimeout doesn't throw "Cannot read properties of undefined (reading
+// 'catch')" when the timer fires after a test has unmounted. Without this the
+// suite is flaky depending on jest worker scheduling.
+const mockUpdateSettingsMutation = jest.fn(() => Promise.resolve());
 jest.mock('convex/react', () => ({
   useMutation: jest.fn(() => mockUpdateSettingsMutation),
 }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary
- Version bump to **v4.2.0** in lockstep across `package.json`, `apps/web/package.json`, and `apps/landing/package.json`.
- Includes a flake fix in `tests/components/Composer.test.tsx` exposed when running `pnpm test` for this release: `mockUpdateSettingsMutation` now returns `Promise.resolve()` so the debounced `useTypingTabs` `.catch(...)` doesn't throw based on jest worker scheduling.
- Closes milestone [v4.2.0](https://github.com/enaboapps/sayit-web/milestone/119).

## Headline change in this release
- #680 / #681 — Signed-out home page redesigned as a polished conversion landing; new `/try` route hosts the Composer for guests.

## Pre-release checks
- [x] `pnpm test` — 464 / 464 passing (run twice for stability)
- [x] `pnpm lint` — clean (web + landing)

## Post-merge
- Tag `v4.2.0` on `main` to trigger the Release workflow (Convex deploy, web deploy, landing deploy, GitHub Release).
- Close milestone v4.2.0 (#119).