### PR TITLE
design: use one typography system throughout the app

### DIFF
--- a/apps/web/app/ClientLayout.tsx
+++ b/apps/web/app/ClientLayout.tsx
@@ -128,7 +128,13 @@ export default function ClientLayout({
   }
 
   return (
-    <ClerkProvider>
+    <ClerkProvider
+      appearance={{
+        variables: {
+          fontFamily: 'var(--font-inter), system-ui, sans-serif',
+        },
+      }}
+    >
       <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
         <AuthProvider>
           <SettingsProvider>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -67,8 +67,7 @@
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
   --color-text-tertiary: var(--text-tertiary);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
 }
 
 @keyframes gradient {
@@ -86,7 +85,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
   margin: 0;
   padding: 0;
   transition: background-color 0.3s ease, color 0.3s ease;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import ClientLayout from './ClientLayout';
 import { Metadata, Viewport } from 'next';
 import RegisterPWA from './register-pwa';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -41,7 +41,7 @@ export default function RootLayout({
         <meta name="theme-color" content="#1a1a1a" />
         <link rel="manifest" href="/manifest.json" />
       </head>
-      <body className={`${inter.className} bg-surface text-foreground`} suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans bg-surface text-foreground`} suppressHydrationWarning>
         <RegisterPWA />
         <ClientLayout>
           {children}

--- a/apps/web/tests/app/RootLayout.test.tsx
+++ b/apps/web/tests/app/RootLayout.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+jest.mock('next/font/google', () => ({
+  Inter: () => ({ className: 'inter-class', variable: 'inter-variable' }),
+}));
+jest.mock('@/app/ClientLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/app/register-pwa', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import RootLayout from '@/app/layout';
+
+describe('RootLayout typography', () => {
+  it('exposes the Inter variable and shared font utility on the body', () => {
+    const layout = RootLayout({ children: <div>Content</div> });
+    const children = React.Children.toArray(layout.props.children) as React.ReactElement[];
+    const body = children.find((child) => child.type === 'body');
+
+    expect(body).toBeDefined();
+    expect(body?.props.className).toContain('inter-variable');
+    expect(body?.props.className).toContain('font-sans');
+  });
+});


### PR DESCRIPTION
## What changed
- make the existing Inter font the root application font and Tailwind `font-sans` source
- remove the global Arial override
- pass the same font family into Clerk surfaces
- add a focused root-layout typography test

## Why
SayIt! loaded Inter but then overrode it with Arial, producing inconsistent typography across product and authentication surfaces.

## Validation
- full Jest suite: 479 tests passed
- ESLint passed
- Next.js production build passed

Closes #711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app’s typography to use the Inter font with sensible fallbacks for a more consistent look and feel.
  * Applied the new font styling across the main layout and authentication screens.

* **Tests**
  * Added coverage to verify the app layout continues to apply the expected font classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->