### PR TITLE
fix: restore Voice Quality selected-state contrast

### DIFF
--- a/apps/web/app/components/TTSSettings.tsx
+++ b/apps/web/app/components/TTSSettings.tsx
@@ -389,15 +389,18 @@ export default function TTSSettings() {
       {/* Voice Quality Card (ElevenLabs only) */}
       {displayProvider === 'elevenlabs' && hasSubscription && (
         <div className="space-y-3">
-          <h3 className="text-sm font-medium text-foreground">Voice Quality</h3>
-          <div className="grid grid-cols-2 gap-3">
+          <h3 id="voice-quality-label" className="text-sm font-medium text-foreground">Voice Quality</h3>
+          <div role="radiogroup" aria-labelledby="voice-quality-label" className="grid grid-cols-2 gap-3">
             <button
               type="button"
+              role="radio"
+              aria-checked={settings.ttsModelPreference === 'fast'}
+              aria-label="Fast — Low latency"
               onClick={() => updateSetting('ttsModelPreference', 'fast')}
-              className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
+              className={`relative min-h-[72px] rounded-2xl border-2 p-4 text-left transition-colors duration-[var(--motion-duration-fast)] ${
                 settings.ttsModelPreference === 'fast'
-                  ? 'border-primary-500 bg-primary-900'
-                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
+                  ? 'border-primary-500 bg-[var(--accent-surface)] text-[var(--accent-foreground)]'
+                  : 'border-border bg-surface text-foreground hover:border-border hover:bg-surface-hover'
               }`}
             >
               <div className="flex items-start gap-3">
@@ -413,19 +416,22 @@ export default function TTSSettings() {
                   )}
                 </div>
                 <div className="min-w-0">
-                  <span className="block font-medium text-foreground text-sm">Fast</span>
-                  <span className="block text-xs text-text-secondary mt-0.5">Low latency</span>
+                  <span className={`block text-sm font-medium ${settings.ttsModelPreference === 'fast' ? 'text-[var(--accent-foreground)]' : 'text-foreground'}`}>Fast</span>
+                  <span className={`mt-0.5 block text-xs ${settings.ttsModelPreference === 'fast' ? 'text-[var(--accent-foreground)]' : 'text-text-secondary'}`}>Low latency</span>
                 </div>
               </div>
             </button>
 
             <button
               type="button"
+              role="radio"
+              aria-checked={settings.ttsModelPreference === 'high_quality'}
+              aria-label="High Quality — More expressive"
               onClick={() => updateSetting('ttsModelPreference', 'high_quality')}
-              className={`relative p-4 rounded-2xl border-2 text-left transition-all min-h-[72px] ${
+              className={`relative min-h-[72px] rounded-2xl border-2 p-4 text-left transition-colors duration-[var(--motion-duration-fast)] ${
                 settings.ttsModelPreference === 'high_quality'
-                  ? 'border-primary-500 bg-primary-900'
-                  : 'border-border bg-surface hover:border-border hover:bg-surface-hover'
+                  ? 'border-primary-500 bg-[var(--accent-surface)] text-[var(--accent-foreground)]'
+                  : 'border-border bg-surface text-foreground hover:border-border hover:bg-surface-hover'
               }`}
             >
               <div className="flex items-start gap-3">
@@ -441,8 +447,8 @@ export default function TTSSettings() {
                   )}
                 </div>
                 <div className="min-w-0">
-                  <span className="block font-medium text-foreground text-sm">High Quality</span>
-                  <span className="block text-xs text-text-secondary mt-0.5">More expressive</span>
+                  <span className={`block text-sm font-medium ${settings.ttsModelPreference === 'high_quality' ? 'text-[var(--accent-foreground)]' : 'text-foreground'}`}>High Quality</span>
+                  <span className={`mt-0.5 block text-xs ${settings.ttsModelPreference === 'high_quality' ? 'text-[var(--accent-foreground)]' : 'text-text-secondary'}`}>More expressive</span>
                 </div>
               </div>
             </button>

--- a/apps/web/tests/components/TTSSettings.test.tsx
+++ b/apps/web/tests/components/TTSSettings.test.tsx
@@ -307,4 +307,44 @@ describe('TTSSettings provider dropdown', () => {
     expect(screen.getByRole('button', { name: 'Browser TTS' })).toBeInTheDocument();
     expect(mockUpdateSetting).not.toHaveBeenCalledWith('ttsProvider', 'browser');
   });
+
+  it('uses theme-aware accent colors and radio semantics for the selected Fast quality', () => {
+    renderTTSSettings({
+      settings: { ttsProvider: 'elevenlabs', ttsVoiceId: 'eleven-voice-1', ttsModelPreference: 'fast' },
+    });
+
+    const group = screen.getByRole('radiogroup', { name: 'Voice Quality' });
+    const fast = within(group).getByRole('radio', { name: 'Fast — Low latency' });
+    const highQuality = within(group).getByRole('radio', { name: 'High Quality — More expressive' });
+
+    expect(fast).toHaveAttribute('aria-checked', 'true');
+    expect(fast).toHaveClass('bg-[var(--accent-surface)]', 'text-[var(--accent-foreground)]');
+    expect(screen.getByText('Fast')).toHaveClass('text-[var(--accent-foreground)]');
+    expect(screen.getByText('Low latency')).toHaveClass('text-[var(--accent-foreground)]');
+    expect(highQuality).toHaveAttribute('aria-checked', 'false');
+    expect(highQuality).toHaveClass('bg-surface', 'text-foreground');
+  });
+
+  it('uses theme-aware accent colors for High Quality and preserves both setting callbacks', async () => {
+    const user = userEvent.setup();
+    renderTTSSettings({
+      settings: { ttsProvider: 'elevenlabs', ttsVoiceId: 'eleven-voice-1', ttsModelPreference: 'high_quality' },
+    });
+
+    const group = screen.getByRole('radiogroup', { name: 'Voice Quality' });
+    const fast = within(group).getByRole('radio', { name: 'Fast — Low latency' });
+    const highQuality = within(group).getByRole('radio', { name: 'High Quality — More expressive' });
+
+    expect(highQuality).toHaveAttribute('aria-checked', 'true');
+    expect(highQuality).toHaveClass('bg-[var(--accent-surface)]', 'text-[var(--accent-foreground)]');
+    expect(screen.getByText('High Quality')).toHaveClass('text-[var(--accent-foreground)]');
+    expect(screen.getByText('More expressive')).toHaveClass('text-[var(--accent-foreground)]');
+    expect(fast).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(fast);
+    await user.click(highQuality);
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith('ttsModelPreference', 'fast');
+    expect(mockUpdateSetting).toHaveBeenCalledWith('ttsModelPreference', 'high_quality');
+  });
 });


### PR DESCRIPTION
Closes #752.

## Root cause

The selected ElevenLabs Voice Quality card used the fixed dark `primary-900` background while its title and description continued to use theme foreground tokens. In light mode that produced unreadable dark-on-dark text.

## What changed

- Uses the existing theme-aware accent surface and foreground for both selected quality choices.
- Keeps normal semantic surface and text colors for unselected choices.
- Labels the choices as a Voice Quality radio group with accurate `aria-checked` state.
- Replaces unrestricted transitions with the Version 5 color-transition token.
- Preserves the existing setting values, callbacks, model selection, and subscription behavior.

## Verification

- 70 Jest suites and 518 tests passed.
- ESLint and Astro Check passed with zero diagnostics.
- Web and landing production builds passed.
- Selected-state contrast measures 6.73:1 in light mode and 11.48:1 in dark mode.
- Manually verified both choices, keyboard activation, high contrast, and no overflow at 390×844 and 1440×900 in Chrome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the ElevenLabs Voice Quality selector with radio-group semantics and clearer labels for assistive technologies.

* **UI Improvements**
  * Refined selected and unselected states with theme-aware colors and smoother transitions.
  * Preserved clear visual feedback when switching between Fast and High Quality options.

* **Bug Fixes**
  * Improved reliability of Voice Quality selection and state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->