### PR TITLE
feature: add QR code to Live Typing sharing

### DIFF
--- a/apps/web/app/components/live-typing/LiveTypingBottomSheet.tsx
+++ b/apps/web/app/components/live-typing/LiveTypingBottomSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { ClipboardIcon, CheckIcon, ArrowPathIcon, ShareIcon, StopIcon } from '@heroicons/react/24/outline';
+import { QRCodeSVG } from 'qrcode.react';
 import BottomSheet from '@/app/components/ui/BottomSheet';
 
 interface LiveTypingBottomSheetProps {
@@ -63,8 +64,8 @@ export default function LiveTypingBottomSheet({
       isOpen={isOpen}
       onClose={onClose}
       title="Live Typing Session"
-      snapPoints={[40]}
-      initialSnap={0}
+      snapPoints={isSharing ? [75, 90] : [40]}
+      initialSnap={isSharing ? 1 : 0}
     >
       <div className="p-4 space-y-4">
         {!isSharing ? (
@@ -110,22 +111,52 @@ export default function LiveTypingBottomSheet({
               Share this link with others to let them see what you're typing in real-time.
             </p>
 
+            {shareableLink ? (
+              <figure className="flex flex-col items-center gap-2">
+                <div className="w-full max-w-[14rem] rounded-[var(--radius-card)] border border-border bg-white p-3 shadow-[var(--shadow-control)]">
+                  <QRCodeSVG
+                    value={shareableLink}
+                    size={224}
+                    level="M"
+                    marginSize={4}
+                    bgColor="#FFFFFF"
+                    fgColor="#000000"
+                    title="QR code for Live Typing share link"
+                    className="h-auto w-full"
+                  />
+                </div>
+                <figcaption className="text-center text-sm text-text-secondary">
+                  Scan to open this Live Typing session on another device.
+                </figcaption>
+              </figure>
+            ) : (
+              <div
+                role="status"
+                aria-live="polite"
+                className="rounded-[var(--radius-control)] border border-border bg-surface-hover px-4 py-3 text-center text-sm text-text-secondary"
+              >
+                Preparing share link…
+              </div>
+            )}
+
             {/* Link display with copy button */}
             <div className="flex gap-2">
               <input
                 type="text"
                 value={shareableLink || ''}
                 readOnly
+                aria-label="Live Typing share link"
                 className="flex-1 px-4 py-3 bg-background border border-border rounded-xl text-foreground text-sm"
               />
               <button
                 onClick={handleCopy}
+                disabled={!shareableLink}
                 className={`min-w-[48px] min-h-[48px] px-4 rounded-xl transition-colors flex items-center justify-center ${
                   copied
                     ? 'bg-green-500 text-white'
                     : 'bg-primary-500 hover:bg-primary-600 text-white'
-                }`}
-                aria-label="Copy link"
+                } disabled:cursor-not-allowed disabled:opacity-50`}
+                aria-label={copied ? 'Live Typing link copied' : 'Copy Live Typing link'}
               >
                 {copied ? (
                   <CheckIcon className="w-5 h-5" />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "jszip": "^3.10.1",
     "nanoid": "^5.1.16",
     "next": "^16.2.10",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-media-recorder": "^1.7.2",

--- a/apps/web/tests/components/LiveTypingBottomSheet.test.tsx
+++ b/apps/web/tests/components/LiveTypingBottomSheet.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LiveTypingBottomSheet from '@/app/components/live-typing/LiveTypingBottomSheet';
+
+jest.mock('@/app/components/ui/BottomSheet', () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    children,
+    title,
+    snapPoints,
+    initialSnap,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    title?: string;
+    snapPoints?: number[];
+    initialSnap?: number;
+  }) =>
+    isOpen ? (
+      <div
+        role="dialog"
+        aria-label={title}
+        data-snap-points={JSON.stringify(snapPoints)}
+        data-initial-snap={initialSnap}
+      >
+        {children}
+      </div>
+    ) : null,
+}));
+
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: ({
+    value,
+    level,
+    marginSize,
+    bgColor,
+    fgColor,
+    title,
+  }: {
+    value: string;
+    level: string;
+    marginSize: number;
+    bgColor: string;
+    fgColor: string;
+    title: string;
+  }) => (
+    <svg
+      role="img"
+      aria-label={title}
+      data-testid="live-typing-qr"
+      data-value={value}
+      data-level={level}
+      data-margin-size={marginSize}
+      data-background={bgColor}
+      data-foreground={fgColor}
+    />
+  ),
+}));
+
+const shareableLink = 'https://app.sayitaac.com/typing-share/view/session-key';
+
+function renderSheet(
+  overrides: Partial<React.ComponentProps<typeof LiveTypingBottomSheet>> = {}
+) {
+  const props: React.ComponentProps<typeof LiveTypingBottomSheet> = {
+    isOpen: true,
+    onClose: jest.fn(),
+    isSharing: true,
+    isCreating: false,
+    shareableLink,
+    onStartSharing: jest.fn().mockResolvedValue(undefined),
+    onEndSession: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+
+  return {
+    ...render(<LiveTypingBottomSheet {...props} />),
+    props,
+  };
+}
+
+function installClipboard() {
+  const clipboard = {
+    writeText: jest.fn().mockResolvedValue(undefined),
+  };
+  Object.defineProperty(navigator, 'clipboard', {
+    value: clipboard,
+    configurable: true,
+    writable: true,
+  });
+  return clipboard;
+}
+
+describe('LiveTypingBottomSheet', () => {
+  it('keeps the inactive sheet compact and starts sharing without a QR code', async () => {
+    const user = userEvent.setup();
+    const { props } = renderSheet({
+      isSharing: false,
+      shareableLink: null,
+    });
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-snap-points', '[40]');
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-initial-snap', '0');
+    expect(screen.queryByTestId('live-typing-qr')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Start Live Typing' }));
+
+    expect(props.onStartSharing).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the exact share URL as an accessible, scanner-friendly QR code', () => {
+    renderSheet();
+
+    const qrCode = screen.getByRole('img', {
+      name: 'QR code for Live Typing share link',
+    });
+    expect(qrCode).toHaveAttribute('data-value', shareableLink);
+    expect(qrCode).toHaveAttribute('data-level', 'M');
+    expect(qrCode).toHaveAttribute('data-margin-size', '4');
+    expect(qrCode).toHaveAttribute('data-background', '#FFFFFF');
+    expect(qrCode).toHaveAttribute('data-foreground', '#000000');
+    expect(
+      screen.getByText('Scan to open this Live Typing session on another device.')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Live Typing share link')).toHaveValue(shareableLink);
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-snap-points', '[75,90]');
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-initial-snap', '1');
+  });
+
+  it('copies the share URL and announces success in the button name', async () => {
+    const user = userEvent.setup();
+    const clipboard = installClipboard();
+    renderSheet();
+
+    await user.click(screen.getByRole('button', { name: 'Copy Live Typing link' }));
+
+    await waitFor(() => {
+      expect(clipboard.writeText).toHaveBeenCalledWith(shareableLink);
+    });
+    expect(
+      screen.getByRole('button', { name: 'Live Typing link copied' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows a preparation state and disables copy while the URL is unavailable', () => {
+    renderSheet({ shareableLink: null });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Preparing share link…');
+    expect(screen.queryByTestId('live-typing-qr')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy Live Typing link' })).toBeDisabled();
+  });
+
+  it('ends the session and closes the sheet', async () => {
+    const user = userEvent.setup();
+    const { props } = renderSheet();
+
+    await user.click(screen.getByRole('button', { name: 'End Live Typing' }));
+
+    await waitFor(() => {
+      expect(props.onEndSession).toHaveBeenCalledTimes(1);
+    });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       next:
         specifier: ^16.2.10
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -5764,6 +5767,11 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -12985,6 +12993,10 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@7.0.1: {}
+
+  qrcode.react@4.2.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary

- render a locally generated SVG QR code for the active Live Typing viewer URL
- preserve the readable URL, Copy action, and existing session lifecycle
- make the active sheet open at a mobile-friendly 90% snap point
- add accessible preparation and copy feedback states

## Validation

- pnpm test ? 71 suites, 523 tests passed
- pnpm lint ? passed
- pnpm build ? passed
- signed-in Chrome: verified QR rendering at 320x568 and 390x844 with no horizontal overflow
- verified the QR URL opens the viewer, live text updates arrive, and ending the session invalidates the viewer

Closes #757


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a QR code for sharing live-typing sessions.
  * Added a “Preparing share link…” status while the share link is unavailable.
  * Improved accessibility labels for sharing controls.
  * Updated the sheet layout based on sharing status.

* **Bug Fixes**
  * Disabled copying until a share link is ready.
  * Added clearer disabled-state styling for the copy button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->