### PR TITLE
release: v4.3.0

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
Release v4.3.0 — typing page redesign milestone.

Includes:
- #701 Radial flyout wheel replacing the composer action rail (#700)
- #703 Split Speak button with attached ElevenLabs v3 tone control (#702)
- Version bump to 4.3.0 across root, web, and landing packages

Made with [Cursor](https://cursor.com)