### PR TITLE
release: v5.0.1

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Release

Prepares SayIt! `v5.0.1` from the completed patch milestone.

## Changes

- Bumps the workspace root, web app, and landing app versions from `5.0.0` to `5.0.1` in lockstep.
- Includes the merged Voice Quality selected-state contrast and radio-semantics fix from #753.

## Verification

- `pnpm test`: 70 suites and 518 tests passed.
- `pnpm lint`: ESLint and Astro Check passed with zero diagnostics.
- `pnpm build`: web and landing production builds passed with the `v5.0.1` service-worker cache key.
- `pnpm install`: lockfile confirmed current.
