### PR TITLE
Redesign Speak as split button with attached tone control

### DIFF
--- a/apps/web/app/components/composer/ComposerSidebar.tsx
+++ b/apps/web/app/components/composer/ComposerSidebar.tsx
@@ -206,25 +206,6 @@ export default function ComposerSidebar({
     ),
   });
 
-  // Choose Tone — primary tile
-  if (enableToneControl) {
-    wheelItems.push({
-      key: 'tone',
-      label: 'Choose Tone',
-      content: (
-        <button
-          type="button"
-          onClick={runAndClose(() => setShowToneSheet(true))}
-          disabled={speakDisabled}
-          className={`${WHEEL_TILE} bg-primary-400 hover:bg-primary-500 text-white`}
-          aria-label="Choose tone"
-        >
-          <AudioWaveform className="w-5 h-5" />
-        </button>
-      ),
-    });
-  }
-
   return (
     <>
       {/* Top-right trigger + quarter-circle action wheel */}
@@ -258,15 +239,39 @@ export default function ComposerSidebar({
             >
               <XMarkIcon className="w-6 h-6" />
             </button>
-            <button
-              type="button"
-              onClick={onSpeak}
-              disabled={speakDisabled}
-              className="w-16 h-16 rounded-full shadow-lg flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              aria-label="Speak"
-            >
-              <SpeakerWaveIcon className="w-8 h-8" />
-            </button>
+            {enableToneControl ? (
+              // Split pill: small tone segment attached to a dominant Speak segment.
+              <div className="flex rounded-full overflow-hidden shadow-lg">
+                <button
+                  type="button"
+                  onClick={() => setShowToneSheet(true)}
+                  disabled={speakDisabled}
+                  className="w-12 h-16 flex items-center justify-center bg-primary-700 hover:bg-primary-600 text-white border-r border-primary-900/40 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="Choose tone"
+                >
+                  <AudioWaveform className="w-5 h-5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={onSpeak}
+                  disabled={speakDisabled}
+                  className="w-16 h-16 flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="Speak"
+                >
+                  <SpeakerWaveIcon className="w-8 h-8" />
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={onSpeak}
+                disabled={speakDisabled}
+                className="w-16 h-16 rounded-full shadow-lg flex items-center justify-center bg-primary-500 hover:bg-primary-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                aria-label="Speak"
+              >
+                <SpeakerWaveIcon className="w-8 h-8" />
+              </button>
+            )}
           </>
         )}
       </div>

--- a/apps/web/tests/components/Composer.test.tsx
+++ b/apps/web/tests/components/Composer.test.tsx
@@ -241,6 +241,39 @@ describe('Composer', () => {
     expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
   });
 
+  it('shows the tone segment attached to Speak when tone control is enabled', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Composer
+        text="Some text"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableToneControl={true}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Choose tone' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Speak' })).toBeInTheDocument();
+
+    // Tone no longer lives inside the radial wheel — opening it must not add
+    // a second tone button.
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getAllByRole('button', { name: 'Choose tone' })).toHaveLength(1);
+  });
+
+  it('does not render a tone segment when tone control is disabled', () => {
+    render(
+      <Composer
+        text="Some text"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Choose tone' })).not.toBeInTheDocument();
+  });
+
   it('lets the textarea shrink first while keeping composer controls rendered', () => {
     render(
       <Composer


### PR DESCRIPTION
## Summary

Closes #702

- When `enableToneControl` is on, the pinned bottom-right Speak button becomes a horizontal split pill: a small tone segment (`AudioWaveform` icon, darker primary) attached to the large, dominant Speak segment. The tone segment opens the ElevenLabs v3 ToneSheet; selecting a tone still speaks immediately (one-shot, unchanged behavior).
- The "Choose Tone" item is removed from the radial flyout wheel — tone control is now always one tap away from Speak instead of hidden behind the wheel.
- Without `enableToneControl` (guest, offline, non-ElevenLabs voices) the plain round Speak renders exactly as before. Stop still replaces the stack while speaking; Clear is unchanged.

## Test plan

- [x] `pnpm test` — 468 tests across 56 suites pass (two new tests: tone segment renders next to Speak with the flag and not in the wheel; no tone segment without the flag)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — web and landing builds pass
- [x] Verified in browser (tone flag forced on `/try` locally, reverted): split pill renders with Speak dominant, tone segment opens the full ToneSheet with all v3 categories, both segments disable when text is empty
- [ ] Manual check on the signed-in Type tab with an ElevenLabs voice configured
