### PR TITLE
Show a live typing status banner above the composer while sharing

### DIFF
--- a/apps/web/app/components/composer/Composer.tsx
+++ b/apps/web/app/components/composer/Composer.tsx
@@ -16,6 +16,7 @@ import ActionPromptBanner from '../typing/ActionPromptBanner';
 import TabBar from '../typing-tabs/TabBar';
 import TabManagementSheet from '../typing-tabs/TabManagementSheet';
 import LiveTypingBottomSheet from '../live-typing/LiveTypingBottomSheet';
+import LiveTypingBanner from '../live-typing/LiveTypingBanner';
 import CopyPasteBottomSheet from './CopyPasteBottomSheet';
 import type { ComposerProps } from './types';
 
@@ -163,6 +164,14 @@ export default function Composer({
               onManage={() => setShowTabList(true)}
             />
           </div>
+        )}
+
+        {/* Live typing status — always visible while a session is being shared */}
+        {enableLiveTyping && actions.user && actions.isLiveTypingSharing && (
+          <LiveTypingBanner
+            onEnd={() => void actions.endLiveTypingSession()}
+            onOpenDetails={() => setShowLiveTypingSheet(true)}
+          />
         )}
 
         {/* Main body: full-width textarea with floating action overlays.

--- a/apps/web/app/components/live-typing/LiveTypingBanner.tsx
+++ b/apps/web/app/components/live-typing/LiveTypingBanner.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+interface LiveTypingBannerProps {
+  /** Ends the live typing session immediately. */
+  onEnd: () => void;
+  /** Reopens the live typing sheet (share link, session details). */
+  onOpenDetails: () => void;
+}
+
+export default function LiveTypingBanner({ onEnd, onOpenDetails }: LiveTypingBannerProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex shrink-0 items-center gap-3 border-b border-green-500/40 bg-status-success px-4 py-2"
+    >
+      <button
+        type="button"
+        onClick={onOpenDetails}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+        aria-label="Live Typing active — view session details"
+      >
+        <span className="relative flex h-2.5 w-2.5 shrink-0" aria-hidden>
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-green-500" />
+        </span>
+        <span className="min-w-0">
+          <span className="block text-sm font-semibold text-green-400">Live Typing active</span>
+          <span className="block truncate text-xs text-text-secondary">
+            Others can see what you type
+          </span>
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onEnd}
+        className="shrink-0 rounded-full bg-green-500 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-green-600 transition-colors"
+        aria-label="End live typing"
+      >
+        End
+      </button>
+    </div>
+  );
+}

--- a/apps/web/tests/components/Composer.test.tsx
+++ b/apps/web/tests/components/Composer.test.tsx
@@ -425,6 +425,74 @@ describe('Composer', () => {
     expect(screen.queryByRole('button', { name: 'Live Typing' })).not.toBeInTheDocument();
   });
 
+  it('shows the live typing banner while sharing and ends the session from it', async () => {
+    const user = userEvent.setup();
+    const endSession = jest.fn();
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+      },
+      loading: false,
+    });
+    mockUseLiveTyping.mockReturnValue({
+      session: null,
+      isSharing: true,
+      isCreating: false,
+      error: null,
+      createSession: jest.fn(),
+      endSession,
+      updateContent: jest.fn(),
+      getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
+    });
+
+    render(
+      <Composer
+        text="Sharing now"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableLiveTyping={true}
+      />
+    );
+
+    expect(screen.getByText('Live Typing active')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'End live typing' }));
+
+    expect(endSession).toHaveBeenCalled();
+  });
+
+  it('does not show the live typing banner when not sharing', () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+      },
+      loading: false,
+    });
+    mockUseLiveTyping.mockReturnValue({
+      session: null,
+      isSharing: false,
+      isCreating: false,
+      error: null,
+      createSession: jest.fn(),
+      endSession: jest.fn(),
+      updateContent: jest.fn(),
+      getShareableLink: jest.fn(() => null),
+    });
+
+    render(
+      <Composer
+        text="Hello"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableLiveTyping={true}
+      />
+    );
+
+    expect(screen.queryByText('Live Typing active')).not.toBeInTheDocument();
+  });
+
   it('shows undo banner in dock portal on mobile and suppresses it inline', () => {
     mockUseIsMobile.mockReturnValue(true);
     mockUseOptionalMobileBottom.mockReturnValue({ dockContainer: document.createElement('div') } as never);


### PR DESCRIPTION
## Summary

Closes #705

- Adds `LiveTypingBanner`: a slim green status banner with a pulsing dot shown above the composer typing area (below the draft tabs) whenever a live typing session is active.
- Tapping the banner body reopens the `LiveTypingBottomSheet` so the share link stays reachable; a small End button ends the session immediately.
- Renders only when `enableLiveTyping`, a signed-in user, and an active session are all present, so guest/offline variants are unaffected. Uses `role="status"` for screen readers.

## Test plan

- [x] `pnpm test` — 470 tests across 56 suites pass (two new tests: banner renders while sharing and End calls `endSession`; banner absent when not sharing)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — web and landing builds pass
- [ ] Manual check on the signed-in Type tab: start a live typing session, confirm the banner appears, the body reopens the sheet, and End stops the session
