### PR TITLE
feature: pause and resume Live Typing

### DIFF
--- a/apps/web/app/components/composer/Composer.tsx
+++ b/apps/web/app/components/composer/Composer.tsx
@@ -172,6 +172,10 @@ export default function Composer({
         {/* Live typing status — always visible while a session is being shared */}
         {enableLiveTyping && actions.user && actions.isLiveTypingSharing && (
           <LiveTypingBanner
+            isPaused={actions.isLiveTypingPaused}
+            isTransitioning={actions.isLiveTypingTransitioning}
+            onPause={() => void actions.handlePauseLiveTyping()}
+            onResume={() => void actions.handleResumeLiveTyping()}
             onEnd={() => void actions.endLiveTypingSession()}
             onOpenDetails={() => setShowLiveTypingSheet(true)}
           />
@@ -252,8 +256,13 @@ export default function Composer({
           onClose={() => setShowLiveTypingSheet(false)}
           isSharing={actions.isLiveTypingSharing}
           isCreating={actions.isLiveTypingCreating}
+          isPaused={actions.isLiveTypingPaused}
+          isTransitioning={actions.isLiveTypingTransitioning}
+          error={actions.liveTypingError}
           shareableLink={actions.shareableLink}
           onStartSharing={actions.handleStartLiveTyping}
+          onPauseSession={actions.handlePauseLiveTyping}
+          onResumeSession={actions.handleResumeLiveTyping}
           onEndSession={async () => { await actions.endLiveTypingSession(); }}
         />
       )}

--- a/apps/web/app/components/composer/useComposerActions.ts
+++ b/apps/web/app/components/composer/useComposerActions.ts
@@ -54,8 +54,13 @@ export function useComposerActions({
   const {
     isSharing: isLiveTypingSharing,
     isCreating: isLiveTypingCreating,
+    isPaused: isLiveTypingPaused,
+    isTransitioning: isLiveTypingTransitioning,
+    error: liveTypingError,
     updateContent: updateLiveTypingContent,
     createSession: createLiveTypingSession,
+    pauseSession: pauseLiveTypingSession,
+    resumeSession: resumeLiveTypingSession,
     endSession: endLiveTypingSession,
     getShareableLink,
   } = useLiveTyping();
@@ -172,10 +177,10 @@ export function useComposerActions({
 
   // Live typing content sync
   useEffect(() => {
-    if (enableLiveTyping && user && isLiveTypingSharing) {
+    if (enableLiveTyping && user && isLiveTypingSharing && !isLiveTypingPaused) {
       updateLiveTypingContent(currentText);
     }
-  }, [currentText, enableLiveTyping, isLiveTypingSharing, updateLiveTypingContent, user]);
+  }, [currentText, enableLiveTyping, isLiveTypingPaused, isLiveTypingSharing, updateLiveTypingContent, user]);
 
   const handleStartLiveTyping = useCallback(async () => {
     const created = await createLiveTypingSession();
@@ -183,6 +188,14 @@ export function useComposerActions({
       updateLiveTypingContent(currentText);
     }
   }, [createLiveTypingSession, currentText, updateLiveTypingContent]);
+
+  const handlePauseLiveTyping = useCallback(async () => {
+    await pauseLiveTypingSession();
+  }, [pauseLiveTypingSession]);
+
+  const handleResumeLiveTyping = useCallback(async () => {
+    await resumeLiveTypingSession(currentText);
+  }, [currentText, resumeLiveTypingSession]);
 
   // Fix text
   const handleFixText = useCallback(async () => {
@@ -254,8 +267,13 @@ export function useComposerActions({
     isLiveTypingButtonActive,
     isLiveTypingSharing,
     isLiveTypingCreating,
+    isLiveTypingPaused,
+    isLiveTypingTransitioning,
+    liveTypingError,
     shareableLink,
     handleStartLiveTyping,
+    handlePauseLiveTyping,
+    handleResumeLiveTyping,
     endLiveTypingSession,
     // context
     isOnline,

--- a/apps/web/app/components/live-typing/LiveTypingBanner.tsx
+++ b/apps/web/app/components/live-typing/LiveTypingBanner.tsx
@@ -1,40 +1,86 @@
 'use client';
 
+import { PauseIcon, PlayIcon } from '@heroicons/react/24/solid';
+
 interface LiveTypingBannerProps {
-  /** Ends the live typing session immediately. */
+  isPaused: boolean;
+  isTransitioning: boolean;
+  onPause: () => void;
+  onResume: () => void;
   onEnd: () => void;
-  /** Reopens the live typing sheet (share link, session details). */
   onOpenDetails: () => void;
 }
 
-export default function LiveTypingBanner({ onEnd, onOpenDetails }: LiveTypingBannerProps) {
+export default function LiveTypingBanner({
+  isPaused,
+  isTransitioning,
+  onPause,
+  onResume,
+  onEnd,
+  onOpenDetails,
+}: LiveTypingBannerProps) {
   return (
     <div
-      role="status"
-      aria-live="polite"
-      className="flex shrink-0 items-center gap-3 border-b border-green-500/40 bg-status-success px-4 py-2"
+      className={`flex shrink-0 items-center gap-2 border-b px-2 py-2 sm:px-4 ${
+        isPaused
+          ? 'border-amber-500/50 bg-status-warning'
+          : 'border-green-500/40 bg-status-success'
+      }`}
     >
       <button
         type="button"
         onClick={onOpenDetails}
-        className="flex min-w-0 flex-1 items-center gap-3 text-left"
-        aria-label="Live Typing active — view session details"
+        className="flex min-h-11 min-w-0 flex-1 items-center gap-2 rounded-[var(--radius-control)] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+        aria-label={`Live Typing ${isPaused ? 'paused' : 'active'} — view session details`}
       >
-        <span className="relative flex h-2.5 w-2.5 shrink-0" aria-hidden>
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
-          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-green-500" />
+        <span className="relative flex h-2.5 w-2.5 shrink-0" aria-hidden="true">
+          {!isPaused && (
+            <span className="absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75 motion-safe:animate-ping" />
+          )}
+          <span
+            className={`relative inline-flex h-2.5 w-2.5 rounded-full ${
+              isPaused ? 'bg-amber-500' : 'bg-green-500'
+            }`}
+          />
         </span>
-        <span className="min-w-0">
-          <span className="block text-sm font-semibold text-green-400">Live Typing active</span>
-          <span className="block truncate text-xs text-text-secondary">
-            Others can see what you type
+        <span className="min-w-0" role="status" aria-live="polite">
+          <span
+            className={`block truncate text-sm font-semibold ${
+              isPaused
+                ? 'text-status-warning-foreground'
+                : 'text-status-success-foreground'
+            }`}
+          >
+            Live Typing {isPaused ? 'paused' : 'active'}
+          </span>
+          <span className="hidden truncate text-xs text-text-secondary sm:block">
+            {isPaused
+              ? 'Your typing is private until you resume'
+              : 'Others can see what you type'}
           </span>
         </span>
       </button>
+
+      <button
+        type="button"
+        onClick={isPaused ? onResume : onPause}
+        disabled={isTransitioning}
+        className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded-[var(--radius-control)] border border-border bg-surface px-3 text-sm font-semibold text-foreground transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-wait disabled:opacity-50"
+        aria-label={isPaused ? 'Resume Live Typing' : 'Pause Live Typing'}
+      >
+        {isPaused ? (
+          <PlayIcon className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <PauseIcon className="h-4 w-4" aria-hidden="true" />
+        )}
+        <span className="hidden sm:inline">{isPaused ? 'Resume' : 'Pause'}</span>
+      </button>
+
       <button
         type="button"
         onClick={onEnd}
-        className="shrink-0 rounded-full bg-green-500 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-green-600 transition-colors"
+        disabled={isTransitioning}
+        className="min-h-11 shrink-0 rounded-[var(--radius-control)] bg-error px-3 text-xs font-semibold text-white transition-colors hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-wait disabled:opacity-50"
         aria-label="End live typing"
       >
         End

--- a/apps/web/app/components/live-typing/LiveTypingBottomSheet.tsx
+++ b/apps/web/app/components/live-typing/LiveTypingBottomSheet.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { useState } from 'react';
-import { ClipboardIcon, CheckIcon, ArrowPathIcon, ShareIcon, StopIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowPathIcon,
+  CheckIcon,
+  ClipboardIcon,
+  PauseIcon,
+  PlayIcon,
+  ShareIcon,
+  StopIcon,
+} from '@heroicons/react/24/outline';
 import { QRCodeSVG } from 'qrcode.react';
 import BottomSheet from '@/app/components/ui/BottomSheet';
 
@@ -10,8 +18,13 @@ interface LiveTypingBottomSheetProps {
   onClose: () => void;
   isSharing: boolean;
   isCreating: boolean;
+  isPaused: boolean;
+  isTransitioning: boolean;
+  error: string | null;
   shareableLink: string | null;
   onStartSharing: () => Promise<void>;
+  onPauseSession: () => Promise<void>;
+  onResumeSession: () => Promise<void>;
   onEndSession: () => Promise<void>;
 }
 
@@ -20,8 +33,13 @@ export default function LiveTypingBottomSheet({
   onClose,
   isSharing,
   isCreating,
+  isPaused,
+  isTransitioning,
+  error,
   shareableLink,
   onStartSharing,
+  onPauseSession,
+  onResumeSession,
   onEndSession,
 }: LiveTypingBottomSheetProps) {
   const [copied, setCopied] = useState(false);
@@ -102,14 +120,39 @@ export default function LiveTypingBottomSheet({
         ) : (
           /* Currently active - show link and controls */
           <div className="space-y-4">
-            <div className="bg-status-success p-3 rounded-xl flex items-center gap-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-              <span className="text-green-400 text-sm font-medium">Live Typing Active</span>
+            <div
+              role="status"
+              aria-live="polite"
+              className={`flex items-center gap-2 rounded-[var(--radius-control)] border p-3 ${
+                isPaused
+                  ? 'border-amber-500/50 bg-status-warning text-status-warning-foreground'
+                  : 'border-green-500/50 bg-status-success text-status-success-foreground'
+              }`}
+            >
+              <div
+                className={`h-2 w-2 rounded-full ${
+                  isPaused ? 'bg-amber-500' : 'bg-green-500 motion-safe:animate-pulse'
+                }`}
+              />
+              <span className="text-sm font-medium">
+                Live Typing {isPaused ? 'Paused' : 'Active'}
+              </span>
             </div>
 
             <p className="text-text-secondary text-sm">
-              Share this link with others to let them see what you're typing in real-time.
+              {isPaused
+                ? 'The last shared message remains visible. Your typing is private until you resume.'
+                : 'Share this link with others to let them see what you’re typing in real-time.'}
             </p>
+
+            {error && (
+              <div
+                role="alert"
+                className="rounded-[var(--radius-control)] border border-red-500/50 bg-status-error px-4 py-3 text-sm text-status-error-foreground"
+              >
+                {error}
+              </div>
+            )}
 
             {shareableLink ? (
               <figure className="flex flex-col items-center gap-2">
@@ -166,10 +209,30 @@ export default function LiveTypingBottomSheet({
               </button>
             </div>
 
+            <button
+              type="button"
+              onClick={isPaused ? onResumeSession : onPauseSession}
+              disabled={isTransitioning || isEnding}
+              className="flex min-h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-control)] border border-border bg-surface-hover px-6 py-3 font-semibold text-foreground transition-colors hover:border-primary-500 hover:bg-primary-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-wait disabled:opacity-50"
+            >
+              {isTransitioning ? (
+                <ArrowPathIcon className="h-5 w-5 motion-safe:animate-spin" aria-hidden="true" />
+              ) : isPaused ? (
+                <PlayIcon className="h-5 w-5" aria-hidden="true" />
+              ) : (
+                <PauseIcon className="h-5 w-5" aria-hidden="true" />
+              )}
+              <span>
+                {isTransitioning
+                  ? (isPaused ? 'Resuming…' : 'Pausing…')
+                  : (isPaused ? 'Resume Live Typing' : 'Pause Live Typing')}
+              </span>
+            </button>
+
             {/* End session button */}
             <button
               onClick={handleEndSession}
-              disabled={isEnding}
+              disabled={isEnding || isTransitioning}
               className="w-full min-h-[48px] px-6 py-3 rounded-xl font-medium transition-all duration-200 flex items-center justify-center gap-2 bg-red-500 hover:bg-red-600 text-white disabled:opacity-50"
             >
               {isEnding ? (

--- a/apps/web/app/typing-share/view/[key]/page.tsx
+++ b/apps/web/app/typing-share/view/[key]/page.tsx
@@ -14,6 +14,7 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
   const { uiPreferences, updateUIPreference } = useSettings();
   const loading = session === undefined;
   const sessionMissing = session === null;
+  const isPaused = Boolean(session?.isPaused);
   const fontSize = uiPreferences.typingShareFontSize;
   const {
     audioEnabled,
@@ -58,8 +59,10 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
         <div className="bg-surface rounded-3xl shadow-2xl hover:shadow-3xl transition-all duration-300">
           <div className="p-6 sm:p-8">
             <h1 className="text-3xl font-bold text-foreground">Live Typing</h1>
-            <p className="text-text-secondary mt-2">
-              You are viewing a live typing session. Updates appear in real-time.
+            <p className="mt-2 text-text-secondary" aria-live="polite">
+              {isPaused
+                ? 'The communicator has paused sharing. The last shared message remains visible.'
+                : 'You are viewing a live typing session. Updates appear in real-time.'}
             </p>
             <div className="mt-4 flex flex-wrap items-center gap-3">
               {!audioEnabled ? (
@@ -74,7 +77,7 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
               ) : (
                 <div className="inline-flex min-h-[36px] items-center gap-2 rounded-full bg-status-info px-4 py-2 text-sm font-semibold text-blue-400">
                   <SpeakerWaveIcon className="h-5 w-5" />
-                  <span>{isSpeaking ? 'Speaking' : 'Audio enabled'}</span>
+                  <span>{isPaused ? 'Audio paused' : (isSpeaking ? 'Speaking' : 'Audio enabled')}</span>
                 </div>
               )}
               {speechError && (
@@ -104,9 +107,21 @@ export default function TypingShareViewPage({ params }: { params: Promise<{ key:
             </div>
 
             <div className="mt-6 flex items-center justify-between">
-              <div className="flex items-center gap-3 bg-status-success px-4 py-2 rounded-3xl">
-                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-                <span className="text-sm font-semibold text-green-500">Connected</span>
+              <div
+                role="status"
+                aria-live="polite"
+                className={`flex min-h-11 items-center gap-3 rounded-[var(--radius-control)] border px-4 py-2 ${
+                  isPaused
+                    ? 'border-amber-500/50 bg-status-warning text-status-warning-foreground'
+                    : 'border-green-500/50 bg-status-success text-status-success-foreground'
+                }`}
+              >
+                <div
+                  className={`h-2 w-2 rounded-full ${
+                    isPaused ? 'bg-amber-500' : 'bg-green-500 motion-safe:animate-pulse'
+                  }`}
+                />
+                <span className="text-sm font-semibold">{isPaused ? 'Paused' : 'Connected'}</span>
               </div>
 
               <div className="flex items-center gap-3">

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -157,6 +157,8 @@ export default defineSchema({
     userId: v.string(), // Clerk user ID
     sessionKey: v.string(),
     content: v.string(),
+    // Optional for backwards compatibility with sessions created before v5.0.4.
+    isPaused: v.optional(v.boolean()),
     speechCommand: v.optional(v.object({
       id: v.string(),
       action: v.union(v.literal('speak'), v.literal('stop')),

--- a/apps/web/convex/typingSessions.ts
+++ b/apps/web/convex/typingSessions.ts
@@ -65,6 +65,7 @@ export const createTypingSession = mutation({
       userId: identity.subject,
       sessionKey: args.sessionKey,
       content: '',
+      isPaused: false,
       expiresAt,
     });
 
@@ -93,9 +94,52 @@ export const updateTypingSessionContent = mutation({
       throw new Error('Unauthorized');
     }
 
+    if (session.isPaused) {
+      return false;
+    }
+
     await ctx.db.patch(session._id, {
       content: args.content,
     });
+
+    return true;
+  },
+});
+
+// Mutation: Pause or resume a typing session without changing its share URL.
+export const setTypingSessionPaused = mutation({
+  args: {
+    sessionKey: v.string(),
+    isPaused: v.boolean(),
+    content: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await getUserIdentity(ctx);
+    if (!identity) {
+      throw new Error('Unauthenticated');
+    }
+
+    const session = await ctx.db
+      .query('typingSessions')
+      .withIndex('by_session_key', (q) => q.eq('sessionKey', args.sessionKey))
+      .first();
+
+    if (!session || session.userId !== identity.subject || session.expiresAt <= Date.now()) {
+      throw new Error('Unauthorized');
+    }
+
+    if (!args.isPaused && args.content === undefined) {
+      throw new Error('Current content is required when resuming');
+    }
+
+    await ctx.db.patch(session._id, args.isPaused
+      ? { isPaused: true }
+      : {
+        isPaused: false,
+        content: args.content,
+      });
+
+    return true;
   },
 });
 
@@ -132,6 +176,10 @@ export const publishTypingSessionSpeechCommand = mutation({
       throw new Error('Unauthorized');
     }
 
+    if (session.isPaused) {
+      return false;
+    }
+
     if (args.action === 'speak') {
       if (!args.text?.trim()) {
         throw new Error('Text is required for speech commands');
@@ -156,6 +204,8 @@ export const publishTypingSessionSpeechCommand = mutation({
           createdAt: Date.now(),
         },
     });
+
+    return true;
   },
 });
 

--- a/apps/web/lib/hooks/useLiveTyping.ts
+++ b/apps/web/lib/hooks/useLiveTyping.ts
@@ -18,6 +18,7 @@ type TypingSession = {
   userId: string;
   sessionKey: string;
   content: string;
+  isPaused?: boolean;
   speechCommand?: LiveTypingSpeechCommand;
   expiresAt: number;
   _creationTime: number;
@@ -27,11 +28,13 @@ export function useLiveTyping() {
   const [sessionKey, setSessionKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [session, setSession] = useState<TypingSession>(null);
 
   const createTypingSession = useMutation(api.typingSessions.createTypingSession);
   const updateTypingSessionContent = useMutation(api.typingSessions.updateTypingSessionContent);
+  const setTypingSessionPaused = useMutation(api.typingSessions.setTypingSessionPaused);
   const publishTypingSessionSpeechCommand = useMutation(api.typingSessions.publishTypingSessionSpeechCommand);
   const deleteTypingSession = useMutation(api.typingSessions.deleteTypingSession);
 
@@ -75,6 +78,7 @@ export function useLiveTyping() {
         userId: sessionFromConvex.userId,
         sessionKey: sessionFromConvex.sessionKey,
         content: sessionFromConvex.content,
+        isPaused: sessionFromConvex.isPaused,
         speechCommand: sessionFromConvex.speechCommand,
         expiresAt: sessionFromConvex.expiresAt,
         _creationTime: sessionFromConvex._creationTime,
@@ -105,6 +109,7 @@ export function useLiveTyping() {
         userId: created.userId,
         sessionKey: created.sessionKey,
         content: created.content,
+        isPaused: created.isPaused,
         speechCommand: created.speechCommand,
         expiresAt: created.expiresAt,
         _creationTime: created._creationTime,
@@ -120,7 +125,7 @@ export function useLiveTyping() {
   }, [createTypingSession]);
 
   const updateContent = useCallback(async (content: string) => {
-    if (!sessionKey) return;
+    if (!sessionKey || session?.isPaused) return;
 
     // Debounce updates to avoid hammering the server
     if (updateTimeoutRef.current) {
@@ -134,12 +139,57 @@ export function useLiveTyping() {
         console.error('Error updating live typing session:', err);
       }
     }, 300); // 300ms debounce
-  }, [sessionKey, updateTypingSessionContent]);
+  }, [session?.isPaused, sessionKey, updateTypingSessionContent]);
+
+  const pauseSession = useCallback(async (): Promise<boolean> => {
+    if (!sessionKey || session?.isPaused) return Boolean(sessionKey);
+
+    if (updateTimeoutRef.current) {
+      clearTimeout(updateTimeoutRef.current);
+      updateTimeoutRef.current = null;
+    }
+
+    setIsTransitioning(true);
+    setError(null);
+    try {
+      await setTypingSessionPaused({ sessionKey, isPaused: true });
+      setSession((current) => current ? { ...current, isPaused: true } : current);
+      return true;
+    } catch (err) {
+      console.error('Error pausing live typing session:', err);
+      setError('Could not pause Live Typing. Check your connection and try again.');
+      return false;
+    } finally {
+      setIsTransitioning(false);
+    }
+  }, [session?.isPaused, sessionKey, setTypingSessionPaused]);
+
+  const resumeSession = useCallback(async (content: string): Promise<boolean> => {
+    if (!sessionKey || !session?.isPaused) return Boolean(sessionKey);
+
+    setIsTransitioning(true);
+    setError(null);
+    try {
+      await setTypingSessionPaused({ sessionKey, isPaused: false, content });
+      setSession((current) => current ? { ...current, content, isPaused: false } : current);
+      return true;
+    } catch (err) {
+      console.error('Error resuming live typing session:', err);
+      setError('Could not resume Live Typing. Check your connection and try again.');
+      return false;
+    } finally {
+      setIsTransitioning(false);
+    }
+  }, [session?.isPaused, sessionKey, setTypingSessionPaused]);
 
   const endSession = useCallback(async () => {
     if (!sessionKey) return;
 
     try {
+      if (updateTimeoutRef.current) {
+        clearTimeout(updateTimeoutRef.current);
+        updateTimeoutRef.current = null;
+      }
       await deleteTypingSession({ sessionKey });
       setSessionKey(null);
       setSession(null);
@@ -159,7 +209,7 @@ export function useLiveTyping() {
     text?: string,
     settings?: LiveTypingSpeechSettings
   ) => {
-    if (!sessionKey) return;
+    if (!sessionKey || session?.isPaused) return;
 
     try {
       const cleanedSettings = settings ? cleanLiveTypingSpeechSettings(settings) : undefined;
@@ -174,7 +224,7 @@ export function useLiveTyping() {
     } catch (err) {
       console.error('Error publishing live typing speech command:', err);
     }
-  }, [publishTypingSessionSpeechCommand, sessionKey]);
+  }, [publishTypingSessionSpeechCommand, session?.isPaused, sessionKey]);
 
   const getShareableLink = useCallback(() => {
     if (typeof window === 'undefined') return null;
@@ -196,10 +246,14 @@ export function useLiveTyping() {
     session,
     isSharing: Boolean(sessionKey),
     isCreating,
+    isPaused: Boolean(session?.isPaused),
+    isTransitioning,
     error,
     createSession,
     updateContent,
     publishSpeechCommand,
+    pauseSession,
+    resumeSession,
     endSession,
     getShareableLink,
   };

--- a/apps/web/lib/hooks/useTypingShareSpeech.ts
+++ b/apps/web/lib/hooks/useTypingShareSpeech.ts
@@ -5,6 +5,7 @@ import { TTSProvider } from '@/lib/tts-provider';
 import type { LiveTypingSpeechCommand, LiveTypingSpeechSettings } from '@/lib/live-typing-speech';
 
 interface TypingShareSpeechSession {
+  isPaused?: boolean;
   speechCommand?: LiveTypingSpeechCommand;
 }
 
@@ -70,7 +71,17 @@ export function useTypingShareSpeech(session: TypingShareSpeechSession | null | 
     const command = session?.speechCommand;
     const tts = ttsRef.current;
 
-    if (!command || !tts || !audioEnabled) {
+    if (!tts || !audioEnabled) {
+      return;
+    }
+
+    if (session?.isPaused) {
+      tts.stop();
+      setIsSpeaking(false);
+      return;
+    }
+
+    if (!command) {
       return;
     }
 
@@ -120,7 +131,7 @@ export function useTypingShareSpeech(session: TypingShareSpeechSession | null | 
     return () => {
       cancelled = true;
     };
-  }, [audioEnabled, session?.speechCommand]);
+  }, [audioEnabled, session?.isPaused, session?.speechCommand]);
 
   return {
     audioEnabled,

--- a/apps/web/tests/app/TypingShareViewPage.test.tsx
+++ b/apps/web/tests/app/TypingShareViewPage.test.tsx
@@ -1,0 +1,77 @@
+import { Suspense } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import TypingShareViewPage from '@/app/typing-share/view/[key]/page';
+
+let mockSession: unknown;
+const mockEnableAudio = jest.fn();
+
+jest.mock('convex/react', () => ({
+  useQuery: jest.fn(() => mockSession),
+}));
+
+jest.mock('@/app/contexts/SettingsContext', () => ({
+  useSettings: jest.fn(() => ({
+    uiPreferences: { typingShareFontSize: 24 },
+    updateUIPreference: jest.fn(),
+  })),
+}));
+
+jest.mock('@/lib/hooks/useTypingShareSpeech', () => ({
+  useTypingShareSpeech: jest.fn(() => ({
+    audioEnabled: true,
+    enableAudio: mockEnableAudio,
+    isSpeaking: false,
+    error: null,
+  })),
+}));
+
+jest.mock('@/app/components/phrases/AnimatedLoading', () => ({
+  __esModule: true,
+  default: () => <div>Loading</div>,
+}));
+
+async function renderPage() {
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>Suspended</div>}>
+        <TypingShareViewPage params={Promise.resolve({ key: 'session-key' })} />
+      </Suspense>
+    );
+  });
+}
+
+describe('TypingShareViewPage', () => {
+  it('keeps the last shared text visible and announces a paused session', async () => {
+    mockSession = {
+      content: 'Last shared message',
+      isPaused: true,
+      expiresAt: Date.now() + 60_000,
+    };
+
+    await renderPage();
+
+    expect(await screen.findByText('Last shared message')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The communicator has paused sharing. The last shared message remains visible.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Paused');
+    expect(screen.getByText('Audio paused')).toBeInTheDocument();
+  });
+
+  it('shows the normal connected state for active and legacy sessions', async () => {
+    mockSession = {
+      content: 'Visible live update',
+      expiresAt: Date.now() + 60_000,
+    };
+
+    await renderPage();
+
+    expect(await screen.findByText('Visible live update')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Connected');
+    expect(
+      screen.getByText('You are viewing a live typing session. Updates appear in real-time.')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/components/Composer.test.tsx
+++ b/apps/web/tests/components/Composer.test.tsx
@@ -50,7 +50,12 @@ jest.mock('@/lib/hooks/useLiveTyping', () => ({
   useLiveTyping: jest.fn(() => ({
     isSharing: false,
     isCreating: false,
+    isPaused: false,
+    isTransitioning: false,
+    error: null,
     createSession: jest.fn(),
+    pauseSession: jest.fn(),
+    resumeSession: jest.fn(),
     endSession: jest.fn(),
     updateContent: jest.fn(),
     publishSpeechCommand: jest.fn(),
@@ -450,8 +455,12 @@ describe('Composer', () => {
       session: null,
       isSharing: true,
       isCreating: false,
+      isPaused: false,
+      isTransitioning: false,
       error: null,
       createSession: jest.fn(),
+      pauseSession: jest.fn(),
+      resumeSession: jest.fn(),
       endSession: jest.fn(),
       updateContent: jest.fn(),
       publishSpeechCommand: jest.fn(),
@@ -488,8 +497,12 @@ describe('Composer', () => {
       session: null,
       isSharing: true,
       isCreating: false,
+      isPaused: false,
+      isTransitioning: false,
       error: null,
       createSession: jest.fn(),
+      pauseSession: jest.fn(),
+      resumeSession: jest.fn(),
       endSession,
       updateContent: jest.fn(),
       publishSpeechCommand: jest.fn(),
@@ -512,6 +525,84 @@ describe('Composer', () => {
     expect(endSession).toHaveBeenCalled();
   });
 
+  it('pauses an active Live Typing session from the banner', async () => {
+    const user = userEvent.setup();
+    const pauseSession = jest.fn().mockResolvedValue(true);
+    mockUseAuth.mockReturnValue({
+      user: { id: 'user-1', email: 'user@example.com' },
+      loading: false,
+    });
+    mockUseLiveTyping.mockReturnValue({
+      session: null,
+      isSharing: true,
+      isCreating: false,
+      isPaused: false,
+      isTransitioning: false,
+      error: null,
+      createSession: jest.fn(),
+      pauseSession,
+      resumeSession: jest.fn(),
+      endSession: jest.fn(),
+      updateContent: jest.fn(),
+      publishSpeechCommand: jest.fn(),
+      getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
+    });
+
+    render(
+      <Composer
+        text="Sharing now"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableLiveTyping={true}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Pause Live Typing' }));
+
+    expect(pauseSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps paused edits private and publishes the current draft when resuming', async () => {
+    const user = userEvent.setup();
+    const updateContent = jest.fn();
+    const resumeSession = jest.fn().mockResolvedValue(true);
+    mockUseAuth.mockReturnValue({
+      user: { id: 'user-1', email: 'user@example.com' },
+      loading: false,
+    });
+    mockUseLiveTyping.mockReturnValue({
+      session: null,
+      isSharing: true,
+      isCreating: false,
+      isPaused: true,
+      isTransitioning: false,
+      error: null,
+      createSession: jest.fn(),
+      pauseSession: jest.fn(),
+      resumeSession,
+      endSession: jest.fn(),
+      updateContent,
+      publishSpeechCommand: jest.fn(),
+      getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
+    });
+
+    render(
+      <Composer
+        text="Private paused draft"
+        onChange={jest.fn()}
+        onSpeak={jest.fn()}
+        enableLiveTyping={true}
+      />
+    );
+
+    expect(screen.getByText('Live Typing paused')).toBeInTheDocument();
+    expect(updateContent).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Resume Live Typing' }));
+
+    expect(resumeSession).toHaveBeenCalledWith('Private paused draft');
+  });
+
   it('delegates speak and stop actions to the parent while sharing', async () => {
     const user = userEvent.setup();
     const onSpeak = jest.fn();
@@ -528,8 +619,12 @@ describe('Composer', () => {
       session: null,
       isSharing: true,
       isCreating: false,
+      isPaused: false,
+      isTransitioning: false,
       error: null,
       createSession: jest.fn(),
+      pauseSession: jest.fn(),
+      resumeSession: jest.fn(),
       endSession: jest.fn(),
       updateContent: jest.fn(),
       getShareableLink: jest.fn(() => 'https://example.com/typing-share/view/session-key'),
@@ -576,8 +671,12 @@ describe('Composer', () => {
       session: null,
       isSharing: false,
       isCreating: false,
+      isPaused: false,
+      isTransitioning: false,
       error: null,
       createSession: jest.fn(),
+      pauseSession: jest.fn(),
+      resumeSession: jest.fn(),
       endSession: jest.fn(),
       updateContent: jest.fn(),
       publishSpeechCommand: jest.fn(),

--- a/apps/web/tests/components/LiveTypingBottomSheet.test.tsx
+++ b/apps/web/tests/components/LiveTypingBottomSheet.test.tsx
@@ -69,8 +69,13 @@ function renderSheet(
     onClose: jest.fn(),
     isSharing: true,
     isCreating: false,
+    isPaused: false,
+    isTransitioning: false,
+    error: null,
     shareableLink,
     onStartSharing: jest.fn().mockResolvedValue(undefined),
+    onPauseSession: jest.fn().mockResolvedValue(undefined),
+    onResumeSession: jest.fn().mockResolvedValue(undefined),
     onEndSession: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -147,7 +152,7 @@ describe('LiveTypingBottomSheet', () => {
   it('shows a preparation state and disables copy while the URL is unavailable', () => {
     renderSheet({ shareableLink: null });
 
-    expect(screen.getByRole('status')).toHaveTextContent('Preparing share link…');
+    expect(screen.getByText('Preparing share link…')).toBeInTheDocument();
     expect(screen.queryByTestId('live-typing-qr')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy Live Typing link' })).toBeDisabled();
   });
@@ -162,5 +167,45 @@ describe('LiveTypingBottomSheet', () => {
       expect(props.onEndSession).toHaveBeenCalledTimes(1);
     });
     expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses an active session while keeping the share link available', async () => {
+    const user = userEvent.setup();
+    const { props } = renderSheet();
+
+    expect(screen.getByText('Live Typing Active')).toBeInTheDocument();
+    expect(screen.getByTestId('live-typing-qr')).toHaveAttribute('data-value', shareableLink);
+
+    await user.click(screen.getByRole('button', { name: 'Pause Live Typing' }));
+
+    expect(props.onPauseSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('explains privacy and resumes a paused session', async () => {
+    const user = userEvent.setup();
+    const { props } = renderSheet({ isPaused: true });
+
+    expect(screen.getByText('Live Typing Paused')).toBeInTheDocument();
+    expect(
+      screen.getByText('The last shared message remains visible. Your typing is private until you resume.')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Resume Live Typing' }));
+
+    expect(props.onResumeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables session controls while pause state is changing', () => {
+    renderSheet({ isTransitioning: true });
+
+    expect(screen.getByRole('button', { name: 'Pausing…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'End Live Typing' })).toBeDisabled();
+  });
+
+  it('shows a session transition error without removing sharing controls', () => {
+    renderSheet({ error: 'Could not pause session' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not pause session');
+    expect(screen.getByRole('button', { name: 'Pause Live Typing' })).toBeEnabled();
   });
 });

--- a/apps/web/tests/convex/typingSessions.test.ts
+++ b/apps/web/tests/convex/typingSessions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
-import { publishTypingSessionSpeechCommand } from '@/convex/typingSessions';
+import {
+  publishTypingSessionSpeechCommand,
+  setTypingSessionPaused,
+  updateTypingSessionContent,
+} from '@/convex/typingSessions';
 
 const mockDb = {
   query: jest.fn(),
@@ -107,5 +111,112 @@ describe('typingSessions speech commands', () => {
       text: 'Hello',
     })).rejects.toThrow('Speech settings are required');
     expect(mockDb.patch).not.toHaveBeenCalled();
+  });
+
+  test('suppresses speech commands while the session is paused', async () => {
+    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-1' });
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      isPaused: true,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(publish({
+      text: 'Private text',
+      settings: speechSettings,
+    })).resolves.toBe(false);
+    expect(mockDb.patch).not.toHaveBeenCalled();
+  });
+});
+
+describe('typingSessions pause state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCtx.auth.getUserIdentity.mockResolvedValue({ subject: 'user-1' });
+  });
+
+  test('pauses a session without changing its content', async () => {
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      content: 'Last shared text',
+      isPaused: false,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await setTypingSessionPaused._handler(mockCtx as never, {
+      sessionKey: 'session-key',
+      isPaused: true,
+    });
+
+    expect(mockDb.patch).toHaveBeenCalledWith('session-1', { isPaused: true });
+  });
+
+  test('atomically publishes the current draft when resuming', async () => {
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      content: 'Last shared text',
+      isPaused: true,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await setTypingSessionPaused._handler(mockCtx as never, {
+      sessionKey: 'session-key',
+      isPaused: false,
+      content: 'Complete private draft',
+    });
+
+    expect(mockDb.patch).toHaveBeenCalledWith('session-1', {
+      isPaused: false,
+      content: 'Complete private draft',
+    });
+  });
+
+  test('requires the current draft when resuming', async () => {
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      isPaused: true,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(setTypingSessionPaused._handler(mockCtx as never, {
+      sessionKey: 'session-key',
+      isPaused: false,
+    })).rejects.toThrow('Current content is required');
+    expect(mockDb.patch).not.toHaveBeenCalled();
+  });
+
+  test('suppresses content updates while paused, including queued updates', async () => {
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      isPaused: true,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(updateTypingSessionContent._handler(mockCtx as never, {
+      sessionKey: 'session-key',
+      content: 'Should remain private',
+    })).resolves.toBe(false);
+    expect(mockDb.patch).not.toHaveBeenCalled();
+  });
+
+  test('treats a legacy session without a pause flag as active', async () => {
+    mockSessionLookup({
+      _id: 'session-1',
+      userId: 'user-1',
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(updateTypingSessionContent._handler(mockCtx as never, {
+      sessionKey: 'session-key',
+      content: 'Visible update',
+    })).resolves.toBe(true);
+    expect(mockDb.patch).toHaveBeenCalledWith('session-1', {
+      content: 'Visible update',
+    });
   });
 });

--- a/apps/web/tests/lib/hooks/useLiveTyping.test.tsx
+++ b/apps/web/tests/lib/hooks/useLiveTyping.test.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useLiveTyping, STORAGE_KEY } from '@/lib/hooks/useLiveTyping';
+
+const mockCreateSession = jest.fn();
+const mockUpdateContent = jest.fn();
+const mockSetPaused = jest.fn();
+const mockPublishSpeech = jest.fn();
+const mockDeleteSession = jest.fn();
+let mockSessionQuery: unknown;
+let mutationCall = 0;
+
+jest.mock('convex/react', () => ({
+  useMutation: jest.fn(() => {
+    const mutations = [
+      mockCreateSession,
+      mockUpdateContent,
+      mockSetPaused,
+      mockPublishSpeech,
+      mockDeleteSession,
+    ];
+    const mutation = mutations[mutationCall % mutations.length];
+    mutationCall += 1;
+    return mutation;
+  }),
+  useQuery: jest.fn(() => mockSessionQuery),
+}));
+
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(() => 'command-id'),
+}));
+
+const activeSession = {
+  _id: 'session-id',
+  _creationTime: 1,
+  userId: 'user-1',
+  sessionKey: 'session-key',
+  content: 'Last shared text',
+  isPaused: false,
+  expiresAt: Date.now() + 60_000,
+};
+
+describe('useLiveTyping pause state', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mutationCall = 0;
+    mockSessionQuery = activeSession;
+    window.localStorage.clear();
+    window.localStorage.setItem(STORAGE_KEY, activeSession.sessionKey);
+    mockSetPaused.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('cancels a pending content update before pausing', async () => {
+    const { result } = renderHook(() => useLiveTyping());
+
+    await waitFor(() => {
+      expect(result.current.isSharing).toBe(true);
+      expect(result.current.isPaused).toBe(false);
+    });
+
+    act(() => {
+      void result.current.updateContent('Queued private draft');
+    });
+
+    await act(async () => {
+      await result.current.pauseSession();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(mockSetPaused).toHaveBeenCalledWith({
+      sessionKey: 'session-key',
+      isPaused: true,
+    });
+    expect(mockUpdateContent).not.toHaveBeenCalled();
+    expect(result.current.isPaused).toBe(true);
+  });
+
+  it('atomically sends the complete current draft when resuming', async () => {
+    mockSessionQuery = { ...activeSession, isPaused: true };
+    const { result } = renderHook(() => useLiveTyping());
+
+    await waitFor(() => {
+      expect(result.current.isPaused).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.resumeSession('Complete private draft');
+    });
+
+    expect(mockSetPaused).toHaveBeenCalledWith({
+      sessionKey: 'session-key',
+      isPaused: false,
+      content: 'Complete private draft',
+    });
+    expect(result.current.isPaused).toBe(false);
+  });
+
+  it('keeps the confirmed paused state when resume fails', async () => {
+    mockSessionQuery = { ...activeSession, isPaused: true };
+    mockSetPaused.mockRejectedValue(new Error('Connection lost'));
+    const { result } = renderHook(() => useLiveTyping());
+
+    await waitFor(() => {
+      expect(result.current.isPaused).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.resumeSession('Private draft');
+    });
+
+    expect(result.current.isPaused).toBe(true);
+    expect(result.current.error).toBe(
+      'Could not resume Live Typing. Check your connection and try again.'
+    );
+  });
+});

--- a/apps/web/tests/lib/hooks/useTypingShareSpeech.test.ts
+++ b/apps/web/tests/lib/hooks/useTypingShareSpeech.test.ts
@@ -112,6 +112,27 @@ describe('useTypingShareSpeech', () => {
     });
   });
 
+  it('stops current speech and ignores commands while sharing is paused', async () => {
+    const command = speakCommand('private-command', 'Private message');
+    const { result, rerender } = renderHook(
+      ({ isPaused, speechCommand }: { isPaused: boolean; speechCommand?: LiveTypingSpeechCommand }) =>
+        useTypingShareSpeech({ isPaused, speechCommand }),
+      { initialProps: { isPaused: false, speechCommand: undefined as LiveTypingSpeechCommand | undefined } }
+    );
+
+    act(() => {
+      result.current.enableAudio();
+    });
+
+    rerender({ isPaused: true, speechCommand: command });
+
+    await waitFor(() => {
+      expect(mockTTSProvider.stop).toHaveBeenCalledTimes(1);
+    });
+    expect(mockTTSProvider.speak).not.toHaveBeenCalled();
+    expect(result.current.isSpeaking).toBe(false);
+  });
+
   it('ignores expected browser interruption errors', () => {
     const { result } = renderHook(() => useTypingShareSpeech({}));
 


### PR DESCRIPTION
﻿## Summary

- add a server-backed pause state that keeps the share URL active and preserves the last visible message
- keep composer edits and remote speech private while paused
- atomically publish the complete current draft when resuming
- add accessible Active/Paused controls and viewer status across mobile and desktop

## User impact

Communicators can temporarily stop sharing without ending or redistributing their Live Typing session. Viewers receive a clear Paused status, retain the last shared message, and automatically reconnect to the current draft when sharing resumes.

## Validation

- `pnpm test` — 541 tests passed
- `pnpm lint`
- `pnpm build`
- manual Chrome checks at 390×844 and 1440×900, including private paused typing, atomic resume, 44px controls, and no horizontal overflow

Closes #761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause and resume controls for live typing sessions.
  * Live typing banners and sharing sheets now show active, paused, and transition states.
  * Paused sessions stop content updates and speech playback.
  * Sharing viewers now see paused status, paused audio, and the last shared content.
  * Errors are displayed when pausing or resuming fails.

* **Bug Fixes**
  * Prevented updates and speech commands from being published while a session is paused.

* **Tests**
  * Added coverage for pause/resume behavior, paused sharing displays, errors, and speech suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->