### PR TITLE
design: inset the workspace composer

### DIFF
--- a/apps/web/app/components/home/AACTabs.tsx
+++ b/apps/web/app/components/home/AACTabs.tsx
@@ -90,7 +90,7 @@ export default function AACTabs({ phrasesContent, typeContent }: AACTabsProps) {
               key="type"
               id="aac-tab-type"
               role="tabpanel"
-              className="absolute inset-0 flex flex-col"
+              className="absolute inset-0 flex flex-col px-3 pb-3 sm:px-4 sm:pb-4"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/apps/web/app/register-pwa.tsx
+++ b/apps/web/app/register-pwa.tsx
@@ -2,9 +2,30 @@
 
 import { useEffect } from 'react';
 
+const SAYIT_CACHE_PREFIX = 'sayit-shell-v';
+
+async function clearDevelopmentPwaState() {
+  if ('serviceWorker' in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+  }
+
+  if ('caches' in window) {
+    const cacheNames = await window.caches.keys();
+    await Promise.all(
+      cacheNames
+        .filter((cacheName) => cacheName.startsWith(SAYIT_CACHE_PREFIX))
+        .map((cacheName) => window.caches.delete(cacheName)),
+    );
+  }
+}
+
 export default function RegisterPWA() {
   useEffect(() => {
     if (process.env.NODE_ENV !== 'production') {
+      void clearDevelopmentPwaState().catch((error) => {
+        console.error('Failed to clear development PWA state:', error);
+      });
       return;
     }
 

--- a/apps/web/public/sw.template.js
+++ b/apps/web/public/sw.template.js
@@ -1,5 +1,6 @@
 const CACHE_NAME = 'sayit-shell-v__SW_CACHE_VERSION__';
 const OFFLINE_URL = '/offline';
+const IS_LOCALHOST = ['localhost', '127.0.0.1', '::1'].includes(self.location.hostname);
 const APP_SHELL = [
   '/',
   OFFLINE_URL,
@@ -50,6 +51,24 @@ async function cacheFirst(request) {
   }
 
   return response;
+}
+
+async function networkFirstAsset(request) {
+  const cache = await caches.open(CACHE_NAME);
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cachedResponse = await cache.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+    throw new Error('No cached static asset available');
+  }
 }
 
 async function staleWhileRevalidate(request) {
@@ -139,7 +158,7 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (isStaticAsset(request, requestUrl)) {
-    event.respondWith(cacheFirst(request));
+    event.respondWith(IS_LOCALHOST ? networkFirstAsset(request) : cacheFirst(request));
     return;
   }
 

--- a/apps/web/tests/app/RegisterPWA.test.tsx
+++ b/apps/web/tests/app/RegisterPWA.test.tsx
@@ -1,0 +1,43 @@
+import { render, waitFor } from '@testing-library/react';
+import RegisterPWA from '@/app/register-pwa';
+
+describe('RegisterPWA', () => {
+  const unregister = jest.fn(() => Promise.resolve(true));
+  const register = jest.fn();
+  const deleteCache = jest.fn(() => Promise.resolve(true));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        getRegistrations: jest.fn(() => Promise.resolve([{ unregister }])),
+        register,
+      },
+    });
+    Object.defineProperty(window, 'caches', {
+      configurable: true,
+      value: {
+        keys: jest.fn(() => Promise.resolve(['sayit-shell-v-old', 'unrelated-cache'])),
+        delete: deleteCache,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+    Reflect.deleteProperty(window, 'caches');
+  });
+
+  it('removes stale SayIt service workers and caches outside production', async () => {
+    render(<RegisterPWA />);
+
+    await waitFor(() => {
+      expect(unregister).toHaveBeenCalledTimes(1);
+      expect(deleteCache).toHaveBeenCalledWith('sayit-shell-v-old');
+    });
+    expect(deleteCache).not.toHaveBeenCalledWith('unrelated-cache');
+    expect(register).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/components/home/AACTabs.test.tsx
+++ b/apps/web/tests/components/home/AACTabs.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import AACTabs from '@/app/components/home/AACTabs';
+
+describe('AACTabs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('insets the Type workspace to reveal the composer corners', () => {
+    localStorage.setItem('aac-active-tab', 'type');
+
+    render(
+      <AACTabs
+        phrasesContent={<div>Phrases content</div>}
+        typeContent={<div>Type content</div>}
+      />,
+    );
+
+    expect(screen.getByRole('tabpanel')).toHaveClass(
+      'px-3',
+      'pb-3',
+      'sm:px-4',
+      'sm:pb-4',
+    );
+  });
+
+  it('leaves the Phrases workspace edge-to-edge', () => {
+    render(
+      <AACTabs
+        phrasesContent={<div>Phrases content</div>}
+        typeContent={<div>Type content</div>}
+      />,
+    );
+
+    expect(screen.getByRole('tabpanel')).not.toHaveClass(
+      'px-3',
+      'pb-3',
+      'sm:px-4',
+      'sm:pb-4',
+    );
+  });
+});


### PR DESCRIPTION
Closes #743.

## What changed

- Adds 12px left, right, and bottom spacing around the signed-in Type composer on mobile.
- Increases that inset to 16px from the small breakpoint upward.
- Leaves the top edge aligned beneath the AAC selector.
- Leaves the Phrases workspace and `/try` spacing unchanged.
- Clears stale SayIt service-worker registrations and caches during development.
- Uses network-first static assets with offline cache fallback on localhost, while retaining cache-first production behavior.
- Adds focused coverage for the Type/Phrases layout and development PWA cleanup.

## Root cause

The composer retained its token-based radius class, but a previously installed localhost PWA worker served an older cached CSS bundle that did not define `--radius-card`. The browser therefore computed the composer radius as `0px`. The new inset exposed that existing stale-style failure.

## Impact

The workspace background frames the composer and its 16px rounded corners render correctly. Local development no longer silently serves stale token CSS, while production offline behavior remains unchanged.

## Verification

- 69 Jest suites / 513 tests passed.
- Web ESLint passed.
- Landing Astro check passed with 0 diagnostics.
- Next.js and landing production builds passed.
- Manually refreshed and verified the signed-in Chrome workspace after clearing the stale worker/cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved spacing and responsive layout for the type workspace tab.
  * Local development now refreshes static assets from the network while retaining cached fallbacks.

* **Bug Fixes**
  * Development sessions now clear stale service worker registrations and cached app data, helping prevent outdated content.

* **Tests**
  * Added coverage for responsive tab layout and service worker/cache cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->