### PR TITLE
release: v5.0.4

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/landing",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sayit/web",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayit",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
﻿## Release v5.0.4

This patch release adds the ability to pause and resume Live Typing without ending the shared session.

### Included

- server-backed pause state with legacy-session compatibility
- private composer edits and suppressed remote speech while paused
- atomic current-draft synchronization on resume
- accessible Active/Paused controls and viewer status
- responsive verification at 390×844 and 1440×900

### Release validation

- `pnpm test` — 541 tests passed
- `pnpm lint`
- `pnpm build`

Feature PR: #762
Milestone: v5.0.4
