### PR TITLE
release: v5.0.0

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Release

Prepares SayIt! `v5.0.0` from the completed Version 5 milestone.

## Changes

- Bumps the workspace root, web app, and landing app versions from `4.5.0` to `5.0.0` in lockstep.
- Leaves application behavior unchanged; the feature work is already merged into `main`.

## Verification

- `pnpm test`: 70 suites and 516 tests passed.
- `pnpm lint`: ESLint and Astro Check passed with zero diagnostics.
- `pnpm build`: web and landing production builds passed using the `v5.0.0` version and service-worker cache key.
- `pnpm install`: lockfile confirmed current.
