### PR TITLE
release: v5.0.3

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- release the Live Typing share QR code
- bump root, web, and landing package versions to v5.0.3

## Validation

- pnpm test ? 71 suites, 523 tests passed
- pnpm lint ? passed
- pnpm build ? passed
- signed-in responsive and real-time browser verification completed

Milestone: v5.0.3
