### PR TITLE
Fan TTS callbacks out to multiple useTTS subscribers

### DIFF
--- a/apps/web/lib/hooks/useOfflineTTS.ts
+++ b/apps/web/lib/hooks/useOfflineTTS.ts
@@ -12,14 +12,17 @@ export function useOfflineTTS() {
     if (!ttsRef.current) {
       ttsRef.current = TTSProvider.getInstance();
       ttsRef.current.setProvider('browser');
-      ttsRef.current.setCallbacks({
-        onStart: () => setIsSpeaking(true),
-        onEnd: () => setIsSpeaking(false),
-        onError: () => setIsSpeaking(false),
-      });
     }
 
     setIsAvailable(ttsRef.current.getStatus().browserTTSAvailable);
+
+    const unsubscribe = ttsRef.current.addCallbacks({
+      onStart: () => setIsSpeaking(true),
+      onEnd: () => setIsSpeaking(false),
+      onError: () => setIsSpeaking(false),
+    });
+
+    return unsubscribe;
   }, []);
 
   const speak = useCallback((text: string) => {

--- a/apps/web/lib/hooks/useTTS.ts
+++ b/apps/web/lib/hooks/useTTS.ts
@@ -49,37 +49,36 @@ export function useTTS() {
   }, [settings.ttsProvider]);
 
   useEffect(() => {
-    // Initialize only once
     if (!ttsRef.current) {
       ttsRef.current = TTSProvider.getInstance();
-      
-      const tts = ttsRef.current;
 
+      const tts = ttsRef.current;
       tts.setProvider(settingsRef.current.ttsProvider);
-      
-      // Set initial state
+
       setIsAvailable(tts.isAvailable());
       setProvider(tts.getCurrentProvider());
       setStatus(tts.getStatus());
       setVoices(tts.getAllVoices());
-  
-      // Set callbacks for updates
-      tts.setCallbacks({
-        onStart: () => setIsSpeaking(true),
-        onEnd: () => setIsSpeaking(false),
-        onError: (error) => {
-          console.error('TTS Error:', error);
-          setIsSpeaking(false);
-        },
-        onVoicesChanged: (newVoices) => {
-          setVoices(newVoices);
-          setStatus(tts.getStatus());
-        },
-        onWordBoundary: (word, charIndex) => {
-          setWordBoundary({ word, charIndex });
-        },
-      });
     }
+
+    const tts = ttsRef.current;
+    const unsubscribe = tts.addCallbacks({
+      onStart: () => setIsSpeaking(true),
+      onEnd: () => setIsSpeaking(false),
+      onError: (error) => {
+        console.error('TTS Error:', error);
+        setIsSpeaking(false);
+      },
+      onVoicesChanged: (newVoices) => {
+        setVoices(newVoices);
+        setStatus(tts.getStatus());
+      },
+      onWordBoundary: (word, charIndex) => {
+        setWordBoundary({ word, charIndex });
+      },
+    });
+
+    return unsubscribe;
   }, []);
 
   const speak = useCallback((text: string, customOptions?: {

--- a/apps/web/lib/tts-provider.ts
+++ b/apps/web/lib/tts-provider.ts
@@ -5,6 +5,14 @@ import { TextToSpeech as WebSpeechTTS } from './tts';
 
 export type TTSProviderType = 'browser' | 'elevenlabs' | 'azure' | 'gemini';
 
+export interface TTSCallbacks {
+  onStart?: () => void;
+  onEnd?: () => void;
+  onError?: (error: Error) => void;
+  onVoicesChanged?: (voices: TTSVoice[]) => void;
+  onWordBoundary?: (word: string, charIndex: number) => void;
+}
+
 export interface TTSVoice {
   id: string;
   name: string;
@@ -34,13 +42,10 @@ export class TTSProvider {
   private webSpeechTTS: WebSpeechTTS;
   private activeProvider: TTSProviderType = 'browser';
   private isSpeaking: boolean = false;
-  private callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: TTSVoice[]) => void;
-    onWordBoundary?: (word: string, charIndex: number) => void;
-  } = {};
+  // Fan-out set so multiple `useTTS()` callers can each receive the same
+  // start/end events. A single-slot callbacks object would let whichever
+  // hook subscribed last silently shadow the others.
+  private callbackSubscribers = new Set<TTSCallbacks>();
 
   private constructor() {
     this.webSpeechTTS = WebSpeechTTS.getInstance();
@@ -62,40 +67,50 @@ export class TTSProvider {
     return TTSProvider.instance;
   }
 
+  private emit<K extends keyof TTSCallbacks>(
+    event: K,
+    ...args: Parameters<NonNullable<TTSCallbacks[K]>>
+  ) {
+    this.callbackSubscribers.forEach((subscriber) => {
+      const handler = subscriber[event] as ((...a: typeof args) => void) | undefined;
+      handler?.(...args);
+    });
+  }
+
   private makeProviderCallbacks(onVoicesChanged?: () => void) {
     return {
-      onStart: () => { this.isSpeaking = true; this.callbacks.onStart?.(); },
-      onEnd: () => { this.isSpeaking = false; this.callbacks.onEnd?.(); },
-      onError: (error: Error) => { this.isSpeaking = false; this.callbacks.onError?.(error); },
+      onStart: () => { this.isSpeaking = true; this.emit('onStart'); },
+      onEnd: () => { this.isSpeaking = false; this.emit('onEnd'); },
+      onError: (error: Error) => { this.isSpeaking = false; this.emit('onError', error); },
       ...(onVoicesChanged ? { onVoicesChanged } : {}),
     };
   }
 
   private setupCallbacks() {
-    const onVoicesChanged = () => this.callbacks.onVoicesChanged?.(this.getAllVoices());
+    const onVoicesChanged = () => this.emit('onVoicesChanged', this.getAllVoices());
 
     this.webSpeechTTS.setCallbacks({
       ...this.makeProviderCallbacks(onVoicesChanged),
-      onWordBoundary: (word, charIndex) => this.callbacks.onWordBoundary?.(word, charIndex),
+      onWordBoundary: (word, charIndex) => this.emit('onWordBoundary', word, charIndex),
     });
     this.elevenlabsTTS.setCallbacks(this.makeProviderCallbacks(onVoicesChanged));
     this.azureTTS.setCallbacks(this.makeProviderCallbacks(onVoicesChanged));
     this.geminiTTS.setCallbacks(this.makeProviderCallbacks(onVoicesChanged));
   }
 
-  public setCallbacks(callbacks: {
-    onStart?: () => void;
-    onEnd?: () => void;
-    onError?: (error: Error) => void;
-    onVoicesChanged?: (voices: TTSVoice[]) => void;
-    onWordBoundary?: (word: string, charIndex: number) => void;
-  }) {
-    this.callbacks = callbacks;
-    
-    // Immediately notify about available voices
+  public addCallbacks(callbacks: TTSCallbacks): () => void {
+    this.callbackSubscribers.add(callbacks);
+
+    // Match the old setCallbacks behavior of immediately notifying new
+    // subscribers about the current voice list so React state can hydrate
+    // without waiting for a real provider voiceschanged event.
     if (callbacks.onVoicesChanged) {
       callbacks.onVoicesChanged(this.getAllVoices());
     }
+
+    return () => {
+      this.callbackSubscribers.delete(callbacks);
+    };
   }
 
   public setProvider(provider: TTSProviderType) {
@@ -182,22 +197,22 @@ export class TTSProvider {
 
   public refreshVoices() {
     this.webSpeechTTS.refreshVoices();
-    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+    this.emit('onVoicesChanged', this.getAllVoices());
   }
 
   public async loadElevenLabsVoices() {
     await this.elevenlabsTTS.loadVoices();
-    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+    this.emit('onVoicesChanged', this.getAllVoices());
   }
 
   public async loadAzureVoices() {
     await this.azureTTS.loadVoices();
-    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+    this.emit('onVoicesChanged', this.getAllVoices());
   }
 
   public async loadGeminiVoices() {
     await this.geminiTTS.loadVoices();
-    this.callbacks.onVoicesChanged?.(this.getAllVoices());
+    this.emit('onVoicesChanged', this.getAllVoices());
   }
 
   public speak(text: string, options?: {

--- a/apps/web/tests/lib/hooks/useTTS.test.ts
+++ b/apps/web/tests/lib/hooks/useTTS.test.ts
@@ -30,7 +30,7 @@ const mockTTSProvider = {
     geminiVoicesLoaded: true,
   })),
   getAllVoices: jest.fn(() => []),
-  setCallbacks: jest.fn(),
+  addCallbacks: jest.fn(() => () => {}),
   setProvider: jest.fn((provider: MockProvider) => {
     mockCurrentProvider = provider;
   }),

--- a/apps/web/tests/lib/tts-provider.test.ts
+++ b/apps/web/tests/lib/tts-provider.test.ts
@@ -122,3 +122,56 @@ describe('TTSProvider status', () => {
     }));
   });
 });
+
+describe('TTSProvider subscribers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (TTSProvider as unknown as { instance?: TTSProvider }).instance = undefined;
+    mockElevenLabsAvailable = false;
+    mockAzureAvailable = false;
+    mockGeminiAvailable = false;
+    mockElevenLabsLoaded = false;
+    mockAzureLoaded = false;
+    mockGeminiLoaded = false;
+  });
+
+  it('fans onStart/onEnd out to every subscriber', () => {
+    const provider = TTSProvider.getInstance();
+    const onStartA = jest.fn();
+    const onEndA = jest.fn();
+    const onStartB = jest.fn();
+    const onEndB = jest.fn();
+
+    provider.addCallbacks({ onStart: onStartA, onEnd: onEndA });
+    provider.addCallbacks({ onStart: onStartB, onEnd: onEndB });
+
+    // TTSProvider's constructor wires browserTTS.setCallbacks during setupCallbacks.
+    // Grab the wrapped onStart/onEnd it registered and invoke them as the browser
+    // TTS would when a real utterance fires.
+    const wrapped = mockBrowserTTS.setCallbacks.mock.calls[0][0];
+    wrapped.onStart();
+    wrapped.onEnd();
+
+    expect(onStartA).toHaveBeenCalledTimes(1);
+    expect(onStartB).toHaveBeenCalledTimes(1);
+    expect(onEndA).toHaveBeenCalledTimes(1);
+    expect(onEndB).toHaveBeenCalledTimes(1);
+  });
+
+  it('addCallbacks returns an unsubscribe that detaches that subscriber only', () => {
+    const provider = TTSProvider.getInstance();
+    const onStartA = jest.fn();
+    const onStartB = jest.fn();
+
+    const unsubscribeA = provider.addCallbacks({ onStart: onStartA });
+    provider.addCallbacks({ onStart: onStartB });
+
+    unsubscribeA();
+
+    const wrapped = mockBrowserTTS.setCallbacks.mock.calls[0][0];
+    wrapped.onStart();
+
+    expect(onStartA).not.toHaveBeenCalled();
+    expect(onStartB).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `TTSProvider` had a single `callbacks` slot; `setCallbacks` replaced it, so when both `PhrasesInterface` and `PhraseBar` called `useTTS()` the last one shadowed the first. `PhrasesInterface`'s `isSpeaking` stayed `false` while audio played, so phrase tiles never showed the amber border + pulsing stop badge.
- Replaced with `addCallbacks(cb): () => void` that adds to a `Set<TTSCallbacks>`. Inner-provider events fan out to every subscriber via a typed `emit()` helper. `useTTS` and `useOfflineTTS` subscribe in their mount effect and return the unsubscribe.

Closes #683.

## Test plan

- [x] `pnpm test` (466/466 pass, including new `addCallbacks` tests covering fan-out and unsubscribe)
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] Manual: tap a phrase tile in legacy mode — confirm tile shows speaking border + pulsing stop badge for the duration of speech, then clears
- [ ] Manual: enable phrase-bar mode with `speakPhrasesOnTap=true` — confirm tile indicator still appears on tap
- [ ] Manual: Composer Speak ↔ Stop toggles reliably whether or not the PhraseBar is rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced text-to-speech event system to support multiple simultaneous listeners with improved cleanup and resource management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enaboapps/sayit-web/pull/684)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->