### PR TITLE
design: use a transparent theme-aware brand mark

### DIFF
--- a/apps/landing/src/components/Header.astro
+++ b/apps/landing/src/components/Header.astro
@@ -9,13 +9,16 @@ const appUrl = import.meta.env.PUBLIC_APP_URL ?? 'https://app.sayitaac.com';
     class="mx-auto flex max-w-[var(--container-wide)] flex-col gap-3 px-6 py-4 md:flex-row md:items-center md:justify-between md:gap-6 md:px-12 lg:px-16"
   >
     <a href="/" class="flex items-center gap-3 text-ink no-underline">
-      <img
-        src="/app-icon.png"
-        alt=""
-        width="32"
-        height="32"
-        class="h-8 w-8 rounded-md"
-      />
+      <svg
+        viewBox="0 0 1024 1024"
+        fill="currentColor"
+        aria-hidden="true"
+        focusable="false"
+        class="h-8 w-8 text-ink"
+      >
+        <path d="M366 190 405 238C319 308 267 404 267 506s52 198 138 269l-39 48C263 738 205 629 205 506s58-232 161-316Z"></path>
+        <path d="M592 296c114 0 206 93 206 207s-92 207-206 207c-32 0-63-7-93-22l-76 27c-9 3-17-5-15-15l18-75c-26-35-41-77-41-122 0-114 93-207 207-207Z"></path>
+      </svg>
       <span class="text-base font-bold tracking-tight">SayIt!</span>
     </a>
     <nav

--- a/apps/web/app/components/BrandMark.tsx
+++ b/apps/web/app/components/BrandMark.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react';
+
+type BrandMarkProps = Omit<SVGProps<SVGSVGElement>, 'children'>;
+
+export default function BrandMark({ className = '', ...props }: BrandMarkProps) {
+  return (
+    <svg
+      viewBox="0 0 1024 1024"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+      {...props}
+    >
+      <path d="M366 190 405 238C319 308 267 404 267 506s52 198 138 269l-39 48C263 738 205 629 205 506s58-232 161-316Z" />
+      <path d="M592 296c114 0 206 93 206 207s-92 207-206 207c-32 0-63-7-93-22l-76 27c-9 3-17-5-15-15l18-75c-26-35-41-77-41-122 0-114 93-207 207-207Z" />
+    </svg>
+  );
+}

--- a/apps/web/app/components/Sidebar.tsx
+++ b/apps/web/app/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { useAuth } from '../contexts/AuthContext';
 import { usePathname } from 'next/navigation';
 import { useQuery } from 'convex/react';
@@ -16,6 +15,7 @@ import {
   LockClosedIcon,
 } from '@heroicons/react/24/outline';
 import { UserButton } from '@clerk/nextjs';
+import BrandMark from './BrandMark';
 
 export default function Sidebar() {
   const { user } = useAuth();
@@ -27,7 +27,7 @@ export default function Sidebar() {
   return (
     <aside className="fixed inset-y-0 left-0 z-50 hidden w-24 flex-col border-r border-border bg-surface md:flex">
       <Link href="/" aria-label="SayIt! home" className="flex h-20 items-center justify-center">
-        <Image src="/icons/app-icon.png" alt="" width={36} height={36} priority />
+        <BrandMark data-testid="brand-mark" className="h-9 w-9 text-foreground" />
       </Link>
 
       <nav aria-label="Primary navigation" className="flex-1 space-y-2 px-2 py-2">

--- a/apps/web/tests/components/navigation/Sidebar.test.tsx
+++ b/apps/web/tests/components/navigation/Sidebar.test.tsx
@@ -17,5 +17,9 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: 'Support' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
     expect(screen.getByRole('complementary')).toHaveClass('w-24');
+
+    const homeLink = screen.getByRole('link', { name: 'SayIt! home' });
+    expect(homeLink.querySelector('[data-testid="brand-mark"]')).toHaveClass('text-foreground');
+    expect(homeLink.querySelector('img')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #745.

## What changed

- Replaces the white-square raster in the desktop app rail with a transparent inline SVG mark.
- Makes the app mark inherit `text-foreground`, adapting automatically to light and dark themes.
- Uses the matching SVG geometry and landing foreground color in the marketing header.
- Preserves existing sizes, labelled home links, and navigation behavior.
- Adds focused coverage ensuring the sidebar no longer renders a raster image.

## Asset safety

All favicon, PWA, Apple-touch, manifest, and metadata raster files remain unchanged. The working copies match their committed blob hashes.

## Verification

- 69 Jest suites / 513 tests passed.
- Web ESLint passed.
- Landing Astro check passed with 0 diagnostics.
- Next.js and landing production builds passed.
- Manually verified the app rail in light and dark themes.
- Manually verified the landing header at desktop width.
