### PR TITLE
design: replace the hover-expanding desktop sidebar with a stable navigation rail

### DIFF
--- a/apps/web/app/ClientLayout.tsx
+++ b/apps/web/app/ClientLayout.tsx
@@ -128,7 +128,13 @@ export default function ClientLayout({
   }
 
   return (
-    <ClerkProvider>
+    <ClerkProvider
+      appearance={{
+        variables: {
+          fontFamily: 'var(--font-inter), system-ui, sans-serif',
+        },
+      }}
+    >
       <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
         <AuthProvider>
           <SettingsProvider>

--- a/apps/web/app/ClientLayout.tsx
+++ b/apps/web/app/ClientLayout.tsx
@@ -145,7 +145,7 @@ export default function ClientLayout({
                     <OfflineDataSync />
                     <div className="flex h-dvh min-h-0 flex-col overflow-hidden md:h-auto md:min-h-dvh md:flex-row md:overflow-visible">
                       <Sidebar />
-                      <div className="flex min-h-0 flex-1 flex-col md:pl-16 lg:pl-16">
+                      <div className="flex min-h-0 flex-1 flex-col md:pl-24">
                         <div className="shrink-0">
                           <ConnectivityBanner />
                           <InstallBanner />

--- a/apps/web/app/components/Sidebar.tsx
+++ b/apps/web/app/components/Sidebar.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { usePathname } from 'next/navigation';
 import { useQuery } from 'convex/react';
@@ -14,9 +13,8 @@ import {
   Cog6ToothIcon,
   ArrowRightStartOnRectangleIcon,
   UsersIcon,
-  LockClosedIcon
+  LockClosedIcon,
 } from '@heroicons/react/24/outline';
-import { Tooltip } from 'react-tooltip';
 import { UserButton } from '@clerk/nextjs';
 
 export default function Sidebar() {
@@ -24,107 +22,71 @@ export default function Sidebar() {
   const pathname = usePathname();
   const profile = useQuery(api.profiles.getProfile);
   const { isActive: hasSubscription } = useSubscription();
-  const [isExpanded, setIsExpanded] = useState(false);
-
   const isCaregiver = profile?.role === 'caregiver';
 
   return (
-    <aside
-      className={`fixed left-0 top-0 h-full z-50 shadow-2xl hidden md:flex flex-col transition-all duration-300 ${
-        isExpanded ? 'w-48' : 'w-16'
-      } bg-surface`}
-      onMouseEnter={() => setIsExpanded(true)}
-      onMouseLeave={() => setIsExpanded(false)}
-      onFocusCapture={() => setIsExpanded(true)}
-      onBlurCapture={(event) => {
-        const nextTarget = event.relatedTarget as Node | null;
-        if (!event.currentTarget.contains(nextTarget)) {
-          setIsExpanded(false);
-        }
-      }}
-    >
-      <div className="p-4 flex justify-center items-center">
-        <div className="rounded-3xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-110">
-          <Image
-            src="/icons/app-icon.png"
-            alt="Logo"
-            width={32}
-            height={32}
-          />
-        </div>
-      </div>
+    <aside className="fixed inset-y-0 left-0 z-50 hidden w-24 flex-col border-r border-border bg-surface md:flex">
+      <Link href="/" aria-label="SayIt! home" className="flex h-20 items-center justify-center">
+        <Image src="/icons/app-icon.png" alt="" width={36} height={36} priority />
+      </Link>
 
-      <nav className="flex-1 p-3 space-y-3">
+      <nav aria-label="Primary navigation" className="flex-1 space-y-2 px-2 py-2">
         <SidebarItem
           href="/"
-          icon={<HomeIcon className="w-6 h-6 flex-shrink-0" />}
+          icon={<HomeIcon className="h-6 w-6" />}
           title="Home"
           isActive={pathname === '/'}
-          isExpanded={isExpanded}
         />
 
         {user && isCaregiver && (
           <SidebarItem
             href="/dashboard"
             icon={
-              hasSubscription ? (
-                <UsersIcon className="w-6 h-6 flex-shrink-0" />
-              ) : (
-                <div className="relative flex-shrink-0">
-                  <UsersIcon className="w-6 h-6" />
-                  <LockClosedIcon className="w-3 h-3 absolute -bottom-1 -right-1 text-text-tertiary" />
-                </div>
-              )
+              <span className="relative">
+                <UsersIcon className="h-6 w-6" />
+                {!hasSubscription && (
+                  <LockClosedIcon className="absolute -bottom-1 -right-1 h-3 w-3 text-text-tertiary" />
+                )}
+              </span>
             }
             title={hasSubscription ? 'Clients' : 'Clients (Pro)'}
             isActive={pathname?.startsWith('/dashboard') ?? false}
-            isExpanded={isExpanded}
           />
         )}
 
         {user && (
           <SidebarItem
             href="/settings"
-            icon={<Cog6ToothIcon className="w-6 h-6 flex-shrink-0" />}
+            icon={<Cog6ToothIcon className="h-6 w-6" />}
             title="Settings"
             isActive={pathname === '/settings'}
-            isExpanded={isExpanded}
           />
         )}
 
         <SidebarItem
           href="/support"
-          icon={<QuestionMarkCircleIcon className="w-6 h-6 flex-shrink-0" />}
+          icon={<QuestionMarkCircleIcon className="h-6 w-6" />}
           title="Support"
           isActive={pathname === '/support'}
-          isExpanded={isExpanded}
         />
       </nav>
 
-      <div className="p-3 flex items-center justify-center">
+      <div className="flex min-h-20 flex-col items-center justify-center gap-1 px-2 py-3 text-xs text-text-secondary">
         {user ? (
-          <UserButton
-            appearance={{
-              elements: {
-                avatarBox: 'w-10 h-10 rounded-full hover:scale-110 transition-transform duration-300'
-              }
-            }}
-          />
-        ) : (
-          <Link
-            href="/sign-in"
-            className="flex items-center justify-center p-2 rounded-3xl transition-all duration-300 shadow-md hover:shadow-xl hover:scale-110 bg-surface-hover text-text-secondary hover:bg-primary-950 hover:text-primary-500"
-            data-tooltip-id="sidebar-tooltip-sign-in"
-            data-tooltip-content="Sign In"
-            aria-label="Sign in"
-          >
-            <ArrowRightStartOnRectangleIcon className="w-6 h-6" />
-            <Tooltip
-              id="sidebar-tooltip-sign-in"
-              place="right"
-              className="z-50"
+          <>
+            <UserButton
+              appearance={{ elements: { avatarBox: 'h-9 w-9 rounded-full' } }}
             />
-          </Link>
+            <span>Account</span>
+          </>
+        ) : (
+          <SidebarItem
+            href="/sign-in"
+            icon={<ArrowRightStartOnRectangleIcon className="h-6 w-6" />}
+            title="Sign in"
+            isActive={pathname?.startsWith('/sign-in') ?? false}
+            compact
+          />
         )}
       </div>
     </aside>
@@ -136,38 +98,23 @@ interface SidebarItemProps {
   icon: React.ReactNode;
   title: string;
   isActive: boolean;
-  isExpanded: boolean;
+  compact?: boolean;
 }
 
-function SidebarItem({ href, icon, title, isActive, isExpanded }: SidebarItemProps) {
+function SidebarItem({ href, icon, title, isActive, compact = false }: SidebarItemProps) {
   return (
     <Link
       href={href}
-      className={`flex items-center p-2 rounded-3xl transition-all duration-300 shadow-md hover:shadow-xl ${
-        isExpanded ? 'justify-start gap-3 px-3' : 'justify-center hover:scale-110'
-      } ${
+      className={`relative flex min-h-[60px] w-full flex-col items-center justify-center gap-1 rounded-[var(--radius-control)] px-1 py-2 text-center transition-colors duration-[var(--motion-duration-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
         isActive
-          ? 'bg-primary-500 text-white shadow-lg'
-          : 'bg-surface-hover text-text-secondary hover:bg-primary-950 hover:text-primary-500'
-      }`}
-      data-tooltip-id={!isExpanded ? `sidebar-tooltip-${title}` : undefined}
-      data-tooltip-content={!isExpanded ? title : undefined}
-      aria-label={title}
+          ? 'bg-primary-950 text-primary-300'
+          : 'text-text-secondary hover:bg-surface-hover hover:text-foreground'
+      } ${compact ? 'min-w-[72px]' : ''}`}
       aria-current={isActive ? 'page' : undefined}
     >
-      {icon}
-      {isExpanded && (
-        <span className="text-sm font-medium whitespace-nowrap overflow-hidden">
-          {title}
-        </span>
-      )}
-      {!isExpanded && (
-        <Tooltip
-          id={`sidebar-tooltip-${title}`}
-          place="right"
-          className="z-50"
-        />
-      )}
+      {isActive && <span aria-hidden="true" className="absolute inset-y-2 left-0 w-1 rounded-r-full bg-primary-500" />}
+      <span aria-hidden="true">{icon}</span>
+      <span className="max-w-full text-[11px] font-medium leading-tight">{title}</span>
     </Link>
   );
 }

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -5,7 +5,7 @@ import { motion, HTMLMotionProps } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-3xl text-sm font-medium transition-all duration-300 shadow-md hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-control)] text-sm font-medium shadow-[var(--shadow-control)] transition-[background-color,border-color,color,box-shadow,transform] duration-[var(--motion-duration-standard)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -22,10 +22,10 @@ const buttonVariants = cva(
       },
       size: {
         // All sizes meet minimum 44px touch target requirement
-        default: 'h-11 min-h-[44px] px-6 py-2',
-        sm: 'h-10 min-h-[44px] rounded-3xl px-4 text-xs',
-        lg: 'h-12 min-h-[48px] rounded-3xl px-10',
-        icon: 'h-11 w-11 min-h-[44px] min-w-[44px]',
+        default: 'h-[var(--control-height)] min-h-[44px] px-6 py-2',
+        sm: 'h-[var(--control-height)] min-h-[44px] px-4 text-xs',
+        lg: 'h-[var(--control-height-large)] min-h-[48px] px-10',
+        icon: 'h-[var(--control-height)] w-[var(--control-height)] min-h-[44px] min-w-[44px]',
       },
     },
     defaultVariants: {
@@ -66,7 +66,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <motion.button
         className={cn(buttonVariants({ variant, size, className }))}
-        whileHover={prefersReducedMotion ? undefined : { scale: 1.05 }}
         whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
         transition={{ duration: 0.2 }}
         ref={ref}

--- a/apps/web/app/components/ui/Input.tsx
+++ b/apps/web/app/components/ui/Input.tsx
@@ -15,13 +15,13 @@ export default function Input({ label, error, className = '', ...props }: InputP
       )}
       <input
         {...props}
-        className={`block w-full px-6 py-3 bg-surface border border-border rounded-3xl text-foreground text-base placeholder:text-text-tertiary shadow-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 focus:shadow-xl hover:shadow-lg transition-all duration-300 ${className}`}
+        className={`block min-h-[var(--control-height)] w-full rounded-[var(--radius-control)] border border-border bg-surface px-4 py-2.5 text-base text-foreground shadow-[var(--shadow-control)] placeholder:text-text-tertiary transition-[background-color,border-color,box-shadow] duration-[var(--motion-duration-standard)] hover:border-text-tertiary focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 ${className}`}
       />
       {error && (
-        <div className="mt-2 text-red-500 text-sm bg-status-error px-4 py-2 rounded-3xl">
+        <div className="mt-2 rounded-[var(--radius-small)] bg-status-error px-4 py-2 text-sm text-red-500">
           {error}
         </div>
       )}
     </div>
   );
-} 
+}

--- a/apps/web/app/components/ui/SettingsCard.tsx
+++ b/apps/web/app/components/ui/SettingsCard.tsx
@@ -16,11 +16,11 @@ export function SettingsCard({
   className = ''
 }: SettingsCardProps) {
   return (
-    <div className={`bg-surface rounded-3xl shadow-2xl hover:shadow-3xl overflow-hidden transition-all duration-300 ${className}`}>
+    <section aria-label={title} className={`overflow-hidden rounded-[var(--radius-card)] border border-border bg-surface shadow-[var(--shadow-card)] ${className}`}>
       <div className="px-8 py-6">
         <div className="flex items-center space-x-4 mb-6">
           {icon && (
-            <div className="flex-shrink-0 text-primary-500 bg-surface-hover p-3 rounded-3xl">
+            <div className="flex-shrink-0 rounded-[var(--radius-control)] bg-surface-hover p-3 text-primary-500">
               {icon}
             </div>
           )}
@@ -39,6 +39,6 @@ export function SettingsCard({
           {children}
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/apps/web/app/components/ui/Switch.tsx
+++ b/apps/web/app/components/ui/Switch.tsx
@@ -30,7 +30,7 @@ export function Switch({
         aria-label={label}
         onClick={() => !disabled && onChange(!checked)}
         className={cn(
-          'relative w-full py-3 pl-6 pr-10 text-left bg-surface border border-border rounded-3xl shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 focus:shadow-xl text-base transition-all duration-300',
+          'relative min-h-[var(--control-height)] w-full rounded-[var(--radius-control)] border border-border bg-surface py-2.5 pl-4 pr-10 text-left text-base shadow-[var(--shadow-control)] transition-[background-color,border-color,box-shadow] duration-[var(--motion-duration-standard)] hover:border-text-tertiary focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500',
           disabled && 'opacity-50 cursor-not-allowed bg-surface-hover'
         )}
         disabled={disabled}
@@ -39,13 +39,13 @@ export function Switch({
         <span className="absolute inset-y-0 right-0 flex items-center pr-4">
           <span
             className={cn(
-              'relative inline-flex h-7 w-12 items-center rounded-full border border-border transition-colors',
+              'relative inline-flex h-7 w-12 items-center rounded-full border border-border transition-colors duration-[var(--motion-duration-fast)]',
               checked ? 'bg-primary-500' : 'bg-surface-hover'
             )}
           >
             <span
               className={cn(
-                'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform',
+                'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform duration-[var(--motion-duration-fast)]',
                 checked ? 'translate-x-5' : 'translate-x-1'
               )}
             />

--- a/apps/web/app/components/ui/Textarea.tsx
+++ b/apps/web/app/components/ui/Textarea.tsx
@@ -17,16 +17,16 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         <textarea
           className={cn(
-            'flex min-h-[120px] w-full rounded-3xl border border-border',
-            'bg-surface shadow-md hover:shadow-lg focus:shadow-xl',
-            'px-6 py-3 text-base',
+            'flex min-h-[120px] w-full rounded-[var(--radius-control)] border border-border',
+            'bg-surface shadow-[var(--shadow-control)] hover:border-text-tertiary',
+            'px-4 py-3 text-base',
             'text-foreground',
             'placeholder:text-text-tertiary',
             'ring-offset-surface',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
             'focus-visible:border-primary-500 focus-visible:ring-offset-2',
             'disabled:cursor-not-allowed disabled:opacity-50',
-            'transition-all duration-300',
+            'transition-[background-color,border-color,box-shadow] duration-[var(--motion-duration-standard)]',
             className,
           )}
           ref={ref}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -22,6 +22,17 @@
   --background-gradient-2: #232220;
   --background-gradient-3: #2d2b29;
   --background-gradient-4: #1a1917;
+
+  /* Version 5 visual system */
+  --radius-card: 1rem;
+  --radius-control: 0.75rem;
+  --radius-small: 0.5rem;
+  --control-height: 2.75rem;
+  --control-height-large: 3rem;
+  --shadow-control: 0 1px 2px rgb(0 0 0 / 0.24);
+  --shadow-card: 0 8px 24px rgb(0 0 0 / 0.18);
+  --motion-duration-fast: 150ms;
+  --motion-duration-standard: 200ms;
 }
 
 /* Fixed color tokens */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -67,8 +67,7 @@
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
   --color-text-tertiary: var(--text-tertiary);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
 }
 
 @keyframes gradient {
@@ -86,7 +85,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
   margin: 0;
   padding: 0;
   transition: background-color 0.3s ease, color 0.3s ease;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import ClientLayout from './ClientLayout';
 import { Metadata, Viewport } from 'next';
 import RegisterPWA from './register-pwa';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -41,7 +41,7 @@ export default function RootLayout({
         <meta name="theme-color" content="#1a1a1a" />
         <link rel="manifest" href="/manifest.json" />
       </head>
-      <body className={`${inter.className} bg-surface text-foreground`} suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans bg-surface text-foreground`} suppressHydrationWarning>
         <RegisterPWA />
         <ClientLayout>
           {children}

--- a/apps/web/tests/app/RootLayout.test.tsx
+++ b/apps/web/tests/app/RootLayout.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+jest.mock('next/font/google', () => ({
+  Inter: () => ({ className: 'inter-class', variable: 'inter-variable' }),
+}));
+jest.mock('@/app/ClientLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/app/register-pwa', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import RootLayout from '@/app/layout';
+
+describe('RootLayout typography', () => {
+  it('exposes the Inter variable and shared font utility on the body', () => {
+    const layout = RootLayout({ children: <div>Content</div> });
+    const children = React.Children.toArray(layout.props.children) as React.ReactElement[];
+    const body = children.find((child) => child.type === 'body');
+
+    expect(body).toBeDefined();
+    expect(body?.props.className).toContain('inter-variable');
+    expect(body?.props.className).toContain('font-sans');
+  });
+});

--- a/apps/web/tests/components/navigation/Sidebar.test.tsx
+++ b/apps/web/tests/components/navigation/Sidebar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import Sidebar from '@/app/components/Sidebar';
+
+jest.mock('@/app/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+jest.mock('@/app/hooks/useSubscription', () => ({
+  useSubscription: () => ({ isActive: false }),
+}));
+
+describe('Sidebar', () => {
+  it('renders a stable labelled navigation rail for guests', () => {
+    render(<Sidebar />);
+
+    expect(screen.getByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Support' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByRole('complementary')).toHaveClass('w-24');
+  });
+});

--- a/apps/web/tests/components/ui/DesignPrimitives.test.tsx
+++ b/apps/web/tests/components/ui/DesignPrimitives.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Button } from '@/app/components/ui/Button';
+import Input from '@/app/components/ui/Input';
+import { Textarea } from '@/app/components/ui/Textarea';
+import { Switch } from '@/app/components/ui/Switch';
+import { SettingsCard } from '@/app/components/ui/SettingsCard';
+
+describe('Version 5 design primitives', () => {
+  it('uses the shared control contract for buttons and form fields', () => {
+    render(
+      <>
+        <Button>Continue</Button>
+        <Input aria-label="Name" />
+        <Textarea aria-label="Message" />
+      </>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toHaveClass('rounded-[var(--radius-control)]');
+    expect(screen.getByLabelText('Name')).toHaveClass('min-h-[var(--control-height)]');
+    expect(screen.getByLabelText('Message')).toHaveClass('rounded-[var(--radius-control)]');
+  });
+
+  it('keeps switch behavior and card semantics intact', () => {
+    const onChange = jest.fn();
+    render(
+      <SettingsCard title="Appearance">
+        <Switch label="High contrast" checked={false} onChange={onChange} />
+      </SettingsCard>,
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'High contrast' }));
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(screen.getByRole('region', { name: 'Appearance' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed
- replace the hover-expanding desktop sidebar with a fixed 96px navigation rail
- keep icons and labels visible with a restrained active indicator
- preserve guest, caregiver, subscription-lock, settings, support, and account behavior
- align the application content inset and add focused navigation coverage

## Validation
- full Jest suite: 482 tests passed
- ESLint passed
- Next.js production build passed

Depends on #712 / PR #727.
Closes #713