### PR TITLE
Add remote speech for live typing

### DIFF
--- a/apps/web/app/components/composer/Composer.tsx
+++ b/apps/web/app/components/composer/Composer.tsx
@@ -194,7 +194,7 @@ export default function Composer({
           <ComposerSidebar
             currentText={currentText}
             onClear={actions.handleClear}
-            onSpeak={() => onSpeak('speak')}
+            onSpeak={() => actions.handleSpeak('speak')}
             onStop={onStop}
             onToneSelected={actions.handleToneSelected}
             isSpeaking={isSpeaking}

--- a/apps/web/app/components/composer/types.ts
+++ b/apps/web/app/components/composer/types.ts
@@ -9,7 +9,7 @@ export interface ReplySuggestionsConfig {
 export interface ComposerProps {
   text: string;
   onChange: (text: string) => void;
-  onSpeak: (source?: 'speak' | 'speakAndClear') => void;
+  onSpeak: (source?: 'speak' | 'speakAndClear', text?: string) => void;
   onSpeakWithTone?: (toneTag: string, options?: { modelId?: string }) => void;
   onMessageCompleted?: (payload: { text: string; source: 'clear'; tabId?: string | null }) => void;
   onStop?: () => void;

--- a/apps/web/app/components/composer/useComposerActions.ts
+++ b/apps/web/app/components/composer/useComposerActions.ts
@@ -85,6 +85,11 @@ export function useComposerActions({
     && entry?.tabId === (activeTabId || 'default')
     && currentText.trim().length === 0;
 
+  const handleSpeak = useCallback((source: 'speak' | 'speakAndClear' = 'speak') => {
+    if (!currentText.trim()) return;
+    onSpeak(source, currentText);
+  }, [currentText, onSpeak]);
+
   const clearTextWithUndo = useCallback((textToClear: string, source: 'clear' | 'skip' = 'clear') => {
     if (source === 'clear' && textToClear.trim()) {
       onMessageCompleted?.({
@@ -119,14 +124,14 @@ export function useComposerActions({
   const runEnterAction = useCallback((action: EnterKeyBehavior) => {
     switch (action) {
     case 'speak':
-      if (currentText.trim()) onSpeak('speak');
+      handleSpeak('speak');
       break;
     case 'clear':
       clearTextWithUndo(currentText, 'clear');
       break;
     case 'speakAndClear':
       if (currentText.trim()) {
-        onSpeak('speakAndClear');
+        handleSpeak('speakAndClear');
         const textSnapshot = currentText;
         setTimeout(() => clearTextWithUndo(textSnapshot, 'skip'), 100);
       }
@@ -136,7 +141,7 @@ export function useComposerActions({
       onChange(currentText + '\n');
       break;
     }
-  }, [clearTextWithUndo, currentText, onChange, onSpeak]);
+  }, [clearTextWithUndo, currentText, handleSpeak, onChange]);
 
   const { handleEnter, isPending: isDoubleEnterPending, remainingMs: doubleEnterRemainingMs } = useDoubleEnter({
     enabled: settings.doubleEnterEnabled,
@@ -225,6 +230,7 @@ export function useComposerActions({
   return {
     // clear/undo
     handleClear,
+    handleSpeak,
     showUndoHint,
     undoRemainingMs,
     undo,

--- a/apps/web/app/components/home/PhrasesInterface.tsx
+++ b/apps/web/app/components/home/PhrasesInterface.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useQuery, useConvex } from 'convex/react';
+import { useMutation, useQuery, useConvex } from 'convex/react';
+import { nanoid } from 'nanoid';
 import { api } from '@/convex/_generated/api';
 import Composer from '../composer';
 import AACTabs from './AACTabs';
@@ -15,6 +16,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { usePhraseBar } from '../../contexts/PhraseBarContext';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
+import type { LiveTypingSpeechSettings } from '@/lib/live-typing-speech';
 import {
   createOpenBoardBlob,
   createOpenBoardZipBlob,
@@ -75,6 +77,7 @@ export default function PhrasesInterface() {
   // of subscribing at mount — keeping a thousands-of-tiles snapshot in
   // memory for users who never click "Export All Boards" was wasteful.
   const convex = useConvex();
+  const publishTypingSessionSpeechCommand = useMutation(api.typingSessions.publishTypingSessionSpeechCommand);
 
   const handlePhrasePress = (phrase: PhraseSummary) => {
     if (settings.usePhraseBar) {
@@ -95,12 +98,6 @@ export default function PhrasesInterface() {
   const handlePhraseStop = () => {
     tts.stop();
     setActivePhraseId(null);
-  };
-
-  const handleSpeakFromDock = (source: 'speak' | 'speakAndClear' = 'speak') => {
-    if (!typingText.trim()) return;
-    tts.speak(typingText);
-    void handleCaptureCompletedMessage({ text: typingText, source, tabId: activeTabId });
   };
 
   const handleInsertSuggestion = (suggestion: string) => {
@@ -199,6 +196,109 @@ export default function PhrasesInterface() {
     && settings.ttsModelPreference === 'high_quality'
     && tts.status.elevenLabsAvailable;
 
+  const liveTypingSpeechSettings = useMemo<LiveTypingSpeechSettings>(() => {
+    const modelId = settings.ttsModelPreference === 'high_quality'
+      ? 'eleven_v3'
+      : 'eleven_flash_v2_5';
+    const selectedVoice = settings.ttsVoiceId
+      ? tts.voices.find(voice => voice.id === settings.ttsVoiceId)
+      : undefined;
+    const selectedProvider = selectedVoice?.provider ?? settings.ttsProvider;
+    const usingPremium = selectedProvider === 'elevenlabs'
+      || selectedProvider === 'azure'
+      || selectedProvider === 'gemini';
+
+    if (usingPremium && !tts.hasSubscription) {
+      return {
+        provider: 'browser',
+        voiceId: tts.voices.find(voice => voice.provider === 'browser')?.id,
+        rate: settings.speechRate,
+        pitch: settings.speechPitch,
+        volume: settings.speechVolume,
+        stability: settings.ttsStability,
+        similarityBoost: settings.ttsSimilarityBoost,
+        modelId,
+      };
+    }
+
+    return {
+      provider: selectedProvider,
+      voiceId: settings.ttsVoiceId || undefined,
+      rate: settings.speechRate,
+      pitch: settings.speechPitch,
+      volume: settings.speechVolume,
+      stability: settings.ttsStability,
+      similarityBoost: settings.ttsSimilarityBoost,
+      modelId,
+    };
+  }, [
+    settings.speechPitch,
+    settings.speechRate,
+    settings.speechVolume,
+    settings.ttsModelPreference,
+    settings.ttsProvider,
+    settings.ttsSimilarityBoost,
+    settings.ttsStability,
+    settings.ttsVoiceId,
+    tts.hasSubscription,
+    tts.voices,
+  ]);
+
+  const publishLiveTypingSpeech = async (
+    action: 'speak' | 'stop',
+    text?: string,
+    settingsOverride?: Partial<LiveTypingSpeechSettings>
+  ) => {
+    if (!user || typeof window === 'undefined') return;
+    const sessionKey = window.localStorage.getItem('typing-share-session-key');
+    if (!sessionKey) return;
+
+    const settingsSnapshot = {
+      ...liveTypingSpeechSettings,
+      ...settingsOverride,
+    };
+    const cleanedSettings = action === 'speak'
+      ? {
+        provider: settingsSnapshot.provider,
+        ...(settingsSnapshot.voiceId ? { voiceId: settingsSnapshot.voiceId } : {}),
+        rate: settingsSnapshot.rate,
+        pitch: settingsSnapshot.pitch,
+        volume: settingsSnapshot.volume,
+        stability: settingsSnapshot.stability,
+        similarityBoost: settingsSnapshot.similarityBoost,
+        ...(settingsSnapshot.modelId ? { modelId: settingsSnapshot.modelId } : {}),
+      }
+      : undefined;
+
+    try {
+      await publishTypingSessionSpeechCommand({
+        sessionKey,
+        commandId: nanoid(),
+        action,
+        ...(text !== undefined ? { text } : {}),
+        ...(cleanedSettings ? { settings: cleanedSettings } : {}),
+      });
+    } catch (error) {
+      console.error('Error publishing live typing speech command:', error);
+    }
+  };
+
+  const handleSpeakFromDock = (
+    source: 'speak' | 'speakAndClear' = 'speak',
+    textOverride?: string
+  ) => {
+    const textToSpeak = textOverride ?? typingText;
+    if (!textToSpeak.trim()) return;
+    void publishLiveTypingSpeech('speak', textToSpeak);
+    tts.speak(textToSpeak);
+    void handleCaptureCompletedMessage({ text: textToSpeak, source, tabId: activeTabId });
+  };
+
+  const handleStopFromDock = () => {
+    void publishLiveTypingSpeech('stop');
+    tts.stop();
+  };
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="shrink-0">
@@ -277,11 +377,12 @@ export default function PhrasesInterface() {
               onChange={setTypingText}
               onSpeak={handleSpeakFromDock}
               onSpeakWithTone={(taggedText: string, options?: { modelId?: string }) => {
+                void publishLiveTypingSpeech('speak', taggedText, options);
                 tts.speak(taggedText, options);
                 void handleCaptureCompletedMessage({ text: typingText, source: 'speak', tabId: activeTabId });
               }}
               onMessageCompleted={(payload: { text: string; source: 'clear'; tabId?: string | null }) => void handleCaptureCompletedMessage(payload)}
-              onStop={tts.stop}
+              onStop={handleStopFromDock}
               isSpeaking={tts.isSpeaking}
               isAvailable={tts.isAvailable}
               enableTabs={true}

--- a/apps/web/app/components/home/PhrasesInterface.tsx
+++ b/apps/web/app/components/home/PhrasesInterface.tsx
@@ -16,7 +16,11 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { usePhraseBar } from '../../contexts/PhraseBarContext';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useOnlineStatus } from '@/lib/hooks/useOnlineStatus';
-import type { LiveTypingSpeechSettings } from '@/lib/live-typing-speech';
+import { STORAGE_KEY } from '@/lib/hooks/useLiveTyping';
+import {
+  cleanLiveTypingSpeechSettings,
+  type LiveTypingSpeechSettings,
+} from '@/lib/live-typing-speech';
 import {
   createOpenBoardBlob,
   createOpenBoardZipBlob,
@@ -250,7 +254,7 @@ export default function PhrasesInterface() {
     settingsOverride?: Partial<LiveTypingSpeechSettings>
   ) => {
     if (!user || typeof window === 'undefined') return;
-    const sessionKey = window.localStorage.getItem('typing-share-session-key');
+    const sessionKey = window.localStorage.getItem(STORAGE_KEY);
     if (!sessionKey) return;
 
     const settingsSnapshot = {
@@ -258,16 +262,7 @@ export default function PhrasesInterface() {
       ...settingsOverride,
     };
     const cleanedSettings = action === 'speak'
-      ? {
-        provider: settingsSnapshot.provider,
-        ...(settingsSnapshot.voiceId ? { voiceId: settingsSnapshot.voiceId } : {}),
-        rate: settingsSnapshot.rate,
-        pitch: settingsSnapshot.pitch,
-        volume: settingsSnapshot.volume,
-        stability: settingsSnapshot.stability,
-        similarityBoost: settingsSnapshot.similarityBoost,
-        ...(settingsSnapshot.modelId ? { modelId: settingsSnapshot.modelId } : {}),
-      }
+      ? cleanLiveTypingSpeechSettings(settingsSnapshot)
       : undefined;
 
     try {

--- a/apps/web/app/typing-share/view/[key]/page.tsx
+++ b/apps/web/app/typing-share/view/[key]/page.tsx
@@ -4,8 +4,9 @@ import { use } from 'react';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { useSettings } from '@/app/contexts/SettingsContext';
+import { useTypingShareSpeech } from '@/lib/hooks/useTypingShareSpeech';
 import AnimatedLoading from '@/app/components/phrases/AnimatedLoading';
-import { ExclamationTriangleIcon, MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { ExclamationTriangleIcon, MinusIcon, PlusIcon, SpeakerWaveIcon } from '@heroicons/react/24/outline';
 
 export default function TypingShareViewPage({ params }: { params: Promise<{ key: string }> }) {
   const { key } = use(params);
@@ -14,6 +15,12 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
   const loading = session === undefined;
   const sessionMissing = session === null;
   const fontSize = uiPreferences.typingShareFontSize;
+  const {
+    audioEnabled,
+    enableAudio,
+    isSpeaking,
+    error: speechError,
+  } = useTypingShareSpeech(session);
 
   const increaseFontSize = () => {
     updateUIPreference('typingShareFontSize', Math.min(fontSize + 4, 64));
@@ -54,6 +61,28 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
             <p className="text-text-secondary mt-2">
               You are viewing a live typing session. Updates appear in real-time.
             </p>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              {!audioEnabled ? (
+                <button
+                  type="button"
+                  onClick={enableAudio}
+                  className="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-600"
+                >
+                  <SpeakerWaveIcon className="h-5 w-5" />
+                  <span>Enable Audio</span>
+                </button>
+              ) : (
+                <div className="inline-flex min-h-[36px] items-center gap-2 rounded-full bg-status-info px-4 py-2 text-sm font-semibold text-blue-400">
+                  <SpeakerWaveIcon className="h-5 w-5" />
+                  <span>{isSpeaking ? 'Speaking' : 'Audio enabled'}</span>
+                </div>
+              )}
+              {speechError && (
+                <p className="text-sm font-medium text-red-400" role="status">
+                  {speechError}
+                </p>
+              )}
+            </div>
           </div>
 
           <div className="px-6 sm:px-8 pb-6 sm:pb-8">

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -157,6 +157,22 @@ export default defineSchema({
     userId: v.string(), // Clerk user ID
     sessionKey: v.string(),
     content: v.string(),
+    speechCommand: v.optional(v.object({
+      id: v.string(),
+      action: v.union(v.literal('speak'), v.literal('stop')),
+      text: v.optional(v.string()),
+      createdAt: v.number(),
+      settings: v.optional(v.object({
+        provider: v.union(v.literal('browser'), v.literal('elevenlabs'), v.literal('azure'), v.literal('gemini')),
+        voiceId: v.optional(v.string()),
+        rate: v.number(),
+        pitch: v.number(),
+        volume: v.number(),
+        stability: v.number(),
+        similarityBoost: v.number(),
+        modelId: v.optional(v.string()),
+      })),
+    })),
     expiresAt: v.number(), // Unix timestamp
   })
     .index('by_user_id', ['userId'])

--- a/apps/web/convex/typingSessions.ts
+++ b/apps/web/convex/typingSessions.ts
@@ -99,6 +99,66 @@ export const updateTypingSessionContent = mutation({
   },
 });
 
+// Mutation: Publish a speech command for the live typing viewer device
+export const publishTypingSessionSpeechCommand = mutation({
+  args: {
+    sessionKey: v.string(),
+    commandId: v.string(),
+    action: v.union(v.literal('speak'), v.literal('stop')),
+    text: v.optional(v.string()),
+    settings: v.optional(v.object({
+      provider: v.union(v.literal('browser'), v.literal('elevenlabs'), v.literal('azure'), v.literal('gemini')),
+      voiceId: v.optional(v.string()),
+      rate: v.number(),
+      pitch: v.number(),
+      volume: v.number(),
+      stability: v.number(),
+      similarityBoost: v.number(),
+      modelId: v.optional(v.string()),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    const session = await ctx.db
+      .query('typingSessions')
+      .withIndex('by_session_key', (q) => q.eq('sessionKey', args.sessionKey))
+      .first();
+
+    if (!session || session.userId !== identity.subject || session.expiresAt <= Date.now()) {
+      throw new Error('Unauthorized');
+    }
+
+    if (args.action === 'speak') {
+      if (!args.text?.trim()) {
+        throw new Error('Text is required for speech commands');
+      }
+      if (!args.settings) {
+        throw new Error('Speech settings are required for speech commands');
+      }
+    }
+
+    await ctx.db.patch(session._id, {
+      speechCommand: args.action === 'speak'
+        ? {
+          id: args.commandId,
+          action: args.action,
+          text: args.text,
+          createdAt: Date.now(),
+          settings: args.settings,
+        }
+        : {
+          id: args.commandId,
+          action: args.action,
+          createdAt: Date.now(),
+        },
+    });
+  },
+});
+
 // Mutation: Delete a typing session
 export const deleteTypingSession = mutation({
   args: {

--- a/apps/web/lib/hooks/useLiveTyping.ts
+++ b/apps/web/lib/hooks/useLiveTyping.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
+import type { LiveTypingSpeechAction, LiveTypingSpeechCommand, LiveTypingSpeechSettings } from '@/lib/live-typing-speech';
 
 const STORAGE_KEY = 'typing-share-session-key';
 const SESSION_KEY_LENGTH = 32;
@@ -12,6 +13,7 @@ type TypingSession = {
   userId: string;
   sessionKey: string;
   content: string;
+  speechCommand?: LiveTypingSpeechCommand;
   expiresAt: number;
   _creationTime: number;
 } | null;
@@ -25,6 +27,7 @@ export function useLiveTyping() {
 
   const createTypingSession = useMutation(api.typingSessions.createTypingSession);
   const updateTypingSessionContent = useMutation(api.typingSessions.updateTypingSessionContent);
+  const publishTypingSessionSpeechCommand = useMutation(api.typingSessions.publishTypingSessionSpeechCommand);
   const deleteTypingSession = useMutation(api.typingSessions.deleteTypingSession);
 
   const sessionFromConvex = useQuery(
@@ -67,6 +70,7 @@ export function useLiveTyping() {
         userId: sessionFromConvex.userId,
         sessionKey: sessionFromConvex.sessionKey,
         content: sessionFromConvex.content,
+        speechCommand: sessionFromConvex.speechCommand,
         expiresAt: sessionFromConvex.expiresAt,
         _creationTime: sessionFromConvex._creationTime,
       });
@@ -96,6 +100,7 @@ export function useLiveTyping() {
         userId: created.userId,
         sessionKey: created.sessionKey,
         content: created.content,
+        speechCommand: created.speechCommand,
         expiresAt: created.expiresAt,
         _creationTime: created._creationTime,
       });
@@ -144,6 +149,39 @@ export function useLiveTyping() {
     }
   }, [sessionKey, deleteTypingSession]);
 
+  const publishSpeechCommand = useCallback(async (
+    action: LiveTypingSpeechAction,
+    text?: string,
+    settings?: LiveTypingSpeechSettings
+  ) => {
+    if (!sessionKey) return;
+
+    try {
+      const cleanedSettings = settings
+        ? {
+          provider: settings.provider,
+          ...(settings.voiceId ? { voiceId: settings.voiceId } : {}),
+          rate: settings.rate,
+          pitch: settings.pitch,
+          volume: settings.volume,
+          stability: settings.stability,
+          similarityBoost: settings.similarityBoost,
+          ...(settings.modelId ? { modelId: settings.modelId } : {}),
+        }
+        : undefined;
+
+      await publishTypingSessionSpeechCommand({
+        sessionKey,
+        commandId: nanoid(),
+        action,
+        ...(text !== undefined ? { text } : {}),
+        ...(cleanedSettings ? { settings: cleanedSettings } : {}),
+      });
+    } catch (err) {
+      console.error('Error publishing live typing speech command:', err);
+    }
+  }, [publishTypingSessionSpeechCommand, sessionKey]);
+
   const getShareableLink = useCallback(() => {
     if (typeof window === 'undefined') return null;
     const key = session?.sessionKey ?? sessionKey;
@@ -167,6 +205,7 @@ export function useLiveTyping() {
     error,
     createSession,
     updateContent,
+    publishSpeechCommand,
     endSession,
     getShareableLink,
   };

--- a/apps/web/lib/hooks/useLiveTyping.ts
+++ b/apps/web/lib/hooks/useLiveTyping.ts
@@ -3,9 +3,14 @@ import { nanoid } from 'nanoid';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
-import type { LiveTypingSpeechAction, LiveTypingSpeechCommand, LiveTypingSpeechSettings } from '@/lib/live-typing-speech';
+import {
+  cleanLiveTypingSpeechSettings,
+  type LiveTypingSpeechAction,
+  type LiveTypingSpeechCommand,
+  type LiveTypingSpeechSettings,
+} from '@/lib/live-typing-speech';
 
-const STORAGE_KEY = 'typing-share-session-key';
+export const STORAGE_KEY = 'typing-share-session-key';
 const SESSION_KEY_LENGTH = 32;
 
 type TypingSession = {
@@ -157,18 +162,7 @@ export function useLiveTyping() {
     if (!sessionKey) return;
 
     try {
-      const cleanedSettings = settings
-        ? {
-          provider: settings.provider,
-          ...(settings.voiceId ? { voiceId: settings.voiceId } : {}),
-          rate: settings.rate,
-          pitch: settings.pitch,
-          volume: settings.volume,
-          stability: settings.stability,
-          similarityBoost: settings.similarityBoost,
-          ...(settings.modelId ? { modelId: settings.modelId } : {}),
-        }
-        : undefined;
+      const cleanedSettings = settings ? cleanLiveTypingSpeechSettings(settings) : undefined;
 
       await publishTypingSessionSpeechCommand({
         sessionKey,

--- a/apps/web/lib/hooks/useTypingShareSpeech.ts
+++ b/apps/web/lib/hooks/useTypingShareSpeech.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { TTSProvider } from '@/lib/tts-provider';
+import type { LiveTypingSpeechCommand, LiveTypingSpeechSettings } from '@/lib/live-typing-speech';
+
+interface TypingShareSpeechSession {
+  speechCommand?: LiveTypingSpeechCommand;
+}
+
+async function prepareProvider(tts: TTSProvider, settings: LiveTypingSpeechSettings) {
+  tts.setProvider(settings.provider);
+
+  if (settings.provider === 'browser') {
+    tts.refreshVoices();
+    return;
+  }
+
+  if (settings.provider === 'elevenlabs') {
+    await tts.loadElevenLabsVoices();
+    return;
+  }
+
+  if (settings.provider === 'azure') {
+    await tts.loadAzureVoices();
+    return;
+  }
+
+  await tts.loadGeminiVoices();
+}
+
+export function useTypingShareSpeech(session: TypingShareSpeechSession | null | undefined) {
+  const [audioEnabled, setAudioEnabled] = useState(false);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const ttsRef = useRef<TTSProvider | null>(null);
+  const lastHandledCommandIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const tts = TTSProvider.getInstance();
+    ttsRef.current = tts;
+
+    const unsubscribe = tts.addCallbacks({
+      onStart: () => {
+        setIsSpeaking(true);
+        setError(null);
+      },
+      onEnd: () => setIsSpeaking(false),
+      onError: (speechError) => {
+        setIsSpeaking(false);
+
+        if (/interrupted|canceled/i.test(speechError.message)) {
+          return;
+        }
+
+        setError('Could not play speech on this device.');
+      },
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const enableAudio = useCallback(() => {
+    lastHandledCommandIdRef.current = session?.speechCommand?.id ?? null;
+    setAudioEnabled(true);
+    setError(null);
+  }, [session?.speechCommand?.id]);
+
+  useEffect(() => {
+    const command = session?.speechCommand;
+    const tts = ttsRef.current;
+
+    if (!command || !tts || !audioEnabled) {
+      return;
+    }
+
+    if (lastHandledCommandIdRef.current === command.id) {
+      return;
+    }
+
+    lastHandledCommandIdRef.current = command.id;
+
+    if (command.action === 'stop') {
+      tts.stop();
+      return;
+    }
+
+    if (!command.text?.trim() || !command.settings) {
+      setError('Speech command is missing text or voice settings.');
+      return;
+    }
+
+    let cancelled = false;
+
+    const speak = async () => {
+      try {
+        await prepareProvider(tts, command.settings!);
+        if (cancelled) return;
+
+        tts.speak(command.text!, {
+          voiceId: command.settings!.voiceId,
+          rate: command.settings!.rate,
+          pitch: command.settings!.pitch,
+          volume: command.settings!.volume,
+          stability: command.settings!.stability,
+          similarityBoost: command.settings!.similarityBoost,
+          modelId: command.settings!.modelId,
+        });
+        setError(null);
+      } catch (err) {
+        console.error('Error playing live typing speech:', err);
+        if (!cancelled) {
+          setError('Could not play speech on this device.');
+        }
+      }
+    };
+
+    void speak();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [audioEnabled, session?.speechCommand]);
+
+  return {
+    audioEnabled,
+    enableAudio,
+    isSpeaking,
+    error,
+  };
+}

--- a/apps/web/lib/live-typing-speech.ts
+++ b/apps/web/lib/live-typing-speech.ts
@@ -20,3 +20,16 @@ export interface LiveTypingSpeechCommand {
   createdAt: number;
   settings?: LiveTypingSpeechSettings;
 }
+
+export function cleanLiveTypingSpeechSettings(settings: LiveTypingSpeechSettings): LiveTypingSpeechSettings {
+  return {
+    provider: settings.provider,
+    ...(settings.voiceId ? { voiceId: settings.voiceId } : {}),
+    rate: settings.rate,
+    pitch: settings.pitch,
+    volume: settings.volume,
+    stability: settings.stability,
+    similarityBoost: settings.similarityBoost,
+    ...(settings.modelId ? { modelId: settings.modelId } : {}),
+  };
+}

--- a/apps/web/lib/live-typing-speech.ts
+++ b/apps/web/lib/live-typing-speech.ts
@@ -1,0 +1,22 @@
+import type { TTSProviderType } from './tts-provider';
+
+export type LiveTypingSpeechAction = 'speak' | 'stop';
+
+export interface LiveTypingSpeechSettings {
+  provider: TTSProviderType;
+  voiceId?: string;
+  rate: number;
+  pitch: number;
+  volume: number;
+  stability: number;
+  similarityBoost: number;
+  modelId?: string;
+}
+
+export interface LiveTypingSpeechCommand {
+  id: string;
+  action: LiveTypingSpeechAction;
+  text?: string;
+  createdAt: number;
+  settings?: LiveTypingSpeechSettings;
+}

--- a/apps/web/tests/components/Composer.test.tsx
+++ b/apps/web/tests/components/Composer.test.tsx
@@ -53,6 +53,7 @@ jest.mock('@/lib/hooks/useLiveTyping', () => ({
     createSession: jest.fn(),
     endSession: jest.fn(),
     updateContent: jest.fn(),
+    publishSpeechCommand: jest.fn(),
     getShareableLink: jest.fn(() => null),
   })),
 }));
@@ -406,6 +407,7 @@ describe('Composer', () => {
       createSession: jest.fn(),
       endSession: jest.fn(),
       updateContent: jest.fn(),
+      publishSpeechCommand: jest.fn(),
       getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
     });
 
@@ -443,6 +445,7 @@ describe('Composer', () => {
       createSession: jest.fn(),
       endSession,
       updateContent: jest.fn(),
+      publishSpeechCommand: jest.fn(),
       getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
     });
 
@@ -462,6 +465,58 @@ describe('Composer', () => {
     expect(endSession).toHaveBeenCalled();
   });
 
+  it('delegates speak and stop actions to the parent while sharing', async () => {
+    const user = userEvent.setup();
+    const onSpeak = jest.fn();
+    const onStop = jest.fn();
+
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+      },
+      loading: false,
+    });
+    mockUseLiveTyping.mockReturnValue({
+      session: null,
+      isSharing: true,
+      isCreating: false,
+      error: null,
+      createSession: jest.fn(),
+      endSession: jest.fn(),
+      updateContent: jest.fn(),
+      getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
+    });
+
+    const { rerender } = render(
+      <Composer
+        text="Sharing now"
+        onChange={jest.fn()}
+        onSpeak={onSpeak}
+        onStop={onStop}
+        enableLiveTyping={true}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Speak' }));
+    expect(onSpeak).toHaveBeenCalledWith('speak', 'Sharing now');
+
+    rerender(
+      <Composer
+        text="Sharing now"
+        onChange={jest.fn()}
+        onSpeak={onSpeak}
+        onStop={onStop}
+        isSpeaking={true}
+        enableLiveTyping={true}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Stop' }));
+
+    expect(onStop).toHaveBeenCalled();
+  });
+
   it('does not show the live typing banner when not sharing', () => {
     mockUseAuth.mockReturnValue({
       user: {
@@ -478,6 +533,7 @@ describe('Composer', () => {
       createSession: jest.fn(),
       endSession: jest.fn(),
       updateContent: jest.fn(),
+      publishSpeechCommand: jest.fn(),
       getShareableLink: jest.fn(() => null),
     });
 

--- a/apps/web/tests/convex/typingSessions.test.ts
+++ b/apps/web/tests/convex/typingSessions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { publishTypingSessionSpeechCommand } from '@/convex/typingSessions';
 
 const mockDb = {
   query: jest.fn(),
@@ -13,7 +14,7 @@ const mockCtx = {
 };
 
 const speechSettings = {
-  provider: 'browser',
+  provider: 'browser' as const,
   voiceId: 'browser-voice',
   rate: 1,
   pitch: 1,
@@ -31,40 +32,45 @@ function mockSessionLookup(session: unknown) {
   });
 }
 
+function publish(args: {
+  sessionKey?: string;
+  commandId?: string;
+  action?: 'speak' | 'stop';
+  text?: string;
+  settings?: typeof speechSettings;
+}) {
+  return publishTypingSessionSpeechCommand._handler(mockCtx as never, {
+    sessionKey: 'session-key',
+    commandId: 'command-1',
+    action: 'speak',
+    ...args,
+  });
+}
+
 describe('typingSessions speech commands', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test('stores a speak command for the session owner', async () => {
-    const session = {
+    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-1' });
+    mockSessionLookup({
       _id: 'session-1',
       userId: 'user-1',
       expiresAt: Date.now() + 60_000,
-    };
-    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-1' });
-    mockSessionLookup(session);
+    });
 
-    const identity = await mockCtx.auth.getUserIdentity();
-    const found = await mockDb.query('typingSessions').withIndex('by_session_key').first();
-    if (!found || found.userId !== identity?.subject || found.expiresAt <= Date.now()) {
-      throw new Error('Unauthorized');
-    }
-
-    await mockDb.patch(found._id, {
-      speechCommand: {
-        id: 'command-1',
-        action: 'speak',
-        text: 'Hello',
-        createdAt: 123,
-        settings: speechSettings,
-      },
+    await publish({
+      text: 'Hello',
+      settings: speechSettings,
     });
 
     expect(mockDb.patch).toHaveBeenCalledWith('session-1', {
       speechCommand: expect.objectContaining({
+        id: 'command-1',
         action: 'speak',
         text: 'Hello',
+        createdAt: expect.any(Number),
         settings: speechSettings,
       }),
     });
@@ -78,26 +84,28 @@ describe('typingSessions speech commands', () => {
       expiresAt: Date.now() + 60_000,
     });
 
-    const identity = await mockCtx.auth.getUserIdentity();
-    const found = await mockDb.query('typingSessions').withIndex('by_session_key').first();
-
-    const publish = () => {
-      if (!found || found.userId !== identity?.subject || found.expiresAt <= Date.now()) {
-        throw new Error('Unauthorized');
-      }
-    };
-
-    expect(publish).toThrow('Unauthorized');
+    await expect(publish({
+      text: 'Hello',
+      settings: speechSettings,
+    })).rejects.toThrow('Unauthorized');
     expect(mockDb.patch).not.toHaveBeenCalled();
   });
 
-  test('rejects speak commands without text or settings', () => {
-    const publish = (text?: string, settings?: unknown) => {
-      if (!text?.trim()) throw new Error('Text is required for speech commands');
-      if (!settings) throw new Error('Speech settings are required for speech commands');
-    };
+  test('rejects speak commands without text or settings', async () => {
+    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-1' });
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      expiresAt: Date.now() + 60_000,
+    });
 
-    expect(() => publish('', speechSettings)).toThrow('Text is required');
-    expect(() => publish('Hello')).toThrow('Speech settings are required');
+    await expect(publish({
+      text: '',
+      settings: speechSettings,
+    })).rejects.toThrow('Text is required');
+    await expect(publish({
+      text: 'Hello',
+    })).rejects.toThrow('Speech settings are required');
+    expect(mockDb.patch).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/convex/typingSessions.test.ts
+++ b/apps/web/tests/convex/typingSessions.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+
+const mockDb = {
+  query: jest.fn(),
+  patch: jest.fn(),
+};
+
+const mockCtx = {
+  db: mockDb,
+  auth: {
+    getUserIdentity: jest.fn(),
+  },
+};
+
+const speechSettings = {
+  provider: 'browser',
+  voiceId: 'browser-voice',
+  rate: 1,
+  pitch: 1,
+  volume: 1,
+  stability: 0.5,
+  similarityBoost: 0.5,
+  modelId: 'eleven_flash_v2_5',
+};
+
+function mockSessionLookup(session: unknown) {
+  mockDb.query.mockReturnValue({
+    withIndex: jest.fn().mockReturnValue({
+      first: jest.fn().mockResolvedValue(session),
+    }),
+  });
+}
+
+describe('typingSessions speech commands', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('stores a speak command for the session owner', async () => {
+    const session = {
+      _id: 'session-1',
+      userId: 'user-1',
+      expiresAt: Date.now() + 60_000,
+    };
+    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-1' });
+    mockSessionLookup(session);
+
+    const identity = await mockCtx.auth.getUserIdentity();
+    const found = await mockDb.query('typingSessions').withIndex('by_session_key').first();
+    if (!found || found.userId !== identity?.subject || found.expiresAt <= Date.now()) {
+      throw new Error('Unauthorized');
+    }
+
+    await mockDb.patch(found._id, {
+      speechCommand: {
+        id: 'command-1',
+        action: 'speak',
+        text: 'Hello',
+        createdAt: 123,
+        settings: speechSettings,
+      },
+    });
+
+    expect(mockDb.patch).toHaveBeenCalledWith('session-1', {
+      speechCommand: expect.objectContaining({
+        action: 'speak',
+        text: 'Hello',
+        settings: speechSettings,
+      }),
+    });
+  });
+
+  test('rejects speech commands from a non-owner', async () => {
+    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-2' });
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const identity = await mockCtx.auth.getUserIdentity();
+    const found = await mockDb.query('typingSessions').withIndex('by_session_key').first();
+
+    const publish = () => {
+      if (!found || found.userId !== identity?.subject || found.expiresAt <= Date.now()) {
+        throw new Error('Unauthorized');
+      }
+    };
+
+    expect(publish).toThrow('Unauthorized');
+    expect(mockDb.patch).not.toHaveBeenCalled();
+  });
+
+  test('rejects speak commands without text or settings', () => {
+    const publish = (text?: string, settings?: unknown) => {
+      if (!text?.trim()) throw new Error('Text is required for speech commands');
+      if (!settings) throw new Error('Speech settings are required for speech commands');
+    };
+
+    expect(() => publish('', speechSettings)).toThrow('Text is required');
+    expect(() => publish('Hello')).toThrow('Speech settings are required');
+  });
+});

--- a/apps/web/tests/lib/hooks/useTypingShareSpeech.test.ts
+++ b/apps/web/tests/lib/hooks/useTypingShareSpeech.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useTypingShareSpeech } from '@/lib/hooks/useTypingShareSpeech';
+import type { LiveTypingSpeechCommand } from '@/lib/live-typing-speech';
+
+const mockTTSProvider = {
+  addCallbacks: jest.fn(() => () => {}),
+  setProvider: jest.fn(),
+  refreshVoices: jest.fn(),
+  loadElevenLabsVoices: jest.fn(async () => {}),
+  loadAzureVoices: jest.fn(async () => {}),
+  loadGeminiVoices: jest.fn(async () => {}),
+  speak: jest.fn(),
+  stop: jest.fn(),
+};
+
+function getCallbacks() {
+  return mockTTSProvider.addCallbacks.mock.calls.at(-1)?.[0];
+}
+
+jest.mock('@/lib/tts-provider', () => ({
+  TTSProvider: {
+    getInstance: jest.fn(() => mockTTSProvider),
+  },
+}));
+
+function speakCommand(id: string, text = 'Hello'): LiveTypingSpeechCommand {
+  return {
+    id,
+    action: 'speak',
+    text,
+    createdAt: Date.now(),
+    settings: {
+      provider: 'browser',
+      voiceId: 'missing-browser-voice',
+      rate: 1.2,
+      pitch: 0.8,
+      volume: 0.7,
+      stability: 0.4,
+      similarityBoost: 0.6,
+      modelId: 'eleven_flash_v2_5',
+    },
+  };
+}
+
+describe('useTypingShareSpeech', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not play the existing command when audio is first enabled', () => {
+    const { result } = renderHook(() => useTypingShareSpeech({
+      speechCommand: speakCommand('old-command'),
+    }));
+
+    act(() => {
+      result.current.enableAudio();
+    });
+
+    expect(result.current.audioEnabled).toBe(true);
+    expect(mockTTSProvider.speak).not.toHaveBeenCalled();
+  });
+
+  it('plays each new command once after audio is enabled', async () => {
+    const first = speakCommand('old-command');
+    const next = speakCommand('new-command', 'New message');
+    const { result, rerender } = renderHook(
+      ({ command }: { command?: LiveTypingSpeechCommand }) => useTypingShareSpeech({ speechCommand: command }),
+      { initialProps: { command: first } }
+    );
+
+    act(() => {
+      result.current.enableAudio();
+    });
+
+    rerender({ command: next });
+
+    await waitFor(() => {
+      expect(mockTTSProvider.speak).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ command: next });
+
+    expect(mockTTSProvider.speak).toHaveBeenCalledTimes(1);
+    expect(mockTTSProvider.speak).toHaveBeenCalledWith('New message', expect.objectContaining({
+      voiceId: 'missing-browser-voice',
+      rate: 1.2,
+      pitch: 0.8,
+      volume: 0.7,
+    }));
+  });
+
+  it('stops speech when a stop command arrives after audio is enabled', async () => {
+    const { result, rerender } = renderHook(
+      ({ command }: { command?: LiveTypingSpeechCommand }) => useTypingShareSpeech({ speechCommand: command }),
+      { initialProps: { command: undefined } }
+    );
+
+    act(() => {
+      result.current.enableAudio();
+    });
+
+    rerender({
+      command: {
+        id: 'stop-command',
+        action: 'stop',
+        createdAt: Date.now(),
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockTTSProvider.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('ignores expected browser interruption errors', () => {
+    const { result } = renderHook(() => useTypingShareSpeech({}));
+
+    act(() => {
+      getCallbacks()?.onStart();
+    });
+
+    expect(result.current.isSpeaking).toBe(true);
+
+    act(() => {
+      getCallbacks()?.onError(new Error('Speech synthesis error: interrupted'));
+    });
+
+    expect(result.current.isSpeaking).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #708.\n\n## Summary\n- publish live typing speech and stop commands through Convex\n- play speech on the public viewer device after audio is enabled\n- preserve sender-side speech behavior and voice settings\n\n## Verification\n- jest --config jest.config.cjs\n- eslint .\n- next build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live typing speech command support, including publish/receive flow and configurable audio settings.
  * Introduced an audio control area in the Live Typing view with enable/status/error feedback.

* **Bug Fixes**
  * Improved speech handling so Speak and Stop actions use the shared live typing flow.
  * Prevented repeated playback of the same speech command and handled interrupted audio more gracefully.

* **Tests**
  * Added coverage for speech command publishing, access checks, and audio playback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->