### PR TITLE
Replace composer action rail with radial flyout wheel

### DIFF
--- a/apps/web/app/components/composer/Composer.tsx
+++ b/apps/web/app/components/composer/Composer.tsx
@@ -165,8 +165,11 @@ export default function Composer({
           </div>
         )}
 
-        {/* Main body: textarea + sidebar */}
-        <div className="flex flex-1 min-h-0">
+        {/* Main body: full-width textarea with floating action overlays.
+            The min height guarantees room for the top-right trigger plus the
+            bottom-right Clear/Speak stack even when the parent gives the
+            composer no height of its own (e.g. /try). */}
+        <div className="relative flex flex-1 min-h-[220px]">
           <ComposerTextarea
             currentText={currentText}
             onTextChange={handleTextChange}
@@ -179,42 +182,39 @@ export default function Composer({
             onBlur={() => captureSnapshot()}
           />
 
-          {/* Sidebar with suggestions popover anchor */}
-          <div className="relative shrink-0">
-            <ComposerSidebar
-              currentText={currentText}
-              onClear={actions.handleClear}
-              onSpeak={() => onSpeak('speak')}
-              onStop={onStop}
-              onToneSelected={actions.handleToneSelected}
-              isSpeaking={isSpeaking}
-              isAvailable={isAvailable}
-              enableFixText={enableFixText}
-              isOnline={actions.isOnline}
-              isFixingText={actions.isFixingText}
-              onFixText={actions.handleFixText}
-              enableLiveTyping={enableLiveTyping}
-              isLiveTypingButtonActive={isLiveTypingButtonActive}
-              onShare={handleShare}
-              hasUser={!!actions.user}
-              onAddAsPhrase={onAddAsPhrase}
-              enableToneControl={enableToneControl}
-              suggestionsCount={suggestionsCount}
-              onSuggestionsOpen={() => setShowSuggestions(true)}
-              suggestionsEnabled={!!replySuggestions && !!actions.user && actions.isOnline}
-              onCopyPasteOpen={() => setCopyPasteOpen(true)}
+          <ComposerSidebar
+            currentText={currentText}
+            onClear={actions.handleClear}
+            onSpeak={() => onSpeak('speak')}
+            onStop={onStop}
+            onToneSelected={actions.handleToneSelected}
+            isSpeaking={isSpeaking}
+            isAvailable={isAvailable}
+            enableFixText={enableFixText}
+            isOnline={actions.isOnline}
+            isFixingText={actions.isFixingText}
+            onFixText={actions.handleFixText}
+            enableLiveTyping={enableLiveTyping}
+            isLiveTypingButtonActive={isLiveTypingButtonActive}
+            onShare={handleShare}
+            hasUser={!!actions.user}
+            onAddAsPhrase={onAddAsPhrase}
+            enableToneControl={enableToneControl}
+            suggestionsCount={suggestionsCount}
+            onSuggestionsOpen={() => setShowSuggestions(true)}
+            suggestionsEnabled={!!replySuggestions && !!actions.user && actions.isOnline}
+            onCopyPasteOpen={() => setCopyPasteOpen(true)}
+          />
+          {replySuggestions && (
+            <SuggestionsPopover
+              isOpen={showSuggestions}
+              onClose={() => setShowSuggestions(false)}
+              history={replySuggestions.history}
+              enabled={replySuggestions.enabled}
+              onSelectSuggestion={(s) => { replySuggestions.onSelect(s); setShowSuggestions(false); }}
+              onCountChange={setSuggestionsCount}
             />
-            {replySuggestions && (
-              <SuggestionsPopover
-                isOpen={showSuggestions}
-                onClose={() => setShowSuggestions(false)}
-                history={replySuggestions.history}
-                enabled={replySuggestions.enabled}
-                onSelectSuggestion={(s) => { replySuggestions.onSelect(s); setShowSuggestions(false); }}
-                onCountChange={setSuggestionsCount}
-              />
-            )}
-          </div>
+          )}
         </div>
 
         {/* Banners only */}

--- a/apps/web/app/components/composer/ComposerSidebar.tsx
+++ b/apps/web/app/components/composer/ComposerSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useState } from 'react';
 import {
   SparklesIcon,
   XMarkIcon,
@@ -15,6 +15,7 @@ import {
 import { AudioWaveform } from 'lucide-react';
 import SubscriptionWrapper from '../SubscriptionWrapper';
 import ToneSheet, { type TonePreset } from '../typing/ToneSheet';
+import RadialFlyout, { type RadialFlyoutItem } from './RadialFlyout';
 
 interface ComposerSidebarProps {
   currentText: string;
@@ -42,9 +43,9 @@ interface ComposerSidebarProps {
   onCopyPasteOpen: () => void;
 }
 
-// Shared base classes — every icon tile fills its grid cell as a square.
-const TILE_BASE =
-  'w-full aspect-square flex items-center justify-center transition-all disabled:opacity-30 disabled:cursor-not-allowed';
+// Shared base classes — round floating tiles used inside the radial wheel.
+const WHEEL_TILE =
+  'w-12 h-12 rounded-full shadow-lg flex items-center justify-center transition-all disabled:opacity-30 disabled:cursor-not-allowed';
 
 export default function ComposerSidebar({
   currentText,
@@ -70,32 +71,39 @@ export default function ComposerSidebar({
   onCopyPasteOpen,
 }: ComposerSidebarProps) {
   const [showToneSheet, setShowToneSheet] = useState(false);
+  const [isWheelOpen, setWheelOpen] = useState(false);
   const speakDisabled = !isAvailable || !currentText.trim();
   const clearDisabled = !currentText.trim();
-  const iconButtons: ReactNode[] = [];
+
+  // Close the wheel before firing an action so overlays (bottom sheets etc.)
+  // open on top of a settled composer.
+  const runAndClose = (action: () => void) => () => {
+    setWheelOpen(false);
+    action();
+  };
+
+  const wheelItems: RadialFlyoutItem[] = [];
 
   // Fix Text — purple tile (offline stub or subscription fallback variants)
   if (enableFixText) {
-    if (!isOnline) {
-      iconButtons.push(
+    wheelItems.push({
+      key: 'fix',
+      label: 'Fix Text',
+      content: !isOnline ? (
         <button
-          key="fix"
           type="button"
           disabled
-          className={`${TILE_BASE} bg-surface-hover text-text-tertiary opacity-40 cursor-not-allowed`}
+          className={`${WHEEL_TILE} bg-surface-hover text-text-tertiary opacity-40 cursor-not-allowed`}
           aria-label="Fix Text (offline)"
         >
           <SparklesIcon className="w-5 h-5" />
         </button>
-      );
-    } else {
-      iconButtons.push(
+      ) : (
         <SubscriptionWrapper
-          key="fix"
           fallback={
             <button
-              onClick={() => (window.location.href = '/pricing')}
-              className={`${TILE_BASE} bg-status-warning text-amber-400 hover:bg-warning hover:text-white`}
+              onClick={runAndClose(() => (window.location.href = '/pricing'))}
+              className={`${WHEEL_TILE} bg-status-warning text-amber-400 hover:bg-warning hover:text-white`}
               aria-label="Fix Text (upgrade)"
             >
               <SparklesIcon className="w-5 h-5" />
@@ -103,9 +111,9 @@ export default function ComposerSidebar({
           }
         >
           <button
-            onClick={onFixText}
+            onClick={runAndClose(onFixText)}
             disabled={!currentText.trim() || isFixingText}
-            className={`${TILE_BASE} ${
+            className={`${WHEEL_TILE} ${
               isFixingText
                 ? 'bg-gradient-to-br from-purple-500 to-purple-600 text-white'
                 : 'bg-status-purple text-purple-400 hover:bg-purple-600 hover:text-white'
@@ -115,97 +123,126 @@ export default function ComposerSidebar({
             {isFixingText ? <ArrowPathIcon className="w-5 h-5 animate-spin" /> : <SparklesIcon className="w-5 h-5" />}
           </button>
         </SubscriptionWrapper>
-      );
-    }
+      ),
+    });
   }
 
   // Live Typing — green tile (with active gradient and offline disabled states)
   if (enableLiveTyping && hasUser) {
-    iconButtons.push(
-      <button
-        key="live"
-        onClick={onShare}
-        disabled={!isOnline}
-        className={`${TILE_BASE} ${
-          !isOnline
-            ? 'bg-surface-hover text-text-tertiary opacity-40'
-            : isLiveTypingButtonActive
-              ? 'bg-gradient-to-br from-green-500 to-green-600 text-white'
-              : 'bg-status-success text-green-400 hover:bg-success hover:text-white'
-        }`}
-        aria-label={isLiveTypingButtonActive ? 'Live Typing Active' : 'Live Typing'}
-      >
-        <ShareIcon className="w-5 h-5" />
-      </button>
-    );
+    wheelItems.push({
+      key: 'live',
+      label: 'Live Typing',
+      content: (
+        <button
+          onClick={runAndClose(onShare)}
+          disabled={!isOnline}
+          className={`${WHEEL_TILE} ${
+            !isOnline
+              ? 'bg-surface-hover text-text-tertiary opacity-40'
+              : isLiveTypingButtonActive
+                ? 'bg-gradient-to-br from-green-500 to-green-600 text-white'
+                : 'bg-status-success text-green-400 hover:bg-success hover:text-white'
+          }`}
+          aria-label={isLiveTypingButtonActive ? 'Live Typing Active' : 'Live Typing'}
+        >
+          <ShareIcon className="w-5 h-5" />
+        </button>
+      ),
+    });
   }
 
   // Save as Phrase — blue tile
   if (onAddAsPhrase) {
-    iconButtons.push(
-      <button
-        key="save"
-        onClick={() => onAddAsPhrase(currentText)}
-        disabled={!currentText.trim()}
-        className={`${TILE_BASE} bg-status-info text-blue-400 hover:bg-blue-600 hover:text-white`}
-        aria-label="Save as phrase"
-      >
-        <BookmarkIcon className="w-5 h-5" />
-      </button>
-    );
+    wheelItems.push({
+      key: 'save',
+      label: 'Save as Phrase',
+      content: (
+        <button
+          onClick={runAndClose(() => onAddAsPhrase(currentText))}
+          disabled={!currentText.trim()}
+          className={`${WHEEL_TILE} bg-status-info text-blue-400 hover:bg-blue-600 hover:text-white`}
+          aria-label="Save as phrase"
+        >
+          <BookmarkIcon className="w-5 h-5" />
+        </button>
+      ),
+    });
   }
 
   // Suggestions — amber tile (with count badge)
   if (suggestionsEnabled) {
-    iconButtons.push(
-      <button
-        key="suggestions"
-        onClick={onSuggestionsOpen}
-        className={`${TILE_BASE} relative bg-status-warning text-amber-400 hover:bg-warning hover:text-white`}
-        aria-label="Suggestions"
-      >
-        <LightBulbIcon className="w-5 h-5" />
-        {suggestionsCount > 0 && (
-          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-primary-500 text-white text-[10px] font-bold px-1">
-            {suggestionsCount}
-          </span>
-        )}
-      </button>
-    );
+    wheelItems.push({
+      key: 'suggestions',
+      label: 'Suggestions',
+      content: (
+        <button
+          onClick={runAndClose(onSuggestionsOpen)}
+          className={`${WHEEL_TILE} relative bg-status-warning text-amber-400 hover:bg-warning hover:text-white`}
+          aria-label="Suggestions"
+        >
+          <LightBulbIcon className="w-5 h-5" />
+          {suggestionsCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-primary-500 text-white text-[10px] font-bold px-1">
+              {suggestionsCount}
+            </span>
+          )}
+        </button>
+      ),
+    });
   }
 
   // Copy / Paste — pink tile (a fifth accent so it's distinct from the others)
-  iconButtons.push(
-    <button
-      key="copy-paste"
-      onClick={onCopyPasteOpen}
-      className={`${TILE_BASE} bg-pink-950/40 text-pink-400 hover:bg-pink-600 hover:text-white`}
-      aria-label="Copy and paste"
-    >
-      <ClipboardIcon className="w-5 h-5" />
-    </button>
-  );
+  wheelItems.push({
+    key: 'copy-paste',
+    label: 'Copy & Paste',
+    content: (
+      <button
+        onClick={runAndClose(onCopyPasteOpen)}
+        className={`${WHEEL_TILE} bg-pink-950/40 text-pink-400 hover:bg-pink-600 hover:text-white`}
+        aria-label="Copy and paste"
+      >
+        <ClipboardIcon className="w-5 h-5" />
+      </button>
+    ),
+  });
 
-  // Balance the 2-column grid when an odd number of buttons rendered.
-  if (iconButtons.length % 2 === 1) {
-    iconButtons.push(<div key="placeholder" aria-hidden className="w-full aspect-square" />);
+  // Choose Tone — primary tile
+  if (enableToneControl) {
+    wheelItems.push({
+      key: 'tone',
+      label: 'Choose Tone',
+      content: (
+        <button
+          type="button"
+          onClick={runAndClose(() => setShowToneSheet(true))}
+          disabled={speakDisabled}
+          className={`${WHEEL_TILE} bg-primary-400 hover:bg-primary-500 text-white`}
+          aria-label="Choose tone"
+        >
+          <AudioWaveform className="w-5 h-5" />
+        </button>
+      ),
+    });
   }
 
   return (
-    <div className="flex flex-col border-l border-border shrink-0 h-full w-24">
-      {/* Icon tile grid */}
-      <div className="grid grid-cols-2 auto-rows-min">{iconButtons}</div>
+    <>
+      {/* Top-right trigger + quarter-circle action wheel */}
+      <RadialFlyout
+        items={wheelItems}
+        isOpen={isWheelOpen}
+        onOpen={() => setWheelOpen(true)}
+        onClose={() => setWheelOpen(false)}
+        triggerBadge={suggestionsEnabled ? suggestionsCount : 0}
+      />
 
-      {/* Spacer — pushes Speak to the bottom */}
-      <div className="flex-1" />
-
-      {/* Bottom stack — Clear on top, then Tone + Speak (or just Speak). Stop replaces all while speaking. */}
-      <div className="flex flex-col shrink-0">
+      {/* Bottom-right pinned stack — Clear above Speak. Stop replaces both while speaking. */}
+      <div className="absolute bottom-4 right-3 z-20 flex flex-col items-end gap-3">
         {isSpeaking ? (
           <button
             type="button"
             onClick={onStop}
-            className="w-full aspect-square flex items-center justify-center bg-error hover:bg-error-hover text-white transition-colors"
+            className="w-16 h-16 rounded-full shadow-lg flex items-center justify-center bg-error hover:bg-error-hover text-white transition-colors"
             aria-label="Stop"
           >
             <StopIcon className="w-8 h-8" />
@@ -216,43 +253,20 @@ export default function ComposerSidebar({
               type="button"
               onClick={onClear}
               disabled={clearDisabled}
-              className="w-full aspect-square flex items-center justify-center bg-status-error text-red-400 hover:bg-error hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              className="w-12 h-12 rounded-full shadow-lg flex items-center justify-center bg-status-error text-red-400 border border-border hover:bg-error hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed"
               aria-label="Clear"
             >
-              <XMarkIcon className="w-8 h-8" />
+              <XMarkIcon className="w-6 h-6" />
             </button>
-            {enableToneControl ? (
-              <div className="grid grid-cols-2">
-                <button
-                  type="button"
-                  onClick={() => setShowToneSheet(true)}
-                  disabled={speakDisabled}
-                  className="w-full aspect-square flex items-center justify-center bg-primary-400 hover:bg-primary-500 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                  aria-label="Choose tone"
-                >
-                  <AudioWaveform className="w-6 h-6" />
-                </button>
-                <button
-                  type="button"
-                  onClick={onSpeak}
-                  disabled={speakDisabled}
-                  className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                  aria-label="Speak"
-                >
-                  <SpeakerWaveIcon className="w-6 h-6" />
-                </button>
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={onSpeak}
-                disabled={speakDisabled}
-                className="w-full aspect-square flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                aria-label="Speak"
-              >
-                <SpeakerWaveIcon className="w-8 h-8" />
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={onSpeak}
+              disabled={speakDisabled}
+              className="w-16 h-16 rounded-full shadow-lg flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Speak"
+            >
+              <SpeakerWaveIcon className="w-8 h-8" />
+            </button>
           </>
         )}
       </div>
@@ -266,6 +280,6 @@ export default function ComposerSidebar({
           setShowToneSheet(false);
         }}
       />
-    </div>
+    </>
   );
 }

--- a/apps/web/app/components/composer/ComposerTextarea.tsx
+++ b/apps/web/app/components/composer/ComposerTextarea.tsx
@@ -35,7 +35,7 @@ export default function ComposerTextarea({
         onBlur={onBlur}
         onKeyDown={onKeyDown}
         placeholder="What do you want to say?"
-        className="absolute inset-0 overflow-y-auto bg-transparent text-foreground placeholder:text-text-tertiary px-6 py-5 resize-none focus:outline-none"
+        className="absolute inset-0 overflow-y-auto bg-transparent text-foreground placeholder:text-text-tertiary pl-6 pr-20 py-5 resize-none focus:outline-none"
         style={{ fontSize: `${textSizePx}px`, lineHeight: '1.6' }}
       />
     </div>

--- a/apps/web/app/components/composer/RadialFlyout.tsx
+++ b/apps/web/app/components/composer/RadialFlyout.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useRef, type ReactNode } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Squares2X2Icon, XMarkIcon } from '@heroicons/react/24/outline';
+
+export interface RadialFlyoutItem {
+  key: string;
+  /** Short label shown next to the tile while the wheel is open. */
+  label: string;
+  /**
+   * The tile button itself (may be wrapped, e.g. in SubscriptionWrapper).
+   * The caller is responsible for closing the wheel in the button's onClick.
+   */
+  content: ReactNode;
+}
+
+interface RadialFlyoutProps {
+  items: RadialFlyoutItem[];
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  /** Count badge shown on the closed trigger (e.g. available suggestions). */
+  triggerBadge?: number;
+}
+
+/**
+ * Position of an item along a quarter-circle arc fanning out from the
+ * trigger: from straight down (90deg) to straight left (180deg), in screen
+ * coordinates (y grows downward). A single item sits at the 135deg midpoint.
+ */
+function itemPosition(index: number, count: number, radius: number) {
+  const angle =
+    count === 1
+      ? (3 * Math.PI) / 4
+      : Math.PI / 2 + (Math.PI / 2) * (index / (count - 1));
+  return {
+    x: Math.cos(angle) * radius,
+    y: Math.sin(angle) * radius,
+    // Unit vector pointing outward from the trigger, used to place labels
+    // on the far side of each tile so they never overlap neighboring tiles.
+    outX: Math.cos(angle),
+    outY: Math.sin(angle),
+  };
+}
+
+const LABEL_OFFSET = 46;
+
+export default function RadialFlyout({
+  items,
+  isOpen,
+  onOpen,
+  onClose,
+  triggerBadge = 0,
+}: RadialFlyoutProps) {
+  const wheelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Larger wheels need a bigger radius so 48px tiles don't overlap along the arc.
+  const radius = Math.max(110, 76 + items.length * 18);
+
+  const close = () => {
+    onClose();
+    triggerRef.current?.focus();
+  };
+
+  // Move focus into the wheel when it opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    const id = requestAnimationFrame(() => {
+      wheelRef.current
+        ?.querySelector<HTMLButtonElement>('button:not(:disabled)')
+        ?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [isOpen]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen) return;
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      close();
+      return;
+    }
+    if (!['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+    const buttons = Array.from(
+      wheelRef.current?.querySelectorAll<HTMLButtonElement>('button:not(:disabled)') ?? []
+    );
+    if (buttons.length === 0) return;
+    e.preventDefault();
+    const currentIndex = buttons.indexOf(document.activeElement as HTMLButtonElement);
+    const direction = e.key === 'ArrowDown' || e.key === 'ArrowRight' ? 1 : -1;
+    buttons[(currentIndex + direction + buttons.length) % buttons.length]?.focus();
+  };
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="absolute top-3 right-3 z-40" onKeyDown={handleKeyDown}>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            key="backdrop"
+            className="fixed inset-0 -z-10 bg-overlay/50"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            onClick={close}
+            aria-hidden
+          />
+        )}
+      </AnimatePresence>
+
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={isOpen ? close : onOpen}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-label={isOpen ? 'Close actions' : 'More actions'}
+        className="relative w-12 h-12 rounded-full flex items-center justify-center bg-surface border border-border text-text-secondary shadow-lg hover:bg-surface-hover hover:text-foreground transition-colors"
+      >
+        {isOpen ? <XMarkIcon className="w-6 h-6" /> : <Squares2X2Icon className="w-6 h-6" />}
+        {!isOpen && triggerBadge > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-primary-500 text-white text-[10px] font-bold px-1">
+            {triggerBadge}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <div
+            ref={wheelRef}
+            role="group"
+            aria-label="Composer actions"
+            className="absolute left-1/2 top-1/2 w-0 h-0"
+          >
+            {items.map((item, index) => {
+              const pos = itemPosition(index, items.length, radius);
+              return (
+                <motion.div
+                  key={item.key}
+                  className="absolute left-0 top-0"
+                  initial={{ x: 0, y: 0, opacity: 0, scale: 0.4 }}
+                  animate={{
+                    x: pos.x,
+                    y: pos.y,
+                    opacity: 1,
+                    scale: 1,
+                    transition: {
+                      type: 'spring',
+                      stiffness: 400,
+                      damping: 28,
+                      delay: index * 0.03,
+                    },
+                  }}
+                  exit={{
+                    x: 0,
+                    y: 0,
+                    opacity: 0,
+                    scale: 0.4,
+                    transition: {
+                      duration: 0.15,
+                      delay: (items.length - 1 - index) * 0.02,
+                    },
+                  }}
+                >
+                  <div className="relative -translate-x-1/2 -translate-y-1/2">
+                    {item.content}
+                    <span
+                      className="absolute pointer-events-none whitespace-nowrap text-[10px] font-medium text-text-primary bg-surface/95 border border-border px-1.5 py-0.5 rounded-full"
+                      style={{
+                        left: `calc(50% + ${pos.outX * LABEL_OFFSET}px)`,
+                        top: `calc(50% + ${pos.outY * LABEL_OFFSET}px)`,
+                        transform: 'translate(-50%, -50%)',
+                      }}
+                      aria-hidden
+                    >
+                      {item.label}
+                    </span>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/tests/components/Composer.test.tsx
+++ b/apps/web/tests/components/Composer.test.tsx
@@ -385,6 +385,9 @@ describe('Composer', () => {
       />
     );
 
+    // Live typing lives inside the radial action wheel — open it first.
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
     expect(screen.getByRole('button', { name: 'Live Typing Active' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Live Typing' })).not.toBeInTheDocument();
   });
@@ -424,6 +427,8 @@ describe('Composer', () => {
 
     expect(screen.queryByTestId('copy-paste-sheet')).not.toBeInTheDocument();
 
+    // Copy/paste lives inside the radial action wheel — open it first.
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
     await user.click(screen.getByRole('button', { name: 'Copy and paste' }));
 
     expect(screen.getByTestId('copy-paste-sheet')).toBeInTheDocument();
@@ -440,6 +445,7 @@ describe('Composer', () => {
     textarea.setSelectionRange(5, 5);
     fireEvent.select(textarea);
 
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
     await user.click(screen.getByRole('button', { name: 'Copy and paste' }));
     await user.click(screen.getByRole('button', { name: 'Trigger Paste' }));
 


### PR DESCRIPTION
## Summary

Closes #700

- Replaces the Type tab's fixed 96px right action rail with a single top-right trigger button that fans out a quarter-circle radial flyout wheel of action tiles (Fix Text, Live Typing, Save as Phrase, Suggestions, Copy & Paste, Choose Tone), each with a small label while open.
- Speak and Clear remain always visible as floating round buttons pinned to the bottom-right; Stop replaces them while speaking, matching previous behavior.
- The composer textarea now spans the full width, with right padding so text clears the floating buttons. Draft tabs are unchanged.
- The wheel respects all existing feature flags and gating (subscription fallback for Fix Text, offline stubs, guest/offline variants), shows the suggestions count badge on both the closed trigger and the wheel item, and supports Escape/backdrop close, arrow-key navigation, and focus return to the trigger.

## Test plan

- [x] `pnpm test` — 466 tests across 56 suites pass (Composer tests updated to open the wheel before clicking wheel actions)
- [x] `pnpm build` — web and landing builds pass
- [x] `pnpm lint` — clean
- [x] Verified in browser on `/try`: wheel opens/closes via trigger, backdrop, and Escape; focus returns to trigger; Speak/Clear pinned bottom-right
- [ ] Manual check of the signed-in Type tab with all wheel items enabled (Fix Text, Live Typing, Save as Phrase, Suggestions, Copy & Paste, Tone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new radial “More actions” menu for composer tools, making actions easier to access from a single button.
  * Improved the composer layout to better support quick actions and overlay controls.
  * Updated the composer text area spacing to give more room for action buttons.

* **Bug Fixes**
  * Improved keyboard and focus behavior when opening and navigating the action menu.
  * Refined mobile and copy/paste flows to work correctly with the new action menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->