### PR TITLE
release: v4.2.1

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to v4.2.1 in workspace root, `apps/web`, and `apps/landing` `package.json`.

## Included in this release

- #683 Phrase tile speaking indicator no longer appears when audio is playing (PR #684)

Milestone: v4.2.1